### PR TITLE
Update the autocode for port buffers & ipc buffers for the changes in fprime#5509

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -411,16 +411,9 @@ case class ComponentCppWriter (
           |      SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
           |    };
           |
-          |    Fw::Serializable::SizeType getCapacity() const {
-          |      return sizeof(m_buff);
-          |    }
-          |
-          |    U8* getBuffAddr() {
-          |      return m_buff;
-          |    }
-          |
-          |    const U8* getBuffAddr() const {
-          |      return m_buff;
+          |    ComponentIpcSerializableBuffer() {
+          |      this->m_buffAddr = m_buff;
+          |      this->m_capacity = sizeof(m_buff);
           |    }
           |
           |  private:

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -411,9 +411,8 @@ case class ComponentCppWriter (
           |      SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
           |    };
           |
-          |    ComponentIpcSerializableBuffer() {
-          |      this->m_buffAddr = m_buff;
-          |      this->m_capacity = sizeof(m_buff);
+          |    ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+          |
           |    }
           |
           |  private:

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortBufferClassWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortBufferClassWriter.scala
@@ -58,32 +58,20 @@ case class PortBufferClassWriter(
   private def getPublicMemberFunctions = addAccessTagAndComment(
     "public",
     s"Public member functions for $portBufferName",
-    List(
-      linesClassMember({
-        val buffAddr =
-          if !hasParams then "nullptr" else "m_buff"
-        lines(
-          s"""|
-              |//! Get the capacity of the buffer
-              |//! \\return The capacity
-              |Fw::Serializable::SizeType getCapacity() const override {
-              |  return CAPACITY;
-              |}
-              |
-              |//! Get the buffer address (non-const)
-              |//! \\return The buffer address
-              |U8* getBuffAddr() override {
-              |  return $buffAddr;
-              |}
-              |
-              |//! Get the buffer address (const)
-              |//! \\return The buffer address
-              |const U8* getBuffAddr() const override {
-              |  return $buffAddr;
-              |}
-              |"""
+    guardedList (hasParams) (
+      List(
+        linesClassMember(
+          lines(
+            s"""|
+                |//! Constructor
+                |${portBufferName}() {
+                |  this->m_buffAddr = m_buff;
+                |  this->m_capacity = CAPACITY;
+                |}
+                |"""
+          )
         )
-      })
+      )
     ),
     CppDoc.Lines.Hpp
   )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortBufferClassWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortBufferClassWriter.scala
@@ -55,26 +55,31 @@ case class PortBufferClassWriter(
     CppDoc.Lines.Hpp
   )
 
-  private def getPublicMemberFunctions = addAccessTagAndComment(
-    "public",
-    s"Public member functions for $portBufferName",
-    guardedList (hasParams) (
+  private def getPublicMemberFunctions = {
+    // LinearBufferBase has no default constructor: every buffer must forward its
+    // storage. Ports with params forward their fixed buffer; param-less ports
+    // have no storage, so they forward nullptr/0.
+    val baseInit =
+      if hasParams then "Fw::LinearBufferBase(m_buff, CAPACITY)"
+      else "Fw::LinearBufferBase(nullptr, 0)"
+    addAccessTagAndComment(
+      "public",
+      s"Public member functions for $portBufferName",
       List(
         linesClassMember(
           lines(
             s"""|
                 |//! Constructor
-                |${portBufferName}() {
-                |  this->m_buffAddr = m_buff;
-                |  this->m_capacity = CAPACITY;
+                |${portBufferName}() : $baseInit {
+                |
                 |}
                 |"""
           )
         )
-      )
-    ),
-    CppDoc.Lines.Hpp
-  )
+      ),
+      CppDoc.Lines.Hpp
+    )
+  }
 
   private def writeBufferCapacity: List[Line] = writeSum(
     portParams.map(

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -12,94 +12,136 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEASYNCPRODUCTPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -108,11 +150,15 @@ void ActiveAsyncProductPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEn
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputDpResponsePort* ActiveAsyncProductPortsOnlyComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* ActiveAsyncProductPortsOnlyComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -123,20 +169,32 @@ Fw::InputDpResponsePort* ActiveAsyncProductPortsOnlyComponentBase ::get_productR
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                                 Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                              Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -147,20 +205,32 @@ void ActiveAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(Fw
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                                 Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                              Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -169,10 +239,18 @@ void ActiveAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(Fw
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveAsyncProductPortsOnlyComponentBase ::ActiveAsyncProductPortsOnlyComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+ActiveAsyncProductPortsOnlyComponentBase ::
+  ActiveAsyncProductPortsOnlyComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveAsyncProductPortsOnlyComponentBase ::~ActiveAsyncProductPortsOnlyComponentBase() {}
+}
+
+ActiveAsyncProductPortsOnlyComponentBase ::
+  ~ActiveAsyncProductPortsOnlyComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -180,18 +258,26 @@ ActiveAsyncProductPortsOnlyComponentBase ::~ActiveAsyncProductPortsOnlyComponent
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveAsyncProductPortsOnlyComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductPortsOnlyComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductPortsOnlyComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductPortsOnlyComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -202,44 +288,75 @@ bool ActiveAsyncProductPortsOnlyComponentBase ::isConnected_productSendOut_Outpu
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                          FwDpIdType id,
-                                                                          const Fw::Buffer& buffer,
-                                                                          const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    productRecvIn_preMsgHook(portNum, id, buffer, status);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  productRecvIn_preMsgHook(
+    portNum,
+    id,
+    buffer,
+    status
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument id
-    _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument id
+  _status = msg.serializeFrom(id);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msg.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument status
-    _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument status
+  _status = msg.serializeFrom(status);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -250,97 +367,142 @@ void ActiveAsyncProductPortsOnlyComponentBase ::productRecvIn_handlerBase(FwInde
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
-                                                                         FwDpIdType id,
-                                                                         const Fw::Buffer& buffer,
-                                                                         const Fw::Success& status) {
-    // Default: no-op
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  productRecvIn_preMsgHook(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port productRecvIn
+    case PRODUCTRECVIN_DPRESPONSE: {
+      // Deserialize argument id
+      FwDpIdType id;
+      _deserStatus = _msg.deserializeTo(id);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument buffer
+      Fw::Buffer buffer;
+      _deserStatus = _msg.deserializeTo(buffer);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument status
+      Fw::Success status;
+      _deserStatus = _msg.deserializeTo(status);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->productRecvIn_handler(
+        portNum,
+        id,
+        buffer,
+        status
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
 
-    switch (_msgType) {
-        // Handle async input port productRecvIn
-        case PRODUCTRECVIN_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvIn_handler(portNum, id, buffer, status);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
-    }
-
-    return MSG_DISPATCH_OK;
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     FwDpIdType id,
-                                                                     const Fw::Buffer& buffer,
-                                                                     const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductPortsOnlyComponentBase* compPtr =
-        static_cast<ActiveAsyncProductPortsOnlyComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductPortsOnlyComponentBase* compPtr = static_cast<ActiveAsyncProductPortsOnlyComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                                      FwDpIdType id,
-                                                                      const Fw::Buffer& buffer,
-                                                                      const Fw::Success& status) {
-    (void)portNum;
-    (void)id;
-    (void)buffer;
-    (void)status;
-    // No data products defined
+void ActiveAsyncProductPortsOnlyComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  (void) portNum;
+  (void) id;
+  (void) buffer;
+  (void) status;
+  // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -40,9 +40,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -12,143 +12,94 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEASYNCPRODUCTPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveAsyncProductPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -157,15 +108,11 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputDpResponsePort* ActiveAsyncProductPortsOnlyComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* ActiveAsyncProductPortsOnlyComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -176,32 +123,20 @@ Fw::InputDpResponsePort* ActiveAsyncProductPortsOnlyComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                                 Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                              Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -212,32 +147,20 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                                 Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                              Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -246,18 +169,10 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveAsyncProductPortsOnlyComponentBase ::
-  ActiveAsyncProductPortsOnlyComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveAsyncProductPortsOnlyComponentBase ::ActiveAsyncProductPortsOnlyComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveAsyncProductPortsOnlyComponentBase ::
-  ~ActiveAsyncProductPortsOnlyComponentBase()
-{
-
-}
+ActiveAsyncProductPortsOnlyComponentBase ::~ActiveAsyncProductPortsOnlyComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -265,26 +180,18 @@ ActiveAsyncProductPortsOnlyComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveAsyncProductPortsOnlyComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductPortsOnlyComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductPortsOnlyComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductPortsOnlyComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -295,75 +202,44 @@ bool ActiveAsyncProductPortsOnlyComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductPortsOnlyComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                          FwDpIdType id,
+                                                                          const Fw::Buffer& buffer,
+                                                                          const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  productRecvIn_preMsgHook(
-    portNum,
-    id,
-    buffer,
-    status
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    productRecvIn_preMsgHook(portNum, id, buffer, status);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument id
-  _status = msg.serializeFrom(id);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument id
+    _status = msg.serializeFrom(id);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msg.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msg.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument status
-  _status = msg.serializeFrom(status);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument status
+    _status = msg.serializeFrom(status);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -374,142 +250,97 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
+void ActiveAsyncProductPortsOnlyComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
+                                                                         FwDpIdType id,
+                                                                         const Fw::Buffer& buffer,
+                                                                         const Fw::Success& status) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port productRecvIn
-    case PRODUCTRECVIN_DPRESPONSE: {
-      // Deserialize argument id
-      FwDpIdType id;
-      _deserStatus = _msg.deserializeTo(id);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument buffer
-      Fw::Buffer buffer;
-      _deserStatus = _msg.deserializeTo(buffer);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument status
-      Fw::Success status;
-      _deserStatus = _msg.deserializeTo(status);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->productRecvIn_handler(
-        portNum,
-        id,
-        buffer,
-        status
-      );
-
-      break;
+    if (_msgType == ACTIVEASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  return MSG_DISPATCH_OK;
+    switch (_msgType) {
+        // Handle async input port productRecvIn
+        case PRODUCTRECVIN_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvIn_handler(portNum, id, buffer, status);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
+    }
+
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductPortsOnlyComponentBase* compPtr = static_cast<ActiveAsyncProductPortsOnlyComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void ActiveAsyncProductPortsOnlyComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     FwDpIdType id,
+                                                                     const Fw::Buffer& buffer,
+                                                                     const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductPortsOnlyComponentBase* compPtr =
+        static_cast<ActiveAsyncProductPortsOnlyComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductPortsOnlyComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  (void) portNum;
-  (void) id;
-  (void) buffer;
-  (void) status;
-  // No data products defined
+void ActiveAsyncProductPortsOnlyComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                                      FwDpIdType id,
+                                                                      const Fw::Buffer& buffer,
+                                                                      const Fw::Success& status) {
+    (void)portNum;
+    (void)id;
+    (void)buffer;
+    (void)status;
+    // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -52,9 +52,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEASYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
     ALIASTYPEDASYNC_ALIASTYPED,
@@ -21,11 +21,11 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -33,1212 +33,772 @@ namespace {
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveAsyncProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+ActiveAsyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+ActiveAsyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-ActiveAsyncProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const ActiveAsyncProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const ActiveAsyncProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const ActiveAsyncProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const ActiveAsyncProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                   FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                  FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveAsyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1247,26 +807,17 @@ void ActiveAsyncProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveAsyncProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveAsyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveAsyncProductsComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* ActiveAsyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -1277,213 +828,141 @@ Fw::InputDpResponsePort* ActiveAsyncProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveAsyncProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveAsyncProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveAsyncProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveAsyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveAsyncProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveAsyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1494,148 +973,78 @@ Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                         Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveAsyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveAsyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1646,116 +1055,66 @@ void ActiveAsyncProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                             Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                     Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                           Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1766,134 +1125,72 @@ void ActiveAsyncProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                         Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveAsyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveAsyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1904,46 +1201,25 @@ void ActiveAsyncProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1952,18 +1228,10 @@ void ActiveAsyncProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveAsyncProductsComponentBase ::
-  ActiveAsyncProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveAsyncProductsComponentBase ::ActiveAsyncProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveAsyncProductsComponentBase ::
-  ~ActiveAsyncProductsComponentBase()
-{
-
-}
+ActiveAsyncProductsComponentBase ::~ActiveAsyncProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1971,118 +1239,76 @@ ActiveAsyncProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2093,92 +1319,59 @@ bool ActiveAsyncProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveAsyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2189,95 +1382,59 @@ bool ActiveAsyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveAsyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                          FwOpcodeType opCode,
+                                                          U32 cmdSeq,
+                                                          Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
-void ActiveAsyncProductsComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                  FwDpIdType id,
+                                                                  const Fw::Buffer& buffer,
+                                                                  const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  productRecvIn_preMsgHook(
-    portNum,
-    id,
-    buffer,
-    status
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    productRecvIn_preMsgHook(portNum, id, buffer, status);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument id
-  _status = msg.serializeFrom(id);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument id
+    _status = msg.serializeFrom(id);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msg.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msg.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument status
-  _status = msg.serializeFrom(status);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument status
+    _status = msg.serializeFrom(status);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -2286,941 +1443,561 @@ void ActiveAsyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveAsyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveAsyncProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveAsyncProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveAsyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveAsyncProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveAsyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveAsyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveAsyncProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveAsyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                               AliasPrim1 u32,
+                                                                               AliasPrim2 f32,
+                                                                               AliasBool b,
+                                                                               const Fw::StringBase& str2,
+                                                                               const AliasEnum& e,
+                                                                               const AliasArray& a,
+                                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveAsyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                     AliasPrim1 u32,
+                                                                                     AliasPrim2 f32,
+                                                                                     AliasBool b,
+                                                                                     const Fw::StringBase& str2,
+                                                                                     const AliasEnum& e,
+                                                                                     const AliasArray& a,
+                                                                                     const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveAsyncProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveAsyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveAsyncProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveAsyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3231,15 +2008,11 @@ void ActiveAsyncProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
+void ActiveAsyncProductsComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
+                                                                 FwDpIdType id,
+                                                                 const Fw::Buffer& buffer,
+                                                                 const Fw::Success& status) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -3250,85 +2023,63 @@ void ActiveAsyncProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveAsyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveAsyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveAsyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveAsyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveAsyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveAsyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3337,209 +2088,103 @@ void ActiveAsyncProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveAsyncProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveAsyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveAsyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveAsyncProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveAsyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveAsyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveAsyncProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveAsyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3548,47 +2193,39 @@ F32 ActiveAsyncProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void ActiveAsyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveAsyncProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveAsyncProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3598,923 +2235,539 @@ Fw::Time ActiveAsyncProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveAsyncProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveAsyncProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveAsyncProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEASYNCPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port productRecvIn
-    case PRODUCTRECVIN_DPRESPONSE: {
-      // Deserialize argument id
-      FwDpIdType id;
-      _deserStatus = _msg.deserializeTo(id);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument buffer
-      Fw::Buffer buffer;
-      _deserStatus = _msg.deserializeTo(buffer);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument status
-      Fw::Success status;
-      _deserStatus = _msg.deserializeTo(status);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->productRecvIn_handler(
-        portNum,
-        id,
-        buffer,
-        status
-      );
-
-      break;
+    if (_msgType == ACTIVEASYNCPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port productRecvIn
+        case PRODUCTRECVIN_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvIn_handler(portNum, id, buffer, status);
 
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            break;
+        }
 
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
-
-      break;
-    }
-
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveAsyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     FwOpcodeType opCode,
+                                                     U32 cmdSeq,
+                                                     Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void ActiveAsyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer,
+                                                             const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveAsyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveAsyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveAsyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveAsyncProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveAsyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveAsyncProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveAsyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveAsyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveAsyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveAsyncProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveAsyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum,
+                                                                          AliasPrim1 u32,
+                                                                          AliasPrim2 f32,
+                                                                          AliasBool b,
+                                                                          const Fw::StringBase& str2,
+                                                                          const AliasEnum& e,
+                                                                          const AliasArray& a,
+                                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveAsyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                FwIndexType portNum,
+                                                                                AliasPrim1 u32,
+                                                                                AliasPrim2 f32,
+                                                                                AliasBool b,
+                                                                                const Fw::StringBase& str2,
+                                                                                const AliasEnum& e,
+                                                                                const AliasArray& a,
+                                                                                const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                      FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveAsyncProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveAsyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveAsyncProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveAsyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str2,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveAsyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4523,68 +2776,32 @@ void ActiveAsyncProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  productRequestOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
+                                                              FwDpIdType id,
+                                                              FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productRequestOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productRequestOut_OutputPort[portNum].invoke(
-    id,
-    dataSize
-  );
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                           FwDpIdType id,
+                                                           const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveAsyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4593,71 +2810,58 @@ void ActiveAsyncProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::
-  dpRequest(
-      ContainerId::T containerId,
-      FwSizeType dataSize
-  )
-{
-  const FwDpIdType globalId = this->getIdBase() + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  this->productRequestOut_out(0, globalId, size);
+void ActiveAsyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+    const FwDpIdType globalId = this->getIdBase() + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    this->productRequestOut_out(0, globalId, size);
 }
 
-void ActiveAsyncProductsComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  DpContainer container;
-  if (status == Fw::Success::SUCCESS) {
-    container = DpContainer(id, buffer, this->getIdBase());
-  }
-  // Convert global id to local id
-  const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(
-    id >= idBase,
-    static_cast<FwAssertArgType>(id),
-    static_cast<FwAssertArgType>(idBase)
-  );
-  const FwDpIdType localId = id - idBase;
-  // Switch on the local id
-  switch (localId) {
-    case ContainerId::Container1:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container1);
-      // Call the handler
-      this->dpRecv_Container1_handler(container, status.e);
-      break;
-    case ContainerId::Container2:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container2);
-      // Call the handler
-      this->dpRecv_Container2_handler(container, status.e);
-      break;
-    case ContainerId::Container3:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container3);
-      // Call the handler
-      this->dpRecv_Container3_handler(container, status.e);
-      break;
-    case ContainerId::Container4:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container4);
-      // Call the handler
-      this->dpRecv_Container4_handler(container, status.e);
-      break;
-    case ContainerId::Container5:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container5);
-      // Call the handler
-      this->dpRecv_Container5_handler(container, status.e);
-      break;
-    default:
-      FW_ASSERT(0);
-      break;
-  }
+void ActiveAsyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                              FwDpIdType id,
+                                                              const Fw::Buffer& buffer,
+                                                              const Fw::Success& status) {
+    DpContainer container;
+    if (status == Fw::Success::SUCCESS) {
+        container = DpContainer(id, buffer, this->getIdBase());
+    }
+    // Convert global id to local id
+    const FwDpIdType idBase = this->getIdBase();
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    const FwDpIdType localId = id - idBase;
+    // Switch on the local id
+    switch (localId) {
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
+    }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEASYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
     ALIASTYPEDASYNC_ALIASTYPED,
@@ -21,11 +21,11 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -33,772 +33,1205 @@ union BuffUnion {
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveAsyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+ActiveAsyncProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-ActiveAsyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const ActiveAsyncProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+ActiveAsyncProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const ActiveAsyncProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const ActiveAsyncProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const ActiveAsyncProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                   FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                  FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveAsyncProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -807,17 +1240,26 @@ void ActiveAsyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreT
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveAsyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveAsyncProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveAsyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* ActiveAsyncProductsComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -828,141 +1270,213 @@ Fw::InputDpResponsePort* ActiveAsyncProductsComponentBase ::get_productRecvIn_In
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveAsyncProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveAsyncProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveAsyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveAsyncProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveAsyncProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveAsyncProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveAsyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveAsyncProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveAsyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveAsyncProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveAsyncProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -973,78 +1487,148 @@ Ports::InputTypedPort* ActiveAsyncProductsComponentBase ::get_typedSync_InputPor
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                         Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1055,66 +1639,116 @@ void ActiveAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNu
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                             Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                     Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                           Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1125,72 +1759,134 @@ void ActiveAsyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexTyp
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                         Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1201,25 +1897,46 @@ void ActiveAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNu
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1228,10 +1945,18 @@ void ActiveAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType port
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveAsyncProductsComponentBase ::ActiveAsyncProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+ActiveAsyncProductsComponentBase ::
+  ActiveAsyncProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveAsyncProductsComponentBase ::~ActiveAsyncProductsComponentBase() {}
+}
+
+ActiveAsyncProductsComponentBase ::
+  ~ActiveAsyncProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1239,76 +1964,118 @@ ActiveAsyncProductsComponentBase ::~ActiveAsyncProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveAsyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveAsyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveAsyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1319,59 +2086,92 @@ bool ActiveAsyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexTyp
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveAsyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveAsyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveAsyncProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1382,59 +2182,95 @@ bool ActiveAsyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(Fw
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                          FwOpcodeType opCode,
-                                                          U32 cmdSeq,
-                                                          Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveAsyncProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void ActiveAsyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                  FwDpIdType id,
-                                                                  const Fw::Buffer& buffer,
-                                                                  const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    productRecvIn_preMsgHook(portNum, id, buffer, status);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  productRecvIn_preMsgHook(
+    portNum,
+    id,
+    buffer,
+    status
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument id
-    _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument id
+  _status = msg.serializeFrom(id);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msg.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument status
-    _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument status
+  _status = msg.serializeFrom(status);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1443,561 +2279,941 @@ void ActiveAsyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType po
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveAsyncProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveAsyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveAsyncProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveAsyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveAsyncProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveAsyncProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveAsyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                               AliasPrim1 u32,
-                                                                               AliasPrim2 f32,
-                                                                               AliasBool b,
-                                                                               const Fw::StringBase& str2,
-                                                                               const AliasEnum& e,
-                                                                               const AliasArray& a,
-                                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveAsyncProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                     AliasPrim1 u32,
-                                                                                     AliasPrim2 f32,
-                                                                                     AliasBool b,
-                                                                                     const Fw::StringBase& str2,
-                                                                                     const AliasEnum& e,
-                                                                                     const AliasArray& a,
-                                                                                     const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveAsyncProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveAsyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveAsyncProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveAsyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveAsyncProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveAsyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2008,11 +3224,15 @@ void ActiveAsyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNu
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
-                                                                 FwDpIdType id,
-                                                                 const Fw::Buffer& buffer,
-                                                                 const Fw::Success& status) {
-    // Default: no-op
+void ActiveAsyncProductsComponentBase ::
+  productRecvIn_preMsgHook(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -2023,63 +3243,85 @@ void ActiveAsyncProductsComponentBase ::productRecvIn_preMsgHook(FwIndexType por
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    // Default: no-op
+void ActiveAsyncProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveAsyncProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Default: no-op
+void ActiveAsyncProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void ActiveAsyncProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Default: no-op
+void ActiveAsyncProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveAsyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Default: no-op
+void ActiveAsyncProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2088,103 +3330,209 @@ void ActiveAsyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwInde
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveAsyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveAsyncProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveAsyncProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveAsyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveAsyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveAsyncProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveAsyncProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveAsyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveAsyncProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2193,39 +3541,47 @@ F32 ActiveAsyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void ActiveAsyncProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveAsyncProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveAsyncProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2235,539 +3591,923 @@ Fw::Time ActiveAsyncProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveAsyncProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveAsyncProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveAsyncProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEASYNCPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEASYNCPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port productRecvIn
+    case PRODUCTRECVIN_DPRESPONSE: {
+      // Deserialize argument id
+      FwDpIdType id;
+      _deserStatus = _msg.deserializeTo(id);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument buffer
+      Fw::Buffer buffer;
+      _deserStatus = _msg.deserializeTo(buffer);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument status
+      Fw::Success status;
+      _deserStatus = _msg.deserializeTo(status);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->productRecvIn_handler(
+        portNum,
+        id,
+        buffer,
+        status
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port productRecvIn
-        case PRODUCTRECVIN_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvIn_handler(portNum, id, buffer, status);
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            break;
-        }
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
+
+      break;
+    }
+
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     FwOpcodeType opCode,
-                                                     U32 cmdSeq,
-                                                     Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveAsyncProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer,
-                                                             const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void ActiveAsyncProductsComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveAsyncProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveAsyncProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveAsyncProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveAsyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveAsyncProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveAsyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveAsyncProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveAsyncProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveAsyncProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveAsyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum,
-                                                                          AliasPrim1 u32,
-                                                                          AliasPrim2 f32,
-                                                                          AliasBool b,
-                                                                          const Fw::StringBase& str2,
-                                                                          const AliasEnum& e,
-                                                                          const AliasArray& a,
-                                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveAsyncProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveAsyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                FwIndexType portNum,
-                                                                                AliasPrim1 u32,
-                                                                                AliasPrim2 f32,
-                                                                                AliasBool b,
-                                                                                const Fw::StringBase& str2,
-                                                                                const AliasEnum& e,
-                                                                                const AliasArray& a,
-                                                                                const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveAsyncProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                      FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveAsyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveAsyncProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveAsyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str2,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveAsyncProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveAsyncProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2776,32 +4516,68 @@ void ActiveAsyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBas
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
-                                                              FwDpIdType id,
-                                                              FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  productRequestOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+  FW_ASSERT(
+    this->m_productRequestOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productRequestOut_OutputPort[portNum].invoke(
+    id,
+    dataSize
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                           FwDpIdType id,
-                                                           const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void ActiveAsyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveAsyncProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2810,58 +4586,71 @@ void ActiveAsyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveAsyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
-    const FwDpIdType globalId = this->getIdBase() + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    this->productRequestOut_out(0, globalId, size);
+void ActiveAsyncProductsComponentBase ::
+  dpRequest(
+      ContainerId::T containerId,
+      FwSizeType dataSize
+  )
+{
+  const FwDpIdType globalId = this->getIdBase() + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  this->productRequestOut_out(0, globalId, size);
 }
 
-void ActiveAsyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                              FwDpIdType id,
-                                                              const Fw::Buffer& buffer,
-                                                              const Fw::Success& status) {
-    DpContainer container;
-    if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
-    }
-    // Convert global id to local id
-    const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
-    const FwDpIdType localId = id - idBase;
-    // Switch on the local id
-    switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
-    }
+void ActiveAsyncProductsComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  DpContainer container;
+  if (status == Fw::Success::SUCCESS) {
+    container = DpContainer(id, buffer, this->getIdBase());
+  }
+  // Convert global id to local id
+  const FwDpIdType idBase = this->getIdBase();
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
+  const FwDpIdType localId = id - idBase;
+  // Switch on the local id
+  switch (localId) {
+    case ContainerId::Container1:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container1);
+      // Call the handler
+      this->dpRecv_Container1_handler(container, status.e);
+      break;
+    case ContainerId::Container2:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container2);
+      // Call the handler
+      this->dpRecv_Container2_handler(container, status.e);
+      break;
+    case ContainerId::Container3:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container3);
+      // Call the handler
+      this->dpRecv_Container3_handler(container, status.e);
+      break;
+    case ContainerId::Container4:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container4);
+      // Call the handler
+      this->dpRecv_Container4_handler(container, status.e);
+      break;
+    case ContainerId::Container5:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container5);
+      // Call the handler
+      this->dpRecv_Container5_handler(container, status.e);
+      break;
+    default:
+      FW_ASSERT(0);
+      break;
+  }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -55,9 +55,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVECOMMANDS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -25,575 +25,926 @@ enum MsgTypeEnum {
     CMD_CMD_PARAMS_PRIORITY,
     CMD_CMD_DROP,
     CMD_CMD_PARAMS_PRIORITY_DROP,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveCommandsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -602,10 +953,15 @@ void ActiveCommandsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType i
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveCommandsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveCommandsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -616,140 +972,213 @@ Fw::InputCmdPort* ActiveCommandsComponentBase ::get_cmdIn_InputPort(FwIndexType 
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveCommandsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveCommandsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveCommandsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveCommandsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveCommandsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveCommandsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveCommandsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveCommandsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveCommandsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveCommandsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveCommandsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -760,62 +1189,120 @@ Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedSync_InputPort(FwI
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -826,65 +1313,116 @@ void ActiveCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                  Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                 Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -895,55 +1433,106 @@ void ActiveCommandsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType por
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -954,24 +1543,46 @@ void ActiveCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -980,51 +1591,113 @@ void ActiveCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, 
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveCommandsComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_ASYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+  );
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveCommandsComponentBase ::ActiveCommandsComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
+ActiveCommandsComponentBase ::
+  ActiveCommandsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveCommandsComponentBase ::~ActiveCommandsComponentBase() {}
+}
+
+ActiveCommandsComponentBase ::
+  ~ActiveCommandsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1032,62 +1705,96 @@ ActiveCommandsComponentBase ::~ActiveCommandsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveCommandsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveCommandsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveCommandsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1098,59 +1805,92 @@ bool ActiveCommandsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType por
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveCommandsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveCommandsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1161,103 +1901,176 @@ bool ActiveCommandsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndex
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                     FwOpcodeType opCode,
-                                                     U32 cmdSeq,
-                                                     Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveCommandsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_CMD_SYNC: {
-            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_CMD_SYNC_PRIMITIVE: {
-            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRING: {
-            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ENUM: {
-            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ARRAY: {
-            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRUCT: {
-            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED: {
-            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_PRIMITIVE: {
-            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRING: {
-            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ENUM: {
-            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ARRAY: {
-            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRUCT: {
-            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_ASYNC: {
-            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PRIORITY: {
-            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY: {
-            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_DROP: {
-            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_CMD_SYNC: {
+      this->CMD_SYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
     }
+
+    case OPCODE_CMD_SYNC_PRIMITIVE: {
+      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRING: {
+      this->CMD_SYNC_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ENUM: {
+      this->CMD_SYNC_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ARRAY: {
+      this->CMD_SYNC_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRUCT: {
+      this->CMD_SYNC_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED: {
+      this->CMD_GUARDED_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_PRIMITIVE: {
+      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRING: {
+      this->CMD_GUARDED_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ENUM: {
+      this->CMD_GUARDED_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ARRAY: {
+      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRUCT: {
+      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_ASYNC: {
+      this->CMD_ASYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PRIORITY: {
+      this->CMD_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY: {
+      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_DROP: {
+      this->CMD_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1266,561 +2079,941 @@ void ActiveCommandsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveCommandsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveCommandsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveCommandsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveCommandsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveCommandsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveCommandsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveCommandsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveCommandsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveCommandsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveCommandsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveCommandsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveCommandsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveCommandsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                          AliasPrim1 u32,
-                                                                          AliasPrim2 f32,
-                                                                          AliasBool b,
-                                                                          const Fw::StringBase& str2,
-                                                                          const AliasEnum& e,
-                                                                          const AliasArray& a,
-                                                                          const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveCommandsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveCommandsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                AliasPrim1 u32,
-                                                                                AliasPrim2 f32,
-                                                                                AliasBool b,
-                                                                                const Fw::StringBase& str2,
-                                                                                const AliasEnum& e,
-                                                                                const AliasArray& a,
-                                                                                const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveCommandsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveCommandsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveCommandsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveCommandsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveCommandsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveCommandsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveCommandsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveCommandsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveCommandsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str2,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveCommandsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveCommandsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1831,63 +3024,85 @@ void ActiveCommandsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                              AliasPrim1 u32,
-                                                              AliasPrim2 f32,
-                                                              AliasBool b,
-                                                              const Fw::StringBase& str2,
-                                                              const AliasEnum& e,
-                                                              const AliasArray& a,
-                                                              const AliasStruct& s) {
-    // Default: no-op
+void ActiveCommandsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveCommandsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Default: no-op
+void ActiveCommandsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Default: no-op
+void ActiveCommandsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Default: no-op
+void ActiveCommandsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Default: no-op
+void ActiveCommandsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1896,103 +3111,209 @@ void ActiveCommandsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveCommandsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveCommandsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveCommandsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveCommandsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveCommandsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                     AliasPrim1 u32,
-                                                     AliasPrim2 f32,
-                                                     AliasBool b,
-                                                     const Fw::StringBase& str2,
-                                                     const AliasEnum& e,
-                                                     const AliasArray& a,
-                                                     const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveCommandsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveCommandsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveCommandsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveCommandsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                U32 u32,
-                                                F32 f32,
-                                                bool b,
-                                                const Fw::StringBase& str1,
-                                                const E& e,
-                                                const A& a,
-                                                const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveCommandsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str2,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveCommandsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2001,9 +3322,15 @@ F32 ActiveCommandsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveCommandsComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -2012,623 +3339,965 @@ void ActiveCommandsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdS
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void ActiveCommandsComponentBase ::
+  CMD_SYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void ActiveCommandsComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                     U32 cmdSeq,
-                                                                     Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
+  this->CMD_SYNC_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 }
 
-void ActiveCommandsComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_SYNC_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_SYNC_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 }
 
-void ActiveCommandsComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_SYNC_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_SYNC_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 }
 
-void ActiveCommandsComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_SYNC_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_SYNC_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 }
 
-void ActiveCommandsComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_SYNC_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_SYNC_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void ActiveCommandsComponentBase ::
+  CMD_GUARDED_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveCommandsComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                        U32 cmdSeq,
-                                                                        Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
-
-#if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-#endif
-
-    this->lock();
-
-    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
-
-    this->unLock();
-}
-
-void ActiveCommandsComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                     U32 cmdSeq,
-                                                                     Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Reset the buffer
-    args.resetDeser();
-
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveCommandsComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_GUARDED_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
+
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_GUARDED_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveCommandsComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                    U32 cmdSeq,
-                                                                    Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_GUARDED_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_GUARDED_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveCommandsComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                     U32 cmdSeq,
-                                                                     Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::
+  CMD_GUARDED_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_GUARDED_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveCommandsComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
+void ActiveCommandsComponentBase ::
+  CMD_GUARDED_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Reset the buffer
+  args.resetDeser();
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void ActiveCommandsComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                               U32 cmdSeq,
-                                                               Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                      U32 cmdSeq,
-                                                                      Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void ActiveCommandsComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+#if FW_CMD_CHECK_RESIDUAL
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
+#endif
+
+  this->lock();
+
+  this->CMD_GUARDED_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
+
+  this->unLock();
 }
 
-void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
-                                                                           U32 cmdSeq,
-                                                                           Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
+void ActiveCommandsComponentBase ::
+  CMD_ASYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+void ActiveCommandsComponentBase ::
+  CMD_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void ActiveCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void ActiveCommandsComponentBase ::
+  CMD_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void ActiveCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2639,48 +4308,76 @@ void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpc
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveCommandsComponentBase ::
+  CMD_ASYNC_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveCommandsComponentBase ::
+  CMD_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveCommandsComponentBase ::
+  CMD_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveCommandsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveCommandsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2690,717 +4387,1139 @@ Fw::Time ActiveCommandsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveCommandsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveCommandsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveCommandsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVECOMMANDS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVECOMMANDS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle command CMD_ASYNC
-        case CMD_CMD_ASYNC: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PRIORITY
-        case CMD_CMD_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY
-        case CMD_CMD_PARAMS_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle command CMD_DROP
-        case CMD_CMD_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY_DROP
-        case CMD_CMD_PARAMS_PRIORITY_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
+
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle command CMD_ASYNC
+    case CMD_CMD_ASYNC: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PRIORITY
+    case CMD_CMD_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY
+    case CMD_CMD_PARAMS_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle command CMD_DROP
+    case CMD_CMD_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY_DROP
+    case CMD_CMD_PARAMS_PRIORITY_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                FwIndexType portNum,
-                                                FwOpcodeType opCode,
-                                                U32 cmdSeq,
-                                                Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveCommandsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveCommandsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveCommandsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveCommandsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveCommandsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveCommandsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveCommandsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveCommandsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveCommandsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveCommandsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveCommandsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveCommandsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveCommandsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveCommandsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveCommandsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                           FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveCommandsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveCommandsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveCommandsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveCommandsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str2,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveCommandsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveCommandsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) {
-    FW_ASSERT(callComp);
-    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveCommandsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3409,31 +5528,68 @@ void ActiveCommandsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* ca
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void ActiveCommandsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-void ActiveCommandsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveCommandsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVECOMMANDS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -25,933 +25,575 @@ namespace {
     CMD_CMD_PARAMS_PRIORITY,
     CMD_CMD_DROP,
     CMD_CMD_PARAMS_PRIORITY_DROP,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveCommandsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -960,15 +602,10 @@ void ActiveCommandsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveCommandsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveCommandsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -979,213 +616,140 @@ Fw::InputCmdPort* ActiveCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveCommandsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveCommandsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveCommandsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveCommandsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveCommandsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveCommandsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveCommandsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveCommandsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveCommandsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveCommandsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveCommandsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1196,120 +760,62 @@ Ports::InputTypedPort* ActiveCommandsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveCommandsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveCommandsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1320,116 +826,65 @@ void ActiveCommandsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                  Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                 Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1440,106 +895,55 @@ void ActiveCommandsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveCommandsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveCommandsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1550,46 +954,24 @@ void ActiveCommandsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveCommandsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1598,113 +980,51 @@ void ActiveCommandsComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveCommandsComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_ASYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveCommandsComponentBase ::
-  ActiveCommandsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveCommandsComponentBase ::ActiveCommandsComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveCommandsComponentBase ::
-  ~ActiveCommandsComponentBase()
-{
-
-}
+ActiveCommandsComponentBase ::~ActiveCommandsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1712,96 +1032,62 @@ ActiveCommandsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveCommandsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveCommandsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveCommandsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1812,92 +1098,59 @@ bool ActiveCommandsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveCommandsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveCommandsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveCommandsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1908,176 +1161,103 @@ bool ActiveCommandsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveCommandsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                     FwOpcodeType opCode,
+                                                     U32 cmdSeq,
+                                                     Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_CMD_SYNC: {
+            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_CMD_SYNC: {
-      this->CMD_SYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
+        case OPCODE_CMD_SYNC_PRIMITIVE: {
+            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRING: {
+            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ENUM: {
+            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ARRAY: {
+            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRUCT: {
+            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED: {
+            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_PRIMITIVE: {
+            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRING: {
+            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ENUM: {
+            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ARRAY: {
+            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRUCT: {
+            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_ASYNC: {
+            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PRIORITY: {
+            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY: {
+            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_DROP: {
+            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_CMD_SYNC_PRIMITIVE: {
-      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRING: {
-      this->CMD_SYNC_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ENUM: {
-      this->CMD_SYNC_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ARRAY: {
-      this->CMD_SYNC_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRUCT: {
-      this->CMD_SYNC_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED: {
-      this->CMD_GUARDED_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_PRIMITIVE: {
-      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRING: {
-      this->CMD_GUARDED_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ENUM: {
-      this->CMD_GUARDED_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ARRAY: {
-      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRUCT: {
-      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_ASYNC: {
-      this->CMD_ASYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PRIORITY: {
-      this->CMD_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY: {
-      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_DROP: {
-      this->CMD_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -2086,941 +1266,561 @@ void ActiveCommandsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveCommandsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveCommandsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveCommandsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveCommandsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveCommandsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveCommandsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveCommandsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveCommandsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveCommandsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveCommandsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveCommandsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                          AliasPrim1 u32,
+                                                                          AliasPrim2 f32,
+                                                                          AliasBool b,
+                                                                          const Fw::StringBase& str2,
+                                                                          const AliasEnum& e,
+                                                                          const AliasArray& a,
+                                                                          const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveCommandsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                AliasPrim1 u32,
+                                                                                AliasPrim2 f32,
+                                                                                AliasBool b,
+                                                                                const Fw::StringBase& str2,
+                                                                                const AliasEnum& e,
+                                                                                const AliasArray& a,
+                                                                                const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveCommandsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveCommandsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveCommandsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveCommandsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str2,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveCommandsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3031,85 +1831,63 @@ void ActiveCommandsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveCommandsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                              AliasPrim1 u32,
+                                                              AliasPrim2 f32,
+                                                              AliasBool b,
+                                                              const Fw::StringBase& str2,
+                                                              const AliasEnum& e,
+                                                              const AliasArray& a,
+                                                              const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveCommandsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveCommandsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveCommandsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveCommandsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Default: no-op
 }
 
-void ActiveCommandsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveCommandsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3118,209 +1896,103 @@ void ActiveCommandsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveCommandsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveCommandsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveCommandsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveCommandsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                     AliasPrim1 u32,
+                                                     AliasPrim2 f32,
+                                                     AliasBool b,
+                                                     const Fw::StringBase& str2,
+                                                     const AliasEnum& e,
+                                                     const AliasArray& a,
+                                                     const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveCommandsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveCommandsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveCommandsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveCommandsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                U32 u32,
+                                                F32 f32,
+                                                bool b,
+                                                const Fw::StringBase& str1,
+                                                const E& e,
+                                                const A& a,
+                                                const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveCommandsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveCommandsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str2,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3329,15 +2001,9 @@ F32 ActiveCommandsComponentBase ::
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveCommandsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -3346,965 +2012,623 @@ void ActiveCommandsComponentBase ::
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  CMD_SYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveCommandsComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                     U32 cmdSeq,
+                                                                     Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_SYNC_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_SYNC_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_SYNC_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_SYNC_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_GUARDED_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveCommandsComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                        U32 cmdSeq,
+                                                                        Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_GUARDED_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                     U32 cmdSeq,
+                                                                     Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_GUARDED_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_GUARDED_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                    U32 cmdSeq,
+                                                                    Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_GUARDED_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveCommandsComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                     U32 cmdSeq,
+                                                                     Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_ASYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
+void ActiveCommandsComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+void ActiveCommandsComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                               U32 cmdSeq,
+                                                               Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                      U32 cmdSeq,
+                                                                      Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+void ActiveCommandsComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
+                                                                           U32 cmdSeq,
+                                                                           Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -4315,76 +2639,48 @@ void ActiveCommandsComponentBase ::
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  CMD_ASYNC_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveCommandsComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveCommandsComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveCommandsComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveCommandsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveCommandsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -4394,1139 +2690,717 @@ Fw::Time ActiveCommandsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveCommandsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveCommandsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveCommandsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVECOMMANDS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVECOMMANDS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
-    }
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle command CMD_ASYNC
-    case CMD_CMD_ASYNC: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle command CMD_ASYNC
+        case CMD_CMD_ASYNC: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PRIORITY
-    case CMD_CMD_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_PRIORITY
+        case CMD_CMD_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY
-    case CMD_CMD_PARAMS_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY
+        case CMD_CMD_PARAMS_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
-    }
-
-    // Handle command CMD_DROP
-    case CMD_CMD_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_DROP
+        case CMD_CMD_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY_DROP
-    case CMD_CMD_PARAMS_PRIORITY_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_DROP
+        case CMD_CMD_PARAMS_PRIORITY_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveCommandsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                FwIndexType portNum,
+                                                FwOpcodeType opCode,
+                                                U32 cmdSeq,
+                                                Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveCommandsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveCommandsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveCommandsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveCommandsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveCommandsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveCommandsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveCommandsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveCommandsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveCommandsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveCommandsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveCommandsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveCommandsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveCommandsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                           FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveCommandsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveCommandsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveCommandsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveCommandsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str2,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveCommandsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveCommandsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) {
+    FW_ASSERT(callComp);
+    ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -5535,68 +3409,31 @@ void ActiveCommandsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveCommandsComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void ActiveCommandsComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-void ActiveCommandsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveCommandsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEEVENTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveEventsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void ActiveEventsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType ins
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveEventsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveEventsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,139 +967,213 @@ Fw::InputCmdPort* ActiveEventsComponentBase ::get_cmdIn_InputPort(FwIndexType po
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveEventsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveEventsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveEventsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveEventsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveEventsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveEventsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveEventsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveEventsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveEventsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveEventsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveEventsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveEventsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveEventsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveEventsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveEventsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveEventsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveEventsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveEventsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveEventsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveEventsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveEventsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveEventsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveEventsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -754,62 +1184,120 @@ Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedSync_InputPort(FwInd
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -820,64 +1308,116 @@ void ActiveEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -888,55 +1428,106 @@ void ActiveEventsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portN
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -947,24 +1538,46 @@ void ActiveEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -973,16 +1586,23 @@ void ActiveEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveEventsComponentBase ::ActiveEventsComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {
-    this->m_EventActivityLowThrottledThrottle = 0;
-    this->m_EventFatalThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+ActiveEventsComponentBase ::
+  ActiveEventsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
+  this->m_EventActivityLowThrottledThrottle = 0;
+  this->m_EventFatalThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-ActiveEventsComponentBase ::~ActiveEventsComponentBase() {}
+ActiveEventsComponentBase ::
+  ~ActiveEventsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -990,62 +1610,96 @@ ActiveEventsComponentBase ::~ActiveEventsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveEventsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveEventsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveEventsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1056,59 +1710,92 @@ bool ActiveEventsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portN
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveEventsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveEventsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1119,19 +1806,24 @@ bool ActiveEventsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexTy
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveEventsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1140,561 +1832,941 @@ void ActiveEventsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveEventsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveEventsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveEventsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveEventsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveEventsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveEventsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveEventsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveEventsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveEventsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveEventsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveEventsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveEventsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveEventsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveEventsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveEventsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveEventsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveEventsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveEventsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveEventsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveEventsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveEventsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveEventsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveEventsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveEventsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveEventsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveEventsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1705,63 +2777,85 @@ void ActiveEventsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    // Default: no-op
+void ActiveEventsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveEventsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveEventsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveEventsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Default: no-op
+void ActiveEventsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveEventsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void ActiveEventsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveEventsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void ActiveEventsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveEventsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void ActiveEventsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1770,103 +2864,209 @@ void ActiveEventsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType p
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveEventsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveEventsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveEventsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveEventsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveEventsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                   AliasPrim1 u32,
-                                                   AliasPrim2 f32,
-                                                   AliasBool b,
-                                                   const Fw::StringBase& str2,
-                                                   const AliasEnum& e,
-                                                   const AliasArray& a,
-                                                   const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveEventsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveEventsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveEventsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveEventsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveEventsComponentBase ::typedOut_out(FwIndexType portNum,
-                                              U32 u32,
-                                              F32 f32,
-                                              bool b,
-                                              const Fw::StringBase& str1,
-                                              const E& e,
-                                              const A& a,
-                                              const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveEventsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str2,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveEventsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -1875,474 +3075,723 @@ F32 ActiveEventsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
+void ActiveEventsComponentBase ::
+  log_ACTIVITY_HI_EventActivityHigh() const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
-    }
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logBuff
+    );
+  }
 
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity High occurred";
+    const char* _formatString =
+      "(%s) %s: Event Activity High occurred";
 #else
-        const char* _formatString = "%s: Event Activity High occurred";
+    const char* _formatString =
+      "%s: Event Activity High occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityHigh ");
+      "EventActivityHigh "
+    );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
-    }
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logString
+    );
+  }
 #endif
 }
 
-void ActiveEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
-    // Check throttle value
-    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+void ActiveEventsComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  // Check throttle value
+  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventActivityLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(u32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(F32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(f32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U8))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(b);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#else
+    const char* _formatString =
+      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventActivityLowThrottled ",
+      u32,
+      static_cast<F64>(f32),
+      b
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveEventsComponentBase ::
+  log_COMMAND_EventCommand(
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
+  ) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    _status = str1.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = str2.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+    const char* _formatString =
+      "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventCommand ",
+      str1.toChar(),
+      str2.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveEventsComponentBase ::
+  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(E::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(e);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+    Fw::String eStr;
+    e.toString(eStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventDiagnostic ",
+      eStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveEventsComponentBase ::
+  log_FATAL_EventFatalThrottled(const A& a)
+{
+  // Check throttle value
+  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventFatalThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(A::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(a);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Fatal occurred with argument: %s";
+#endif
+
+    Fw::String aStr;
+    a.toString(aStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventFatalThrottled ",
+      aStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveEventsComponentBase ::
+  log_WARNING_HI_EventWarningHigh(const S& s) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(S::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(s);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Warning High occurred with argument: %s";
+#endif
+
+    Fw::String sStr;
+    s.toString(sStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningHigh ",
+      sStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled()
+{
+  // Check throttle value
+  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventWarningLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
+#else
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningLowThrottled "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval()
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+  // Check throttle value & throttle timeout
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
+
+    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+      // The counter has overflowed, check if time interval has passed
+      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
+        // Reset the count
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+      } else {
+        // Throttle the event
         return;
-    } else {
-        this->m_EventActivityLowThrottledThrottle++;
+      }
     }
 
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+    // Reset the throttle time if needed
+    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+      // This is the first event, reset the throttle time
+      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
     }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+    // Increment the count
+    this->m_EventWarningLowThrottledIntervalThrottle++;
+  }
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(3));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
-        _status = _logBuff.serializeFrom(u32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(f32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(b);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
 #else
-        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
-    }
-#endif
-}
-
-void ActiveEventsComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
-                                                          const Fw::StringBase& str2) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(2));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
-                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventCommand ", str1.toChar(), str2.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
-    }
-#endif
-}
-
-void ActiveEventsComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(e);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-        Fw::String eStr;
-        e.toString(eStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventDiagnostic ", eStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
-    }
-#endif
-}
-
-void ActiveEventsComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
-    // Check throttle value
-    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventFatalThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-        _status = _logBuff.serializeFrom(static_cast<U8>(4));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = _logBuff.serializeFrom(static_cast<U32>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(a);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
-#endif
-
-        Fw::String aStr;
-        a.toString(aStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventFatalThrottled ", aStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
-    }
-#endif
-}
-
-void ActiveEventsComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(s);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
-#endif
-
-        Fw::String sStr;
-        s.toString(sStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningHigh ", sStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
-    }
-#endif
-}
-
-void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
-    // Check throttle value
-    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventWarningLowThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottled ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
-#endif
-}
-
-void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-    // Check throttle value & throttle timeout
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
-
-        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-            // The counter has overflowed, check if time interval has passed
-            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
-                Fw::TimeInterval(10, 0)) {
-                // Reset the count
-                this->m_EventWarningLowThrottledIntervalThrottle = 0;
-            } else {
-                // Throttle the event
-                return;
-            }
-        }
-
-        // Reset the throttle time if needed
-        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-            // This is the first event, reset the throttle time
-            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
-        }
-
-        // Increment the count
-        this->m_EventWarningLowThrottledIntervalThrottle++;
-    }
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottledInterval ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
+      "EventWarningLowThrottledInterval "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
 #endif
 }
 
@@ -2350,45 +3799,56 @@ void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventActivityLowThrottledThrottle = 0;
+void ActiveEventsComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventActivityLowThrottledThrottle = 0;
 }
 
-void ActiveEventsComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventFatalThrottledThrottle = 0;
+void ActiveEventsComponentBase ::
+  log_FATAL_EventFatalThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventFatalThrottledThrottle = 0;
 }
 
-void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventWarningLowThrottledThrottle = 0;
+void ActiveEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventWarningLowThrottledThrottle = 0;
 }
 
-void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
+void ActiveEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
+{
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
 
-        // Reset throttle counter
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-        // Reset the throttle time
-        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-    }
+    // Reset the throttle time
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveEventsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveEventsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2398,505 +3858,868 @@ Fw::Time ActiveEventsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveEventsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveEventsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveEventsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEEVENTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEEVENTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                              FwIndexType portNum,
-                                              FwOpcodeType opCode,
-                                              U32 cmdSeq,
-                                              Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveEventsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveEventsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveEventsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveEventsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveEventsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveEventsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveEventsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveEventsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveEventsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveEventsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveEventsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveEventsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveEventsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveEventsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveEventsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveEventsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveEventsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveEventsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveEventsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveEventsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveEventsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveEventsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveEventsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveEventsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str2,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveEventsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveEventsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                  FwIndexType portNum,
-                                                  U32 u32,
-                                                  F32 f32,
-                                                  bool b,
-                                                  const Fw::StringBase& str1,
-                                                  const E& e,
-                                                  const A& a,
-                                                  const S& s) {
-    FW_ASSERT(callComp);
-    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveEventsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2905,39 +4728,80 @@ void ActiveEventsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* call
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::eventOut_out(FwIndexType portNum,
-                                              FwEventIdType id,
-                                              Fw::Time& timeTag,
-                                              const Fw::LogSeverity& severity,
-                                              Fw::LogBuffer& args) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  eventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::LogBuffer& args
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
+  FW_ASSERT(
+    this->m_eventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_eventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    args
+  );
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void ActiveEventsComponentBase ::textEventOut_out(FwIndexType portNum,
-                                                  FwEventIdType id,
-                                                  Fw::Time& timeTag,
-                                                  const Fw::LogSeverity& severity,
-                                                  Fw::TextLogString& text) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  textEventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::TextLogString& text
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
+  FW_ASSERT(
+    this->m_textEventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_textEventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    text
+  );
 }
 
 #endif
 
-void ActiveEventsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveEventsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEEVENTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveEventsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void ActiveEventsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveEventsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveEventsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,139 @@ Fw::InputCmdPort* ActiveEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveEventsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveEventsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveEventsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveEventsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveEventsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveEventsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveEventsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveEventsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveEventsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveEventsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveEventsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveEventsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveEventsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveEventsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveEventsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveEventsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveEventsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +754,62 @@ Ports::InputTypedPort* ActiveEventsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveEventsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveEventsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +820,64 @@ void ActiveEventsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +888,55 @@ void ActiveEventsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveEventsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveEventsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +947,24 @@ void ActiveEventsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveEventsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,23 +973,16 @@ void ActiveEventsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveEventsComponentBase ::
-  ActiveEventsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
-  this->m_EventActivityLowThrottledThrottle = 0;
-  this->m_EventFatalThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledIntervalThrottle = 0;
+ActiveEventsComponentBase ::ActiveEventsComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {
+    this->m_EventActivityLowThrottledThrottle = 0;
+    this->m_EventFatalThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-ActiveEventsComponentBase ::
-  ~ActiveEventsComponentBase()
-{
-
-}
+ActiveEventsComponentBase ::~ActiveEventsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1617,96 +990,62 @@ ActiveEventsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveEventsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveEventsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveEventsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1717,92 +1056,59 @@ bool ActiveEventsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveEventsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveEventsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveEventsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1813,24 +1119,19 @@ bool ActiveEventsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveEventsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1839,941 +1140,561 @@ void ActiveEventsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveEventsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveEventsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveEventsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveEventsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveEventsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveEventsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveEventsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveEventsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveEventsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveEventsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveEventsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveEventsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveEventsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveEventsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveEventsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveEventsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveEventsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveEventsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveEventsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveEventsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveEventsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveEventsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveEventsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveEventsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveEventsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveEventsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -2784,85 +1705,63 @@ void ActiveEventsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveEventsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveEventsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveEventsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveEventsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveEventsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Default: no-op
 }
 
-void ActiveEventsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveEventsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void ActiveEventsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveEventsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void ActiveEventsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveEventsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2871,209 +1770,103 @@ void ActiveEventsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveEventsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveEventsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveEventsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveEventsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveEventsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                   AliasPrim1 u32,
+                                                   AliasPrim2 f32,
+                                                   AliasBool b,
+                                                   const Fw::StringBase& str2,
+                                                   const AliasEnum& e,
+                                                   const AliasArray& a,
+                                                   const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveEventsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveEventsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveEventsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveEventsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveEventsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::typedOut_out(FwIndexType portNum,
+                                              U32 u32,
+                                              F32 f32,
+                                              bool b,
+                                              const Fw::StringBase& str1,
+                                              const E& e,
+                                              const A& a,
+                                              const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveEventsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveEventsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str2,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3082,723 +1875,474 @@ F32 ActiveEventsComponentBase ::
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  log_ACTIVITY_HI_EventActivityHigh() const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
+void ActiveEventsComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
 
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logBuff
-    );
-  }
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
+    }
 
-  // Emit the event on the text log port
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity High occurred";
+        const char* _formatString = "(%s) %s: Event Activity High occurred";
 #else
-    const char* _formatString =
-      "%s: Event Activity High occurred";
+        const char* _formatString = "%s: Event Activity High occurred";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventActivityHigh "
-    );
+                          "EventActivityHigh ");
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
+    }
 #endif
 }
 
-void ActiveEventsComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  // Check throttle value
-  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventActivityLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(3));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(F32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U8))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#else
-    const char* _formatString =
-      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventActivityLowThrottled ",
-      u32,
-      static_cast<F64>(f32),
-      b
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveEventsComponentBase ::
-  log_COMMAND_EventCommand(
-      const Fw::StringBase& str1,
-      const Fw::StringBase& str2
-  ) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(2));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    _status = str1.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = str2.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-    const char* _formatString =
-      "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventCommand ",
-      str1.toChar(),
-      str2.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveEventsComponentBase ::
-  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(E::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-    Fw::String eStr;
-    e.toString(eStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventDiagnostic ",
-      eStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveEventsComponentBase ::
-  log_FATAL_EventFatalThrottled(const A& a)
-{
-  // Check throttle value
-  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventFatalThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serializeFrom(static_cast<U8>(4));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = _logBuff.serializeFrom(static_cast<U32>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(A::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Fatal occurred with argument: %s";
-#endif
-
-    Fw::String aStr;
-    a.toString(aStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventFatalThrottled ",
-      aStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveEventsComponentBase ::
-  log_WARNING_HI_EventWarningHigh(const S& s) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(S::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Warning High occurred with argument: %s";
-#endif
-
-    Fw::String sStr;
-    s.toString(sStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningHigh ",
-      sStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled()
-{
-  // Check throttle value
-  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventWarningLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
-#else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningLowThrottled "
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval()
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-  // Check throttle value & throttle timeout
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
-    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-      // The counter has overflowed, check if time interval has passed
-      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
-        // Reset the count
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
-      } else {
-        // Throttle the event
+void ActiveEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
+    // Check throttle value
+    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
         return;
-      }
+    } else {
+        this->m_EventActivityLowThrottledThrottle++;
     }
 
-    // Reset the throttle time if needed
-    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-      // This is the first event, reset the throttle time
-      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
     }
 
-    // Increment the count
-    this->m_EventWarningLowThrottledIntervalThrottle++;
-  }
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(3));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(u32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Emit the event on the text log port
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(f32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(b);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
+        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
+        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventWarningLowThrottledInterval "
-    );
+                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
+    }
+#endif
+}
+
+void ActiveEventsComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
+                                                          const Fw::StringBase& str2) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(2));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
+                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventCommand ", str1.toChar(), str2.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
+    }
+#endif
+}
+
+void ActiveEventsComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(e);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+        Fw::String eStr;
+        e.toString(eStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventDiagnostic ", eStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
+    }
+#endif
+}
+
+void ActiveEventsComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
+    // Check throttle value
+    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventFatalThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+        _status = _logBuff.serializeFrom(static_cast<U8>(4));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = _logBuff.serializeFrom(static_cast<U32>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(a);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
+#endif
+
+        Fw::String aStr;
+        a.toString(aStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventFatalThrottled ", aStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
+    }
+#endif
+}
+
+void ActiveEventsComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(s);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
+#endif
+
+        Fw::String sStr;
+        s.toString(sStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningHigh ", sStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
+    }
+#endif
+}
+
+void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
+    // Check throttle value
+    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventWarningLowThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottled ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
+#endif
+}
+
+void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+    // Check throttle value & throttle timeout
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+            // The counter has overflowed, check if time interval has passed
+            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
+                Fw::TimeInterval(10, 0)) {
+                // Reset the count
+                this->m_EventWarningLowThrottledIntervalThrottle = 0;
+            } else {
+                // Throttle the event
+                return;
+            }
+        }
+
+        // Reset the throttle time if needed
+        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+            // This is the first event, reset the throttle time
+            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+        }
+
+        // Increment the count
+        this->m_EventWarningLowThrottledIntervalThrottle++;
+    }
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottledInterval ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
 #endif
 }
 
@@ -3806,56 +2350,45 @@ void ActiveEventsComponentBase ::
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventActivityLowThrottledThrottle = 0;
-}
-
-void ActiveEventsComponentBase ::
-  log_FATAL_EventFatalThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventFatalThrottledThrottle = 0;
-}
-
-void ActiveEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventWarningLowThrottledThrottle = 0;
-}
-
-void ActiveEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
-{
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
+void ActiveEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
     // Reset throttle counter
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    this->m_EventActivityLowThrottledThrottle = 0;
+}
 
-    // Reset the throttle time
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-  }
+void ActiveEventsComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventFatalThrottledThrottle = 0;
+}
+
+void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledThrottle = 0;
+}
+
+void ActiveEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        // Reset throttle counter
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+
+        // Reset the throttle time
+        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveEventsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveEventsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3865,868 +2398,505 @@ Fw::Time ActiveEventsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveEventsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveEventsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveEventsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEEVENTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVEEVENTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveEventsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                              FwIndexType portNum,
+                                              FwOpcodeType opCode,
+                                              U32 cmdSeq,
+                                              Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveEventsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveEventsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveEventsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveEventsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveEventsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveEventsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveEventsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveEventsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveEventsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveEventsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveEventsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveEventsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveEventsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveEventsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveEventsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveEventsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveEventsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveEventsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveEventsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str2,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveEventsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveEventsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                  FwIndexType portNum,
+                                                  U32 u32,
+                                                  F32 f32,
+                                                  bool b,
+                                                  const Fw::StringBase& str1,
+                                                  const E& e,
+                                                  const A& a,
+                                                  const S& s) {
+    FW_ASSERT(callComp);
+    ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4735,80 +2905,39 @@ void ActiveEventsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveEventsComponentBase ::
-  eventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::LogBuffer& args
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::eventOut_out(FwIndexType portNum,
+                                              FwEventIdType id,
+                                              Fw::Time& timeTag,
+                                              const Fw::LogSeverity& severity,
+                                              Fw::LogBuffer& args) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_eventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_eventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    args
-  );
+    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void ActiveEventsComponentBase ::
-  textEventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::TextLogString& text
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::textEventOut_out(FwIndexType portNum,
+                                                  FwEventIdType id,
+                                                  Fw::Time& timeTag,
+                                                  const Fw::LogSeverity& severity,
+                                                  Fw::TextLogString& text) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_textEventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_textEventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    text
-  );
+    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
 }
 
 #endif
 
-void ActiveEventsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveEventsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEEXTERNALPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveExternalParamsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void ActiveExternalParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStore
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveExternalParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveExternalParamsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,141 +967,213 @@ Fw::InputCmdPort* ActiveExternalParamsComponentBase ::get_cmdIn_InputPort(FwInde
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveExternalParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveExternalParamsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveExternalParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveExternalParamsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveExternalParamsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveExternalParamsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveExternalParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveExternalParamsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -756,63 +1184,120 @@ Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedSync_InputPo
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                       Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -823,67 +1308,116 @@ void ActiveExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portN
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                            Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -894,57 +1428,106 @@ void ActiveExternalParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexTy
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                       Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -955,25 +1538,46 @@ void ActiveExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portN
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -982,192 +1586,298 @@ void ActiveExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType por
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveExternalParamsComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+  );
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::loadParameters() {
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void ActiveExternalParamsComponentBase ::
+  loadParameters()
+{
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-    FwPrmIdType _id{};
-    Fw::ParamBuffer _paramBuffer;
+  FwPrmIdType _id{};
+  Fw::ParamBuffer _paramBuffer;
 
-    _id = _baseId + PARAMID_PARAMI32EXT;
+  _id = _baseId + PARAMID_PARAMI32EXT;
 
-    // Get serialized parameter ParamI32Ext
-    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamI32Ext
+  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMI32EXT,
+    this->m_param_ParamI32Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMF64EXT;
+
+  // Get serialized parameter ParamF64Ext
+  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMF64EXT,
+    this->m_param_ParamF64Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRINGEXT;
+
+  // Get serialized parameter ParamStringExt
+  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
     }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMF64EXT;
-
-    // Get serialized parameter ParamF64Ext
-    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+    Fw::String _val = Fw::String("external default");
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRINGEXT;
+  _id = _baseId + PARAMID_PARAMENUMEXT;
 
-    // Get serialized parameter ParamStringExt
-    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamEnumExt
+  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-        Fw::String _val = Fw::String("external default");
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMENUMEXT,
+    this->m_param_ParamEnumExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMENUMEXT;
+  _id = _baseId + PARAMID_PARAMARRAYEXT;
 
-    // Get serialized parameter ParamEnumExt
-    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamArrayExt
+  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
     }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMARRAYEXT;
-
-    // Get serialized parameter ParamArrayExt
-    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-        A _val = A({1, 2, 3});
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-    // Get serialized parameter ParamStructExt
-    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+    A _val = A({1, 2, 3});
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
-                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parametersLoaded();
+  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+  // Get serialized parameter ParamStructExt
+  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMSTRUCTEXT,
+    this->m_param_ParamStructExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  // Call notifier
+  this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveExternalParamsComponentBase ::ActiveExternalParamsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+ActiveExternalParamsComponentBase ::
+  ActiveExternalParamsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveExternalParamsComponentBase ::~ActiveExternalParamsComponentBase() {}
+}
+
+ActiveExternalParamsComponentBase ::
+  ~ActiveExternalParamsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1175,62 +1885,96 @@ ActiveExternalParamsComponentBase ::~ActiveExternalParamsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveExternalParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveExternalParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveExternalParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1241,59 +1985,92 @@ bool ActiveExternalParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexTy
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveExternalParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveExternalParamsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1304,90 +2081,143 @@ bool ActiveExternalParamsComponentBase ::isConnected_typedReturnOut_OutputPort(F
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                           FwOpcodeType opCode,
-                                                           U32 cmdSeq,
-                                                           Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveExternalParamsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_PARAMI32EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_PARAMI32EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_PARAMI32EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
     }
+
+    case OPCODE_PARAMI32EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1396,561 +2226,941 @@ void ActiveExternalParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveExternalParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveExternalParamsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveExternalParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveExternalParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveExternalParamsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveExternalParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveExternalParamsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveExternalParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveExternalParamsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveExternalParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                                AliasPrim1 u32,
-                                                                                AliasPrim2 f32,
-                                                                                AliasBool b,
-                                                                                const Fw::StringBase& str2,
-                                                                                const AliasEnum& e,
-                                                                                const AliasArray& a,
-                                                                                const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveExternalParamsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveExternalParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                      AliasPrim1 u32,
-                                                                                      AliasPrim2 f32,
-                                                                                      AliasBool b,
-                                                                                      const Fw::StringBase& str2,
-                                                                                      const AliasEnum& e,
-                                                                                      const AliasArray& a,
-                                                                                      const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveExternalParamsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveExternalParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveExternalParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                             U32 u32,
-                                                                             F32 f32,
-                                                                             bool b,
-                                                                             const Fw::StringBase& str1,
-                                                                             const E& e,
-                                                                             const A& a,
-                                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveExternalParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveExternalParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveExternalParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveExternalParamsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveExternalParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveExternalParamsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1961,63 +3171,85 @@ void ActiveExternalParamsComponentBase ::typedSync_handlerBase(FwIndexType portN
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) {
-    // Default: no-op
+void ActiveExternalParamsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveExternalParamsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Default: no-op
+void ActiveExternalParamsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Default: no-op
+void ActiveExternalParamsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Default: no-op
+void ActiveExternalParamsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Default: no-op
+void ActiveExternalParamsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2026,103 +3258,209 @@ void ActiveExternalParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwInd
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveExternalParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveExternalParamsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveExternalParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveExternalParamsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveExternalParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                           AliasPrim1 u32,
-                                                           AliasPrim2 f32,
-                                                           AliasBool b,
-                                                           const Fw::StringBase& str2,
-                                                           const AliasEnum& e,
-                                                           const AliasArray& a,
-                                                           const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveExternalParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveExternalParamsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveExternalParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                             AliasPrim1 u32,
-                                                                             AliasPrim2 f32,
-                                                                             AliasBool b,
-                                                                             const Fw::StringBase& str2,
-                                                                             const AliasEnum& e,
-                                                                             const AliasArray& a,
-                                                                             const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveExternalParamsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveExternalParamsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveExternalParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str2,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveExternalParamsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2131,169 +3469,213 @@ F32 ActiveExternalParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveExternalParamsComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
-    // Do nothing by default
+void ActiveExternalParamsComponentBase ::
+  parameterUpdated(FwPrmIdType id)
+{
+  // Do nothing by default
 }
 
-void ActiveExternalParamsComponentBase ::parametersLoaded() {
-    // Do nothing by default
+void ActiveExternalParamsComponentBase ::
+  parametersLoaded()
+{
+  // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-I32 ActiveExternalParamsComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
-    I32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamI32Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+I32 ActiveExternalParamsComponentBase ::
+  paramGet_ParamI32Ext(Fw::ParamValid& valid)
+{
+  I32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamI32Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 ActiveExternalParamsComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+F64 ActiveExternalParamsComponentBase ::
+  paramGet_ParamF64Ext(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString ActiveExternalParamsComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStringExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+Fw::ParamString ActiveExternalParamsComponentBase ::
+  paramGet_ParamStringExt(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStringExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E ActiveExternalParamsComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnumExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+E ActiveExternalParamsComponentBase ::
+  paramGet_ParamEnumExt(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnumExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A ActiveExternalParamsComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArrayExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+A ActiveExternalParamsComponentBase ::
+  paramGet_ParamArrayExt(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArrayExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S ActiveExternalParamsComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStructExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+S ActiveExternalParamsComponentBase ::
+  paramGet_ParamStructExt(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStructExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::registerExternalParameters(
-    Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
-    FW_ASSERT(paramExternalDelegatePtr != nullptr);
-    this->paramDelegatePtr = paramExternalDelegatePtr;
+void ActiveExternalParamsComponentBase ::
+  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
+{
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
+  this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveExternalParamsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveExternalParamsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2303,507 +3685,868 @@ Fw::Time ActiveExternalParamsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveExternalParamsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveExternalParamsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveExternalParamsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEEXTERNALPARAMS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEEXTERNALPARAMS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveExternalParamsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                AliasPrim1 u32,
-                                                                AliasPrim2 f32,
-                                                                AliasBool b,
-                                                                const Fw::StringBase& str2,
-                                                                const AliasEnum& e,
-                                                                const AliasArray& a,
-                                                                const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveExternalParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                  FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveExternalParamsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveExternalParamsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveExternalParamsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveExternalParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveExternalParamsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveExternalParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveExternalParamsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveExternalParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                             FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveExternalParamsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveExternalParamsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveExternalParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                           FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveExternalParamsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveExternalParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                 FwIndexType portNum,
-                                                                                 AliasPrim1 u32,
-                                                                                 AliasPrim2 f32,
-                                                                                 AliasBool b,
-                                                                                 const Fw::StringBase& str2,
-                                                                                 const AliasEnum& e,
-                                                                                 const AliasArray& a,
-                                                                                 const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveExternalParamsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveExternalParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveExternalParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveExternalParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveExternalParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveExternalParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveExternalParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveExternalParamsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveExternalParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveExternalParamsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveExternalParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveExternalParamsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2812,51 +4555,112 @@ void ActiveExternalParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBa
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void ActiveExternalParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                            FwOpcodeType opCode,
-                                                            U32 cmdSeq,
-                                                            const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-Fw::ParamValid ActiveExternalParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                                 FwPrmIdType id,
-                                                                 Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::ParamValid ActiveExternalParamsComponentBase ::
+  prmGetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_prmGetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void ActiveExternalParamsComponentBase ::prmSetOut_out(FwIndexType portNum,
-                                                       FwPrmIdType id,
-                                                       Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  prmSetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmSetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_prmSetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void ActiveExternalParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveExternalParamsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2865,306 +4669,396 @@ void ActiveExternalParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw:
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMI32EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMI32EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMF64EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMF64EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRINGEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMENUMEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMENUMEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMARRAYEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRUCTEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
+  return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamI32Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSave_ParamI32Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamF64Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSave_ParamF64Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamStringExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSave_ParamStringExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamEnumExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSave_ParamEnumExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamArrayExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSave_ParamArrayExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamStructExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::
+  paramSave_ParamStructExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEEXTERNALPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveExternalParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void ActiveExternalParamsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveExternalParamsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveExternalParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,141 @@ Fw::InputCmdPort* ActiveExternalParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveExternalParamsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveExternalParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveExternalParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveExternalParamsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveExternalParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveExternalParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveExternalParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveExternalParamsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveExternalParamsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveExternalParamsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveExternalParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveExternalParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveExternalParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +756,63 @@ Ports::InputTypedPort* ActiveExternalParamsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                       Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveExternalParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveExternalParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +823,67 @@ void ActiveExternalParamsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                            Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +894,57 @@ void ActiveExternalParamsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                       Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveExternalParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveExternalParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +955,25 @@ void ActiveExternalParamsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveExternalParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,298 +982,192 @@ void ActiveExternalParamsComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveExternalParamsComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  loadParameters()
-{
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void ActiveExternalParamsComponentBase ::loadParameters() {
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-  FwPrmIdType _id{};
-  Fw::ParamBuffer _paramBuffer;
+    FwPrmIdType _id{};
+    Fw::ParamBuffer _paramBuffer;
 
-  _id = _baseId + PARAMID_PARAMI32EXT;
+    _id = _baseId + PARAMID_PARAMI32EXT;
 
-  // Get serialized parameter ParamI32Ext
-  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamI32Ext
+    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMI32EXT,
-    this->m_param_ParamI32Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMF64EXT;
-
-  // Get serialized parameter ParamF64Ext
-  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMF64EXT,
-    this->m_param_ParamF64Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMSTRINGEXT;
-
-  // Get serialized parameter ParamStringExt
-  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-    Fw::String _val = Fw::String("external default");
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMF64EXT;
+
+    // Get serialized parameter ParamF64Ext
+    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMENUMEXT;
+    _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
-  // Get serialized parameter ParamEnumExt
-  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStringExt
+    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMENUMEXT,
-    this->m_param_ParamEnumExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+        Fw::String _val = Fw::String("external default");
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAYEXT;
+    _id = _baseId + PARAMID_PARAMENUMEXT;
 
-  // Get serialized parameter ParamArrayExt
-  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnumExt
+    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-    A _val = A({1, 2, 3});
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+    // Get serialized parameter ParamArrayExt
+    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+        A _val = A({1, 2, 3});
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+    // Get serialized parameter ParamStructExt
+    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
+                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-  // Get serialized parameter ParamStructExt
-  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMSTRUCTEXT,
-    this->m_param_ParamStructExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  // Call notifier
-  this->parametersLoaded();
+    // Call notifier
+    this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveExternalParamsComponentBase ::
-  ActiveExternalParamsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveExternalParamsComponentBase ::ActiveExternalParamsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveExternalParamsComponentBase ::
-  ~ActiveExternalParamsComponentBase()
-{
-
-}
+ActiveExternalParamsComponentBase ::~ActiveExternalParamsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1892,96 +1175,62 @@ ActiveExternalParamsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1992,92 +1241,59 @@ bool ActiveExternalParamsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveExternalParamsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveExternalParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2088,143 +1304,90 @@ bool ActiveExternalParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveExternalParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                           FwOpcodeType opCode,
+                                                           U32 cmdSeq,
+                                                           Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_PARAMI32EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_PARAMI32EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
+        case OPCODE_PARAMI32EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_PARAMI32EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -2233,941 +1396,561 @@ void ActiveExternalParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveExternalParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveExternalParamsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveExternalParamsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveExternalParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveExternalParamsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveExternalParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveExternalParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveExternalParamsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveExternalParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                                AliasPrim1 u32,
+                                                                                AliasPrim2 f32,
+                                                                                AliasBool b,
+                                                                                const Fw::StringBase& str2,
+                                                                                const AliasEnum& e,
+                                                                                const AliasArray& a,
+                                                                                const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveExternalParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                      AliasPrim1 u32,
+                                                                                      AliasPrim2 f32,
+                                                                                      AliasBool b,
+                                                                                      const Fw::StringBase& str2,
+                                                                                      const AliasEnum& e,
+                                                                                      const AliasArray& a,
+                                                                                      const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                             U32 u32,
+                                                                             F32 f32,
+                                                                             bool b,
+                                                                             const Fw::StringBase& str1,
+                                                                             const E& e,
+                                                                             const A& a,
+                                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveExternalParamsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveExternalParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveExternalParamsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveExternalParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3178,85 +1961,63 @@ void ActiveExternalParamsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveExternalParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveExternalParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveExternalParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveExternalParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveExternalParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Default: no-op
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveExternalParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3265,209 +2026,103 @@ void ActiveExternalParamsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveExternalParamsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveExternalParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveExternalParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                           AliasPrim1 u32,
+                                                           AliasPrim2 f32,
+                                                           AliasBool b,
+                                                           const Fw::StringBase& str2,
+                                                           const AliasEnum& e,
+                                                           const AliasArray& a,
+                                                           const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveExternalParamsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveExternalParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveExternalParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                             AliasPrim1 u32,
+                                                                             AliasPrim2 f32,
+                                                                             AliasBool b,
+                                                                             const Fw::StringBase& str2,
+                                                                             const AliasEnum& e,
+                                                                             const AliasArray& a,
+                                                                             const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveExternalParamsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveExternalParamsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveExternalParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str2,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3476,213 +2131,169 @@ F32 ActiveExternalParamsComponentBase ::
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveExternalParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  parameterUpdated(FwPrmIdType id)
-{
-  // Do nothing by default
+void ActiveExternalParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
+    // Do nothing by default
 }
 
-void ActiveExternalParamsComponentBase ::
-  parametersLoaded()
-{
-  // Do nothing by default
+void ActiveExternalParamsComponentBase ::parametersLoaded() {
+    // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-I32 ActiveExternalParamsComponentBase ::
-  paramGet_ParamI32Ext(Fw::ParamValid& valid)
-{
-  I32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamI32Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+I32 ActiveExternalParamsComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
+    I32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamI32Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-F64 ActiveExternalParamsComponentBase ::
-  paramGet_ParamF64Ext(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+F64 ActiveExternalParamsComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-Fw::ParamString ActiveExternalParamsComponentBase ::
-  paramGet_ParamStringExt(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStringExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+Fw::ParamString ActiveExternalParamsComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStringExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-E ActiveExternalParamsComponentBase ::
-  paramGet_ParamEnumExt(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnumExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+E ActiveExternalParamsComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnumExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-A ActiveExternalParamsComponentBase ::
-  paramGet_ParamArrayExt(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArrayExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+A ActiveExternalParamsComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArrayExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-S ActiveExternalParamsComponentBase ::
-  paramGet_ParamStructExt(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStructExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+S ActiveExternalParamsComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStructExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
-{
-  FW_ASSERT(paramExternalDelegatePtr != nullptr);
-  this->paramDelegatePtr = paramExternalDelegatePtr;
+void ActiveExternalParamsComponentBase ::registerExternalParameters(
+    Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
+    FW_ASSERT(paramExternalDelegatePtr != nullptr);
+    this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveExternalParamsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveExternalParamsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3692,868 +2303,507 @@ Fw::Time ActiveExternalParamsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveExternalParamsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveExternalParamsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveExternalParamsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEEXTERNALPARAMS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVEEXTERNALPARAMS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveExternalParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                AliasPrim1 u32,
+                                                                AliasPrim2 f32,
+                                                                AliasBool b,
+                                                                const Fw::StringBase& str2,
+                                                                const AliasEnum& e,
+                                                                const AliasArray& a,
+                                                                const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveExternalParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                  FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveExternalParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveExternalParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveExternalParamsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveExternalParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveExternalParamsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveExternalParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveExternalParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                             FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveExternalParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveExternalParamsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveExternalParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                           FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveExternalParamsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveExternalParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                 FwIndexType portNum,
+                                                                                 AliasPrim1 u32,
+                                                                                 AliasPrim2 f32,
+                                                                                 AliasBool b,
+                                                                                 const Fw::StringBase& str2,
+                                                                                 const AliasEnum& e,
+                                                                                 const AliasArray& a,
+                                                                                 const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveExternalParamsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveExternalParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveExternalParamsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveExternalParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveExternalParamsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveExternalParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4562,112 +2812,51 @@ void ActiveExternalParamsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveExternalParamsComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void ActiveExternalParamsComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                            FwOpcodeType opCode,
+                                                            U32 cmdSeq,
+                                                            const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-Fw::ParamValid ActiveExternalParamsComponentBase ::
-  prmGetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::ParamValid ActiveExternalParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                                 FwPrmIdType id,
+                                                                 Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_prmGetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void ActiveExternalParamsComponentBase ::
-  prmSetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::prmSetOut_out(FwIndexType portNum,
+                                                       FwPrmIdType id,
+                                                       Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmSetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_prmSetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void ActiveExternalParamsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveExternalParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4676,396 +2865,306 @@ void ActiveExternalParamsComponentBase ::
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMI32EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMI32EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMF64EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMF64EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRINGEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMENUMEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMENUMEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMARRAYEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRUCTEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    }
+    return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSave_ParamI32Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamI32Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSave_ParamF64Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamF64Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSave_ParamStringExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamStringExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSave_ParamEnumExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamEnumExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSave_ParamArrayExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamArrayExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveExternalParamsComponentBase ::
-  paramSave_ParamStructExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveExternalParamsComponentBase ::paramSave_ParamStructExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
@@ -13,49 +13,61 @@
 
 namespace ExternalSm {
 
-namespace {
-enum MsgTypeEnum {
-    ACTIVEEXTERNALSTATEMACHINES_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    EXTERNAL_STATE_MACHINE_SIGNAL,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    // Size of buffer for external state machine signals
-    // The external SmSignalBuffer stores the signal data
-    BYTE externalSmBufferSize[2 * sizeof(FwEnumStoreType) + Fw::SmSignalBuffer::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+  namespace {
+    enum MsgTypeEnum {
+      ACTIVEEXTERNALSTATEMACHINES_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      EXTERNAL_STATE_MACHINE_SIGNAL,
     };
 
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
-    }
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      // Size of buffer for external state machine signals
+      // The external SmSignalBuffer stores the signal data
+      BYTE externalSmBufferSize[
+        2 * sizeof(FwEnumStoreType) + Fw::SmSignalBuffer::SERIALIZED_SIZE
+      ];
+    };
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+      public:
 
-void ActiveExternalStateMachinesComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
+
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
+
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
+
+  void ActiveExternalStateMachinesComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -68,370 +80,545 @@ void ActiveExternalStateMachinesComponentBase ::init(FwSizeType queueDepth, FwEn
     this->m_stateMachine_sm6.init(static_cast<FwEnumStoreType>(SmId::sm6));
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-ActiveExternalStateMachinesComponentBase ::ActiveExternalStateMachinesComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName),
+  ActiveExternalStateMachinesComponentBase ::
+    ActiveExternalStateMachinesComponentBase(const char* compName) :
+      Fw::ActiveComponentBase(compName),
       m_stateMachine_sm1(this),
       m_stateMachine_sm2(this),
       m_stateMachine_sm3(this),
       m_stateMachine_sm4(this),
       m_stateMachine_sm5(this),
-      m_stateMachine_sm6(this) {}
+      m_stateMachine_sm6(this)
+  {
 
-ActiveExternalStateMachinesComponentBase ::~ActiveExternalStateMachinesComponentBase() {}
+  }
 
-// ----------------------------------------------------------------------
-// State getter functions
-// ----------------------------------------------------------------------
+  ActiveExternalStateMachinesComponentBase ::
+    ~ActiveExternalStateMachinesComponentBase()
+  {
 
-ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States
-ActiveExternalStateMachinesComponentBase ::sm1_getState() const {
+  }
+
+  // ----------------------------------------------------------------------
+  // State getter functions
+  // ----------------------------------------------------------------------
+
+  ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States ActiveExternalStateMachinesComponentBase ::
+    sm1_getState() const
+  {
     return this->m_stateMachine_sm1.state;
-}
+  }
 
-ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States
-ActiveExternalStateMachinesComponentBase ::sm2_getState() const {
+  ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States ActiveExternalStateMachinesComponentBase ::
+    sm2_getState() const
+  {
     return this->m_stateMachine_sm2.state;
-}
+  }
 
-ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
-ActiveExternalStateMachinesComponentBase ::sm3_getState() const {
+  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
+    sm3_getState() const
+  {
     return this->m_stateMachine_sm3.state;
-}
+  }
 
-ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
-ActiveExternalStateMachinesComponentBase ::sm4_getState() const {
+  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
+    sm4_getState() const
+  {
     return this->m_stateMachine_sm4.state;
-}
+  }
 
-ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
-ActiveExternalStateMachinesComponentBase ::sm5_getState() const {
+  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
+    sm5_getState() const
+  {
     return this->m_stateMachine_sm5.state;
-}
+  }
 
-ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
-ActiveExternalStateMachinesComponentBase ::sm6_getState() const {
+  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
+    sm6_getState() const
+  {
     return this->m_stateMachine_sm6.state;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Functions for sending signals to external state machines
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Functions for sending signals to external state machines
+  // ----------------------------------------------------------------------
 
-void ActiveExternalStateMachinesComponentBase ::sm1_stateMachineInvoke(
-    const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
-    const Fw::SmSignalBuffer& data) {
+  void ActiveExternalStateMachinesComponentBase ::
+    sm1_stateMachineInvoke(
+        const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
+        const Fw::SmSignalBuffer& data
+    )
+  {
+
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm1));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 1, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveExternalStateMachinesComponentBase ::sm2_stateMachineInvoke(
-    const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
-    const Fw::SmSignalBuffer& data) {
+  void ActiveExternalStateMachinesComponentBase ::
+    sm2_stateMachineInvoke(
+        const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
+        const Fw::SmSignalBuffer& data
+    )
+  {
+
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm2));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 2, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveExternalStateMachinesComponentBase ::sm3_stateMachineInvoke(
-    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-    const Fw::SmSignalBuffer& data) {
+  void ActiveExternalStateMachinesComponentBase ::
+    sm3_stateMachineInvoke(
+        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+        const Fw::SmSignalBuffer& data
+    )
+  {
+
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm3));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveExternalStateMachinesComponentBase ::sm4_stateMachineInvoke(
-    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-    const Fw::SmSignalBuffer& data) {
+  void ActiveExternalStateMachinesComponentBase ::
+    sm4_stateMachineInvoke(
+        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+        const Fw::SmSignalBuffer& data
+    )
+  {
+
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm4));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 4, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveExternalStateMachinesComponentBase ::sm5_stateMachineInvoke(
-    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-    const Fw::SmSignalBuffer& data) {
+  void ActiveExternalStateMachinesComponentBase ::
+    sm5_stateMachineInvoke(
+        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+        const Fw::SmSignalBuffer& data
+    )
+  {
+
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm5));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 0, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->sm5_stateMachineOverflowHook(signal, data);
-        return;
+      this->sm5_stateMachineOverflowHook(signal, data);
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveExternalStateMachinesComponentBase ::sm6_stateMachineInvoke(
-    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-    const Fw::SmSignalBuffer& data) {
+  void ActiveExternalStateMachinesComponentBase ::
+    sm6_stateMachineInvoke(
+        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+        const Fw::SmSignalBuffer& data
+    )
+  {
+
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm6));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalStateMachinesComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalStateMachinesComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::BLOCKING,
+      _priority
+    );
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == ACTIVEEXTERNALSTATEMACHINES_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle signals to external state machines
-        case EXTERNAL_STATE_MACHINE_SIGNAL: {
-            // Deserialize the state machine ID to an FwEnumStoreType
-            FwEnumStoreType enumStoreSmId = 0;
-            _deserStatus = _msg.deserializeTo(enumStoreSmId);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Cast it to the correct type
-            SmId stateMachineId = static_cast<SmId>(enumStoreSmId);
 
-            // Deserialize the state machine signal to an FwEnumStoreType.
-            // This value will be cast to the correct type in the
-            // switch statement that calls the state machine update function.
-            FwEnumStoreType enumStoreSmSignal = 0;
-            _deserStatus = _msg.deserializeTo(enumStoreSmSignal);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle signals to external state machines
+      case EXTERNAL_STATE_MACHINE_SIGNAL: {
 
-            // Deserialize the state machine data
-            Fw::SmSignalBuffer data;
-            _deserStatus = _msg.deserializeTo(data);
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize the state machine ID to an FwEnumStoreType
+        FwEnumStoreType enumStoreSmId = 0;
+        _deserStatus = _msg.deserializeTo(enumStoreSmId);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+        // Cast it to the correct type
+        SmId stateMachineId = static_cast<SmId>(enumStoreSmId);
 
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+        // Deserialize the state machine signal to an FwEnumStoreType.
+        // This value will be cast to the correct type in the
+        // switch statement that calls the state machine update function.
+        FwEnumStoreType enumStoreSmSignal = 0;
+        _deserStatus = _msg.deserializeTo(enumStoreSmSignal);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Call the state machine update function
-            switch (stateMachineId) {
-                case SmId::sm1: {
-                    ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals
-                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::
-                                                 ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
-                    this->m_stateMachine_sm1.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-                    break;
-                }
+        // Deserialize the state machine data
+        Fw::SmSignalBuffer data;
+        _deserStatus = _msg.deserializeTo(data);
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-                case SmId::sm2: {
-                    ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals
-                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::
-                                                 ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
-                    this->m_stateMachine_sm2.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-                    break;
-                }
+        // Make sure there was no data left over.
+        // That means the buffer size was incorrect.
+        FW_ASSERT(
+          _msg.getDeserializeSizeLeft() == 0,
+          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+        );
 
-                case SmId::sm3: {
-                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
-                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
-                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-                    this->m_stateMachine_sm3.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-                    break;
-                }
+        // Call the state machine update function
+        switch (stateMachineId) {
 
-                case SmId::sm4: {
-                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
-                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
-                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-                    this->m_stateMachine_sm4.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-                    break;
-                }
-
-                case SmId::sm5: {
-                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
-                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
-                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-                    this->m_stateMachine_sm5.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-                    break;
-                }
-
-                case SmId::sm6: {
-                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
-                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
-                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-                    this->m_stateMachine_sm6.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-                    break;
-                }
-
-                default:
-                    return MSG_DISPATCH_ERROR;
-            }
-
+          case SmId::sm1: {
+            ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal =
+              static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
+            this->m_stateMachine_sm1.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
             break;
+          }
+
+          case SmId::sm2: {
+            ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal =
+              static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
+            this->m_stateMachine_sm2.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+            break;
+          }
+
+          case SmId::sm3: {
+            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
+              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+            this->m_stateMachine_sm3.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+            break;
+          }
+
+          case SmId::sm4: {
+            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
+              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+            this->m_stateMachine_sm4.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+            break;
+          }
+
+          case SmId::sm5: {
+            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
+              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+            this->m_stateMachine_sm5.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+            break;
+          }
+
+          case SmId::sm6: {
+            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
+              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+            this->m_stateMachine_sm6.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+            break;
+          }
+
+          default:
+            return MSG_DISPATCH_ERROR;
         }
 
-        default:
-            return MSG_DISPATCH_ERROR;
+        break;
+      }
+
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-}  // namespace ExternalSm
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
@@ -13,68 +13,49 @@
 
 namespace ExternalSm {
 
-  namespace {
-    enum MsgTypeEnum {
-      ACTIVEEXTERNALSTATEMACHINES_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      EXTERNAL_STATE_MACHINE_SIGNAL,
+namespace {
+enum MsgTypeEnum {
+    ACTIVEEXTERNALSTATEMACHINES_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    EXTERNAL_STATE_MACHINE_SIGNAL,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    // Size of buffer for external state machine signals
+    // The external SmSignalBuffer stores the signal data
+    BYTE externalSmBufferSize[2 * sizeof(FwEnumStoreType) + Fw::SmSignalBuffer::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
     };
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      // Size of buffer for external state machine signals
-      // The external SmSignalBuffer stores the signal data
-      BYTE externalSmBufferSize[
-        2 * sizeof(FwEnumStoreType) + Fw::SmSignalBuffer::SERIALIZED_SIZE
-      ];
-    };
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-      public:
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
 
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
-
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
-
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
-
-  void ActiveExternalStateMachinesComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+void ActiveExternalStateMachinesComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -87,545 +68,370 @@ namespace ExternalSm {
     this->m_stateMachine_sm6.init(static_cast<FwEnumStoreType>(SmId::sm6));
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  ActiveExternalStateMachinesComponentBase ::
-    ActiveExternalStateMachinesComponentBase(const char* compName) :
-      Fw::ActiveComponentBase(compName),
+ActiveExternalStateMachinesComponentBase ::ActiveExternalStateMachinesComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName),
       m_stateMachine_sm1(this),
       m_stateMachine_sm2(this),
       m_stateMachine_sm3(this),
       m_stateMachine_sm4(this),
       m_stateMachine_sm5(this),
-      m_stateMachine_sm6(this)
-  {
+      m_stateMachine_sm6(this) {}
 
-  }
+ActiveExternalStateMachinesComponentBase ::~ActiveExternalStateMachinesComponentBase() {}
 
-  ActiveExternalStateMachinesComponentBase ::
-    ~ActiveExternalStateMachinesComponentBase()
-  {
+// ----------------------------------------------------------------------
+// State getter functions
+// ----------------------------------------------------------------------
 
-  }
-
-  // ----------------------------------------------------------------------
-  // State getter functions
-  // ----------------------------------------------------------------------
-
-  ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States ActiveExternalStateMachinesComponentBase ::
-    sm1_getState() const
-  {
+ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States
+ActiveExternalStateMachinesComponentBase ::sm1_getState() const {
     return this->m_stateMachine_sm1.state;
-  }
+}
 
-  ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States ActiveExternalStateMachinesComponentBase ::
-    sm2_getState() const
-  {
+ExternalSm::ActiveExternalStateMachines_S1::ActiveExternalStateMachines_S1_States
+ActiveExternalStateMachinesComponentBase ::sm2_getState() const {
     return this->m_stateMachine_sm2.state;
-  }
+}
 
-  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
-    sm3_getState() const
-  {
+ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
+ActiveExternalStateMachinesComponentBase ::sm3_getState() const {
     return this->m_stateMachine_sm3.state;
-  }
+}
 
-  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
-    sm4_getState() const
-  {
+ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
+ActiveExternalStateMachinesComponentBase ::sm4_getState() const {
     return this->m_stateMachine_sm4.state;
-  }
+}
 
-  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
-    sm5_getState() const
-  {
+ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
+ActiveExternalStateMachinesComponentBase ::sm5_getState() const {
     return this->m_stateMachine_sm5.state;
-  }
+}
 
-  ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States ActiveExternalStateMachinesComponentBase ::
-    sm6_getState() const
-  {
+ExternalSm::ActiveExternalStateMachines_S2::ActiveExternalStateMachines_S2_States
+ActiveExternalStateMachinesComponentBase ::sm6_getState() const {
     return this->m_stateMachine_sm6.state;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Functions for sending signals to external state machines
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Functions for sending signals to external state machines
+// ----------------------------------------------------------------------
 
-  void ActiveExternalStateMachinesComponentBase ::
-    sm1_stateMachineInvoke(
-        const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
-        const Fw::SmSignalBuffer& data
-    )
-  {
-
+void ActiveExternalStateMachinesComponentBase ::sm1_stateMachineInvoke(
+    const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
+    const Fw::SmSignalBuffer& data) {
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 1, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveExternalStateMachinesComponentBase ::
-    sm2_stateMachineInvoke(
-        const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
-        const Fw::SmSignalBuffer& data
-    )
-  {
-
+void ActiveExternalStateMachinesComponentBase ::sm2_stateMachineInvoke(
+    const ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal,
+    const Fw::SmSignalBuffer& data) {
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm2));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 2, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveExternalStateMachinesComponentBase ::
-    sm3_stateMachineInvoke(
-        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-        const Fw::SmSignalBuffer& data
-    )
-  {
-
+void ActiveExternalStateMachinesComponentBase ::sm3_stateMachineInvoke(
+    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+    const Fw::SmSignalBuffer& data) {
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm3));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveExternalStateMachinesComponentBase ::
-    sm4_stateMachineInvoke(
-        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-        const Fw::SmSignalBuffer& data
-    )
-  {
-
+void ActiveExternalStateMachinesComponentBase ::sm4_stateMachineInvoke(
+    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+    const Fw::SmSignalBuffer& data) {
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm4));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 4, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveExternalStateMachinesComponentBase ::
-    sm5_stateMachineInvoke(
-        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-        const Fw::SmSignalBuffer& data
-    )
-  {
-
+void ActiveExternalStateMachinesComponentBase ::sm5_stateMachineInvoke(
+    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+    const Fw::SmSignalBuffer& data) {
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm5));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 0, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->sm5_stateMachineOverflowHook(signal, data);
-      return;
+        this->sm5_stateMachineOverflowHook(signal, data);
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveExternalStateMachinesComponentBase ::
-    sm6_stateMachineInvoke(
-        const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
-        const Fw::SmSignalBuffer& data
-    )
-  {
-
+void ActiveExternalStateMachinesComponentBase ::sm6_stateMachineInvoke(
+    const ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal,
+    const Fw::SmSignalBuffer& data) {
     ComponentIpcSerializableBuffer _msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm6));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = _msg.serializeFrom(data);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(_msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalStateMachinesComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalStateMachinesComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::BLOCKING,
-      _priority
-    );
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == ACTIVEEXTERNALSTATEMACHINES_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
+        // Handle signals to external state machines
+        case EXTERNAL_STATE_MACHINE_SIGNAL: {
+            // Deserialize the state machine ID to an FwEnumStoreType
+            FwEnumStoreType enumStoreSmId = 0;
+            _deserStatus = _msg.deserializeTo(enumStoreSmId);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Cast it to the correct type
+            SmId stateMachineId = static_cast<SmId>(enumStoreSmId);
 
-      // Handle signals to external state machines
-      case EXTERNAL_STATE_MACHINE_SIGNAL: {
+            // Deserialize the state machine signal to an FwEnumStoreType.
+            // This value will be cast to the correct type in the
+            // switch statement that calls the state machine update function.
+            FwEnumStoreType enumStoreSmSignal = 0;
+            _deserStatus = _msg.deserializeTo(enumStoreSmSignal);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Deserialize the state machine ID to an FwEnumStoreType
-        FwEnumStoreType enumStoreSmId = 0;
-        _deserStatus = _msg.deserializeTo(enumStoreSmId);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-        // Cast it to the correct type
-        SmId stateMachineId = static_cast<SmId>(enumStoreSmId);
+            // Deserialize the state machine data
+            Fw::SmSignalBuffer data;
+            _deserStatus = _msg.deserializeTo(data);
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Deserialize the state machine signal to an FwEnumStoreType.
-        // This value will be cast to the correct type in the
-        // switch statement that calls the state machine update function.
-        FwEnumStoreType enumStoreSmSignal = 0;
-        _deserStatus = _msg.deserializeTo(enumStoreSmSignal);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
 
-        // Deserialize the state machine data
-        Fw::SmSignalBuffer data;
-        _deserStatus = _msg.deserializeTo(data);
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Call the state machine update function
+            switch (stateMachineId) {
+                case SmId::sm1: {
+                    ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals
+                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::
+                                                 ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
+                    this->m_stateMachine_sm1.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+                    break;
+                }
 
-        // Make sure there was no data left over.
-        // That means the buffer size was incorrect.
-        FW_ASSERT(
-          _msg.getDeserializeSizeLeft() == 0,
-          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-        );
+                case SmId::sm2: {
+                    ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals
+                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::
+                                                 ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
+                    this->m_stateMachine_sm2.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+                    break;
+                }
 
-        // Call the state machine update function
-        switch (stateMachineId) {
+                case SmId::sm3: {
+                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
+                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
+                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+                    this->m_stateMachine_sm3.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+                    break;
+                }
 
-          case SmId::sm1: {
-            ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal =
-              static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
-            this->m_stateMachine_sm1.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+                case SmId::sm4: {
+                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
+                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
+                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+                    this->m_stateMachine_sm4.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+                    break;
+                }
+
+                case SmId::sm5: {
+                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
+                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
+                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+                    this->m_stateMachine_sm5.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+                    break;
+                }
+
+                case SmId::sm6: {
+                    ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals
+                        signal = static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::
+                                                 ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
+                    this->m_stateMachine_sm6.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
+                    break;
+                }
+
+                default:
+                    return MSG_DISPATCH_ERROR;
+            }
+
             break;
-          }
-
-          case SmId::sm2: {
-            ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals signal =
-              static_cast<ExternalSm::ActiveExternalStateMachines_S1_Interface::ActiveExternalStateMachines_S1_Signals>(enumStoreSmSignal);
-            this->m_stateMachine_sm2.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-            break;
-          }
-
-          case SmId::sm3: {
-            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
-              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-            this->m_stateMachine_sm3.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-            break;
-          }
-
-          case SmId::sm4: {
-            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
-              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-            this->m_stateMachine_sm4.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-            break;
-          }
-
-          case SmId::sm5: {
-            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
-              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-            this->m_stateMachine_sm5.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-            break;
-          }
-
-          case SmId::sm6: {
-            ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals signal =
-              static_cast<ExternalSm::ActiveExternalStateMachines_S2_Interface::ActiveExternalStateMachines_S2_Signals>(enumStoreSmSignal);
-            this->m_stateMachine_sm6.update(static_cast<FwEnumStoreType>(stateMachineId), signal, data);
-            break;
-          }
-
-          default:
-            return MSG_DISPATCH_ERROR;
         }
 
-        break;
-      }
-
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
-
 }
+
+}  // namespace ExternalSm

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
@@ -46,9 +46,8 @@ namespace ExternalSm {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEGETPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,768 +20,1190 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveGetProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+ActiveGetProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-ActiveGetProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const ActiveGetProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+ActiveGetProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const ActiveGetProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const ActiveGetProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const ActiveGetProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                 FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveGetProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts()); port++) {
-        this->m_productGetOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_productGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -790,10 +1212,15 @@ void ActiveGetProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreTyp
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveGetProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveGetProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -804,140 +1231,213 @@ Fw::InputCmdPort* ActiveGetProductsComponentBase ::get_cmdIn_InputPort(FwIndexTy
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveGetProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveGetProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveGetProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveGetProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveGetProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveGetProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveGetProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveGetProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -948,77 +1448,148 @@ Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedSync_InputPort(
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                    Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_productGetOut_OutputPort(FwIndexType portNum, Fw::InputDpGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_productGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_productGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1029,66 +1600,116 @@ void ActiveGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum,
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                     Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                           Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                   Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1099,62 +1720,120 @@ void ActiveGetProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType 
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1165,24 +1844,46 @@ void ActiveGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum,
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1191,10 +1892,18 @@ void ActiveGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNu
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveGetProductsComponentBase ::ActiveGetProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+ActiveGetProductsComponentBase ::
+  ActiveGetProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveGetProductsComponentBase ::~ActiveGetProductsComponentBase() {}
+}
+
+ActiveGetProductsComponentBase ::
+  ~ActiveGetProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1202,76 +1911,118 @@ ActiveGetProductsComponentBase ::~ActiveGetProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGetProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_productGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_productGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productGetOut_OutputPort[portNum].isConnected();
+  return this->m_productGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveGetProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveGetProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1282,59 +2033,92 @@ bool ActiveGetProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType 
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGetProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGetProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1345,19 +2129,24 @@ bool ActiveGetProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIn
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                        FwOpcodeType opCode,
-                                                        U32 cmdSeq,
-                                                        Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveGetProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1366,561 +2155,941 @@ void ActiveGetProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveGetProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGetProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGetProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGetProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveGetProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveGetProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveGetProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveGetProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveGetProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGetProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGetProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveGetProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveGetProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                             AliasPrim1 u32,
-                                                                             AliasPrim2 f32,
-                                                                             AliasBool b,
-                                                                             const Fw::StringBase& str2,
-                                                                             const AliasEnum& e,
-                                                                             const AliasArray& a,
-                                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveGetProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveGetProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                   AliasPrim1 u32,
-                                                                                   AliasPrim2 f32,
-                                                                                   AliasBool b,
-                                                                                   const Fw::StringBase& str2,
-                                                                                   const AliasEnum& e,
-                                                                                   const AliasArray& a,
-                                                                                   const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGetProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGetProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGetProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGetProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGetProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGetProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveGetProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveGetProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveGetProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveGetProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGetProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1931,63 +3100,85 @@ void ActiveGetProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    // Default: no-op
+void ActiveGetProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveGetProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Default: no-op
+void ActiveGetProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Default: no-op
+void ActiveGetProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    // Default: no-op
+void ActiveGetProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    // Default: no-op
+void ActiveGetProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1996,103 +3187,209 @@ void ActiveGetProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexT
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveGetProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveGetProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveGetProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGetProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveGetProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveGetProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveGetProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveGetProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                          AliasPrim1 u32,
-                                                                          AliasPrim2 f32,
-                                                                          AliasBool b,
-                                                                          const Fw::StringBase& str2,
-                                                                          const AliasEnum& e,
-                                                                          const AliasArray& a,
-                                                                          const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGetProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGetProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveGetProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str2,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveGetProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2101,39 +3398,47 @@ F32 ActiveGetProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void ActiveGetProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveGetProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveGetProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2143,506 +3448,868 @@ Fw::Time ActiveGetProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveGetProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveGetProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveGetProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEGETPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEGETPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveGetProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveGetProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGetProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveGetProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveGetProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGetProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveGetProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGetProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveGetProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveGetProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGetProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveGetProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveGetProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveGetProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveGetProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                              FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveGetProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGetProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGetProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGetProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGetProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                    FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGetProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveGetProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveGetProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveGetProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveGetProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGetProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGetProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2651,33 +4318,70 @@ void ActiveGetProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase*
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-Fw::Success ActiveGetProductsComponentBase ::productGetOut_out(FwIndexType portNum,
-                                                               FwDpIdType id,
-                                                               FwSizeType dataSize,
-                                                               Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::Success ActiveGetProductsComponentBase ::
+  productGetOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize,
+      Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_productGetOut_OutputPort[portNum].invoke(id, dataSize, buffer);
+  FW_ASSERT(
+    this->m_productGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_productGetOut_OutputPort[portNum].invoke(
+    id,
+    dataSize,
+    buffer
+  );
 }
 
-void ActiveGetProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                         FwDpIdType id,
-                                                         const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void ActiveGetProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGetProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2686,20 +4390,24 @@ void ActiveGetProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Ti
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-Fw::Success::T ActiveGetProductsComponentBase ::dpGet(ContainerId::T containerId,
-                                                      FwSizeType dataSize,
-                                                      FwDpPriorityType priority,
-                                                      DpContainer& container) {
-    const FwDpIdType baseId = this->getIdBase();
-    const FwDpIdType globalId = baseId + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    Fw::Buffer buffer;
-    const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
-    if (status == Fw::Success::SUCCESS) {
-        // Assign a fresh DpContainer into container
-        // This action clears out all the container state
-        container = DpContainer(globalId, buffer, baseId);
-        container.setPriority(priority);
-    }
-    return status;
+Fw::Success::T ActiveGetProductsComponentBase ::
+  dpGet(
+      ContainerId::T containerId,
+      FwSizeType dataSize,
+      FwDpPriorityType priority,
+      DpContainer& container
+  )
+{
+  const FwDpIdType baseId = this->getIdBase();
+  const FwDpIdType globalId = baseId + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  Fw::Buffer buffer;
+  const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
+  if (status == Fw::Success::SUCCESS) {
+    // Assign a fresh DpContainer into container
+    // This action clears out all the container state
+    container = DpContainer(globalId, buffer, baseId);
+    container.setPriority(priority);
+  }
+  return status;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEGETPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,1197 +20,768 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveGetProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+ActiveGetProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+ActiveGetProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-ActiveGetProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const ActiveGetProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const ActiveGetProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const ActiveGetProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const ActiveGetProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                 FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveGetProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_productGetOut_OutputPort[port].init();
+    // Connect output port productGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts()); port++) {
+        this->m_productGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1219,15 +790,10 @@ void ActiveGetProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveGetProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveGetProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -1238,213 +804,140 @@ Fw::InputCmdPort* ActiveGetProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveGetProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveGetProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveGetProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveGetProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveGetProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveGetProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveGetProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveGetProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveGetProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveGetProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveGetProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveGetProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGetProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGetProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1455,148 +948,77 @@ Ports::InputTypedPort* ActiveGetProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                    Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_productGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_productGetOut_OutputPort(FwIndexType portNum, Fw::InputDpGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_productGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGetProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveGetProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1607,116 +1029,66 @@ void ActiveGetProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                     Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                           Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                   Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1727,120 +1099,62 @@ void ActiveGetProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGetProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveGetProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1851,46 +1165,24 @@ void ActiveGetProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGetProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1899,18 +1191,10 @@ void ActiveGetProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveGetProductsComponentBase ::
-  ActiveGetProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveGetProductsComponentBase ::ActiveGetProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveGetProductsComponentBase ::
-  ~ActiveGetProductsComponentBase()
-{
-
-}
+ActiveGetProductsComponentBase ::~ActiveGetProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1918,118 +1202,76 @@ ActiveGetProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_productGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_productGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productGetOut_OutputPort[portNum].isConnected();
+    return this->m_productGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2040,92 +1282,59 @@ bool ActiveGetProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGetProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGetProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2136,24 +1345,19 @@ bool ActiveGetProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveGetProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                        FwOpcodeType opCode,
+                                                        U32 cmdSeq,
+                                                        Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -2162,941 +1366,561 @@ void ActiveGetProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGetProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGetProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGetProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveGetProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveGetProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveGetProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveGetProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGetProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGetProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveGetProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveGetProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                             AliasPrim1 u32,
+                                                                             AliasPrim2 f32,
+                                                                             AliasBool b,
+                                                                             const Fw::StringBase& str2,
+                                                                             const AliasEnum& e,
+                                                                             const AliasArray& a,
+                                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGetProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                   AliasPrim1 u32,
+                                                                                   AliasPrim2 f32,
+                                                                                   AliasBool b,
+                                                                                   const Fw::StringBase& str2,
+                                                                                   const AliasEnum& e,
+                                                                                   const AliasArray& a,
+                                                                                   const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGetProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveGetProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveGetProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveGetProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveGetProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGetProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3107,85 +1931,63 @@ void ActiveGetProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveGetProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveGetProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGetProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGetProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGetProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    // Default: no-op
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGetProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3194,209 +1996,103 @@ void ActiveGetProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveGetProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveGetProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGetProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveGetProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveGetProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveGetProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGetProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                          AliasPrim1 u32,
+                                                                          AliasPrim2 f32,
+                                                                          AliasBool b,
+                                                                          const Fw::StringBase& str2,
+                                                                          const AliasEnum& e,
+                                                                          const AliasArray& a,
+                                                                          const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveGetProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveGetProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveGetProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str2,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3405,47 +2101,39 @@ F32 ActiveGetProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void ActiveGetProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveGetProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveGetProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3455,868 +2143,506 @@ Fw::Time ActiveGetProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveGetProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveGetProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveGetProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEGETPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVEGETPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveGetProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveGetProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGetProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveGetProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveGetProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGetProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveGetProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGetProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveGetProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGetProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveGetProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveGetProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveGetProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveGetProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveGetProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                              FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                    FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveGetProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveGetProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveGetProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveGetProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveGetProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGetProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4325,70 +2651,33 @@ void ActiveGetProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-Fw::Success ActiveGetProductsComponentBase ::
-  productGetOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize,
-      Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::Success ActiveGetProductsComponentBase ::productGetOut_out(FwIndexType portNum,
+                                                               FwDpIdType id,
+                                                               FwSizeType dataSize,
+                                                               Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_productGetOut_OutputPort[portNum].invoke(
-    id,
-    dataSize,
-    buffer
-  );
+    FW_ASSERT(this->m_productGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_productGetOut_OutputPort[portNum].invoke(id, dataSize, buffer);
 }
 
-void ActiveGetProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                         FwDpIdType id,
+                                                         const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void ActiveGetProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGetProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4397,24 +2686,20 @@ void ActiveGetProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-Fw::Success::T ActiveGetProductsComponentBase ::
-  dpGet(
-      ContainerId::T containerId,
-      FwSizeType dataSize,
-      FwDpPriorityType priority,
-      DpContainer& container
-  )
-{
-  const FwDpIdType baseId = this->getIdBase();
-  const FwDpIdType globalId = baseId + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  Fw::Buffer buffer;
-  const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
-  if (status == Fw::Success::SUCCESS) {
-    // Assign a fresh DpContainer into container
-    // This action clears out all the container state
-    container = DpContainer(globalId, buffer, baseId);
-    container.setPriority(priority);
-  }
-  return status;
+Fw::Success::T ActiveGetProductsComponentBase ::dpGet(ContainerId::T containerId,
+                                                      FwSizeType dataSize,
+                                                      FwDpPriorityType priority,
+                                                      DpContainer& container) {
+    const FwDpIdType baseId = this->getIdBase();
+    const FwDpIdType globalId = baseId + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    Fw::Buffer buffer;
+    const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
+    if (status == Fw::Success::SUCCESS) {
+        // Assign a fresh DpContainer into container
+        // This action clears out all the container state
+        container = DpContainer(globalId, buffer, baseId);
+        container.setPriority(priority);
+    }
+    return status;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEGUARDEDPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,785 +20,1216 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveGuardedProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id,
-                                                              const Fw::Buffer& buffer,
-                                                              FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+ActiveGuardedProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-ActiveGuardedProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const ActiveGuardedProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+ActiveGuardedProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const ActiveGuardedProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const ActiveGuardedProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const ActiveGuardedProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                     FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveGuardedProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -807,17 +1238,26 @@ void ActiveGuardedProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStor
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveGuardedProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveGuardedProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveGuardedProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* ActiveGuardedProductsComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -828,142 +1268,213 @@ Fw::InputDpResponsePort* ActiveGuardedProductsComponentBase ::get_productRecvIn_
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveGuardedProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveGuardedProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveGuardedProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveGuardedProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveGuardedProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveGuardedProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::get_typedReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -974,79 +1485,148 @@ Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedSync_InputP
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                           Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1057,67 +1637,116 @@ void ActiveGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType port
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                             Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1128,73 +1757,134 @@ void ActiveGuardedProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexT
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                           Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1205,25 +1895,46 @@ void ActiveGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType port
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                       Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1232,10 +1943,18 @@ void ActiveGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType po
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveGuardedProductsComponentBase ::ActiveGuardedProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+ActiveGuardedProductsComponentBase ::
+  ActiveGuardedProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveGuardedProductsComponentBase ::~ActiveGuardedProductsComponentBase() {}
+}
+
+ActiveGuardedProductsComponentBase ::
+  ~ActiveGuardedProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1243,76 +1962,118 @@ ActiveGuardedProductsComponentBase ::~ActiveGuardedProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGuardedProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveGuardedProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveGuardedProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1323,59 +2084,92 @@ bool ActiveGuardedProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexT
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGuardedProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveGuardedProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1386,37 +2180,53 @@ bool ActiveGuardedProductsComponentBase ::isConnected_typedReturnOut_OutputPort(
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                            FwOpcodeType opCode,
-                                                            U32 cmdSeq,
-                                                            Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveGuardedProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void ActiveGuardedProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                    FwDpIdType id,
-                                                                    const Fw::Buffer& buffer,
-                                                                    const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->productRecvIn_handler(portNum, id, buffer, status);
+  // Call handler function
+  this->productRecvIn_handler(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
 // ----------------------------------------------------------------------
@@ -1425,561 +2235,941 @@ void ActiveGuardedProductsComponentBase ::productRecvIn_handlerBase(FwIndexType 
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGuardedProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveGuardedProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveGuardedProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveGuardedProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveGuardedProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGuardedProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveGuardedProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                                 AliasPrim1 u32,
-                                                                                 AliasPrim2 f32,
-                                                                                 AliasBool b,
-                                                                                 const Fw::StringBase& str2,
-                                                                                 const AliasEnum& e,
-                                                                                 const AliasArray& a,
-                                                                                 const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveGuardedProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                       AliasPrim1 u32,
-                                                                                       AliasPrim2 f32,
-                                                                                       AliasBool b,
-                                                                                       const Fw::StringBase& str2,
-                                                                                       const AliasEnum& e,
-                                                                                       const AliasArray& a,
-                                                                                       const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGuardedProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                              U32 u32,
-                                                                              F32 f32,
-                                                                              bool b,
-                                                                              const Fw::StringBase& str1,
-                                                                              const E& e,
-                                                                              const A& a,
-                                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                             U32 u32,
-                                                                             F32 f32,
-                                                                             bool b,
-                                                                             const Fw::StringBase& str1,
-                                                                             const E& e,
-                                                                             const A& a,
-                                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveGuardedProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveGuardedProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveGuardedProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveGuardedProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1990,63 +3180,85 @@ void ActiveGuardedProductsComponentBase ::typedSync_handlerBase(FwIndexType port
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    // Default: no-op
+void ActiveGuardedProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveGuardedProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Default: no-op
+void ActiveGuardedProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Default: no-op
+void ActiveGuardedProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                             U32 u32,
-                                                                             F32 f32,
-                                                                             bool b,
-                                                                             const Fw::StringBase& str1,
-                                                                             const E& e,
-                                                                             const A& a,
-                                                                             const S& s) {
-    // Default: no-op
+void ActiveGuardedProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Default: no-op
+void ActiveGuardedProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2055,103 +3267,209 @@ void ActiveGuardedProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIn
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveGuardedProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveGuardedProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGuardedProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveGuardedProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveGuardedProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveGuardedProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveGuardedProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveGuardedProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveGuardedProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2160,39 +3478,47 @@ F32 ActiveGuardedProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void ActiveGuardedProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveGuardedProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveGuardedProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2202,518 +3528,887 @@ Fw::Time ActiveGuardedProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveGuardedProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveGuardedProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveGuardedProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEGUARDEDPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEGUARDEDPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       FwOpcodeType opCode,
-                                                       U32 cmdSeq,
-                                                       Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveGuardedProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               FwDpIdType id,
-                                                               const Fw::Buffer& buffer,
-                                                               const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void ActiveGuardedProductsComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                   FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGuardedProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveGuardedProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveGuardedProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGuardedProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                    FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveGuardedProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGuardedProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveGuardedProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                              FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGuardedProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveGuardedProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveGuardedProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveGuardedProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                  FwIndexType portNum,
-                                                                                  AliasPrim1 u32,
-                                                                                  AliasPrim2 f32,
-                                                                                  AliasBool b,
-                                                                                  const Fw::StringBase& str2,
-                                                                                  const AliasEnum& e,
-                                                                                  const AliasArray& a,
-                                                                                  const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveGuardedProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveGuardedProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveGuardedProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveGuardedProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str2,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveGuardedProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveGuardedProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2722,32 +4417,68 @@ void ActiveGuardedProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentB
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
-                                                                FwDpIdType id,
-                                                                FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  productRequestOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+  FW_ASSERT(
+    this->m_productRequestOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productRequestOut_OutputPort[portNum].invoke(
+    id,
+    dataSize
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void ActiveGuardedProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveGuardedProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2756,58 +4487,71 @@ void ActiveGuardedProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
-    const FwDpIdType globalId = this->getIdBase() + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    this->productRequestOut_out(0, globalId, size);
+void ActiveGuardedProductsComponentBase ::
+  dpRequest(
+      ContainerId::T containerId,
+      FwSizeType dataSize
+  )
+{
+  const FwDpIdType globalId = this->getIdBase() + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  this->productRequestOut_out(0, globalId, size);
 }
 
-void ActiveGuardedProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                                FwDpIdType id,
-                                                                const Fw::Buffer& buffer,
-                                                                const Fw::Success& status) {
-    DpContainer container;
-    if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
-    }
-    // Convert global id to local id
-    const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
-    const FwDpIdType localId = id - idBase;
-    // Switch on the local id
-    switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
-    }
+void ActiveGuardedProductsComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  DpContainer container;
+  if (status == Fw::Success::SUCCESS) {
+    container = DpContainer(id, buffer, this->getIdBase());
+  }
+  // Convert global id to local id
+  const FwDpIdType idBase = this->getIdBase();
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
+  const FwDpIdType localId = id - idBase;
+  // Switch on the local id
+  switch (localId) {
+    case ContainerId::Container1:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container1);
+      // Call the handler
+      this->dpRecv_Container1_handler(container, status.e);
+      break;
+    case ContainerId::Container2:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container2);
+      // Call the handler
+      this->dpRecv_Container2_handler(container, status.e);
+      break;
+    case ContainerId::Container3:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container3);
+      // Call the handler
+      this->dpRecv_Container3_handler(container, status.e);
+      break;
+    case ContainerId::Container4:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container4);
+      // Call the handler
+      this->dpRecv_Container4_handler(container, status.e);
+      break;
+    case ContainerId::Container5:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container5);
+      // Call the handler
+      this->dpRecv_Container5_handler(container, status.e);
+      break;
+    default:
+      FW_ASSERT(0);
+      break;
+  }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEGUARDEDPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,1223 +20,785 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveGuardedProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+ActiveGuardedProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id,
+                                                              const Fw::Buffer& buffer,
+                                                              FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+ActiveGuardedProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-ActiveGuardedProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const ActiveGuardedProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const ActiveGuardedProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const ActiveGuardedProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const ActiveGuardedProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                     FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveGuardedProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1245,26 +807,17 @@ void ActiveGuardedProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveGuardedProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveGuardedProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveGuardedProductsComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* ActiveGuardedProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -1275,213 +828,142 @@ Fw::InputDpResponsePort* ActiveGuardedProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveGuardedProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveGuardedProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveGuardedProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveGuardedProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveGuardedProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveGuardedProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveGuardedProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveGuardedProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveGuardedProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::get_typedReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveGuardedProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1492,148 +974,79 @@ Ports::InputTypedPort* ActiveGuardedProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                           Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGuardedProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveGuardedProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1644,116 +1057,67 @@ void ActiveGuardedProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                             Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1764,134 +1128,73 @@ void ActiveGuardedProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                           Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveGuardedProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveGuardedProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1902,46 +1205,25 @@ void ActiveGuardedProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                       Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1950,18 +1232,10 @@ void ActiveGuardedProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveGuardedProductsComponentBase ::
-  ActiveGuardedProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveGuardedProductsComponentBase ::ActiveGuardedProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveGuardedProductsComponentBase ::
-  ~ActiveGuardedProductsComponentBase()
-{
-
-}
+ActiveGuardedProductsComponentBase ::~ActiveGuardedProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1969,118 +1243,76 @@ ActiveGuardedProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2091,92 +1323,59 @@ bool ActiveGuardedProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveGuardedProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveGuardedProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2187,53 +1386,37 @@ bool ActiveGuardedProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveGuardedProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                            FwOpcodeType opCode,
+                                                            U32 cmdSeq,
+                                                            Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
-void ActiveGuardedProductsComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                    FwDpIdType id,
+                                                                    const Fw::Buffer& buffer,
+                                                                    const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->productRecvIn_handler(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+    // Call handler function
+    this->productRecvIn_handler(portNum, id, buffer, status);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
 // ----------------------------------------------------------------------
@@ -2242,941 +1425,561 @@ void ActiveGuardedProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGuardedProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGuardedProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveGuardedProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveGuardedProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveGuardedProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveGuardedProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGuardedProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveGuardedProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveGuardedProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                                 AliasPrim1 u32,
+                                                                                 AliasPrim2 f32,
+                                                                                 AliasBool b,
+                                                                                 const Fw::StringBase& str2,
+                                                                                 const AliasEnum& e,
+                                                                                 const AliasArray& a,
+                                                                                 const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGuardedProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                       AliasPrim1 u32,
+                                                                                       AliasPrim2 f32,
+                                                                                       AliasBool b,
+                                                                                       const Fw::StringBase& str2,
+                                                                                       const AliasEnum& e,
+                                                                                       const AliasArray& a,
+                                                                                       const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                              U32 u32,
+                                                                              F32 f32,
+                                                                              bool b,
+                                                                              const Fw::StringBase& str1,
+                                                                              const E& e,
+                                                                              const A& a,
+                                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                             U32 u32,
+                                                                             F32 f32,
+                                                                             bool b,
+                                                                             const Fw::StringBase& str1,
+                                                                             const E& e,
+                                                                             const A& a,
+                                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveGuardedProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveGuardedProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveGuardedProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveGuardedProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3187,85 +1990,63 @@ void ActiveGuardedProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveGuardedProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveGuardedProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGuardedProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGuardedProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGuardedProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                             U32 u32,
+                                                                             F32 f32,
+                                                                             bool b,
+                                                                             const Fw::StringBase& str1,
+                                                                             const E& e,
+                                                                             const A& a,
+                                                                             const S& s) {
+    // Default: no-op
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveGuardedProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3274,209 +2055,103 @@ void ActiveGuardedProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveGuardedProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveGuardedProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGuardedProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveGuardedProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveGuardedProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveGuardedProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveGuardedProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveGuardedProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3485,47 +2160,39 @@ F32 ActiveGuardedProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void ActiveGuardedProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveGuardedProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveGuardedProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3535,887 +2202,518 @@ Fw::Time ActiveGuardedProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveGuardedProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveGuardedProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveGuardedProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEGUARDEDPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVEGUARDEDPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveGuardedProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       FwOpcodeType opCode,
+                                                       U32 cmdSeq,
+                                                       Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void ActiveGuardedProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               FwDpIdType id,
+                                                               const Fw::Buffer& buffer,
+                                                               const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGuardedProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                   FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveGuardedProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveGuardedProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGuardedProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveGuardedProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                    FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveGuardedProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveGuardedProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveGuardedProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                              FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveGuardedProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveGuardedProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveGuardedProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveGuardedProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveGuardedProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                  FwIndexType portNum,
+                                                                                  AliasPrim1 u32,
+                                                                                  AliasPrim2 f32,
+                                                                                  AliasBool b,
+                                                                                  const Fw::StringBase& str2,
+                                                                                  const AliasEnum& e,
+                                                                                  const AliasArray& a,
+                                                                                  const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveGuardedProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveGuardedProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveGuardedProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveGuardedProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str2,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveGuardedProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4424,68 +2722,32 @@ void ActiveGuardedProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  productRequestOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
+                                                                FwDpIdType id,
+                                                                FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productRequestOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productRequestOut_OutputPort[portNum].invoke(
-    id,
-    dataSize
-  );
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveGuardedProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4494,71 +2756,58 @@ void ActiveGuardedProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveGuardedProductsComponentBase ::
-  dpRequest(
-      ContainerId::T containerId,
-      FwSizeType dataSize
-  )
-{
-  const FwDpIdType globalId = this->getIdBase() + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  this->productRequestOut_out(0, globalId, size);
+void ActiveGuardedProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+    const FwDpIdType globalId = this->getIdBase() + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    this->productRequestOut_out(0, globalId, size);
 }
 
-void ActiveGuardedProductsComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  DpContainer container;
-  if (status == Fw::Success::SUCCESS) {
-    container = DpContainer(id, buffer, this->getIdBase());
-  }
-  // Convert global id to local id
-  const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(
-    id >= idBase,
-    static_cast<FwAssertArgType>(id),
-    static_cast<FwAssertArgType>(idBase)
-  );
-  const FwDpIdType localId = id - idBase;
-  // Switch on the local id
-  switch (localId) {
-    case ContainerId::Container1:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container1);
-      // Call the handler
-      this->dpRecv_Container1_handler(container, status.e);
-      break;
-    case ContainerId::Container2:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container2);
-      // Call the handler
-      this->dpRecv_Container2_handler(container, status.e);
-      break;
-    case ContainerId::Container3:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container3);
-      // Call the handler
-      this->dpRecv_Container3_handler(container, status.e);
-      break;
-    case ContainerId::Container4:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container4);
-      // Call the handler
-      this->dpRecv_Container4_handler(container, status.e);
-      break;
-    case ContainerId::Container5:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container5);
-      // Call the handler
-      this->dpRecv_Container5_handler(container, status.e);
-      break;
-    default:
-      FW_ASSERT(0);
-      break;
-  }
+void ActiveGuardedProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                                FwDpIdType id,
+                                                                const Fw::Buffer& buffer,
+                                                                const Fw::Success& status) {
+    DpContainer container;
+    if (status == Fw::Success::SUCCESS) {
+        container = DpContainer(id, buffer, this->getIdBase());
+    }
+    // Convert global id to local id
+    const FwDpIdType idBase = this->getIdBase();
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    const FwDpIdType localId = id - idBase;
+    // Switch on the local id
+    switch (localId) {
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
+    }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -12,133 +12,208 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVENOARGSPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     NOARGSASYNC_NOARGS,
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = 0,
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveNoArgsPortsOnlyComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -147,33 +222,48 @@ void ActiveNoArgsPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStor
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
 #endif
@@ -184,19 +274,32 @@ Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsRet
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveNoArgsPortsOnlyComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveNoArgsPortsOnlyComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -207,11 +310,18 @@ void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsReturnOut_OutputPort(FwIndex
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveNoArgsPortsOnlyComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -220,10 +330,18 @@ void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType p
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveNoArgsPortsOnlyComponentBase ::ActiveNoArgsPortsOnlyComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+ActiveNoArgsPortsOnlyComponentBase ::
+  ActiveNoArgsPortsOnlyComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveNoArgsPortsOnlyComponentBase ::~ActiveNoArgsPortsOnlyComponentBase() {}
+}
+
+ActiveNoArgsPortsOnlyComponentBase ::
+  ~ActiveNoArgsPortsOnlyComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -231,18 +349,26 @@ ActiveNoArgsPortsOnlyComponentBase ::~ActiveNoArgsPortsOnlyComponentBase() {}
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveNoArgsPortsOnlyComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveNoArgsPortsOnlyComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveNoArgsPortsOnlyComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveNoArgsPortsOnlyComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -253,76 +379,103 @@ bool ActiveNoArgsPortsOnlyComponentBase ::isConnected_noArgsReturnOut_OutputPort
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveNoArgsPortsOnlyComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveNoArgsPortsOnlyComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveNoArgsPortsOnlyComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveNoArgsPortsOnlyComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
 // ----------------------------------------------------------------------
@@ -333,8 +486,10 @@ U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnSync_handlerBase(FwIndexTyp
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveNoArgsPortsOnlyComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -343,20 +498,34 @@ void ActiveNoArgsPortsOnlyComponentBase ::noArgsAsync_preMsgHook(FwIndexType por
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveNoArgsPortsOnlyComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveNoArgsPortsOnlyComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
 #endif
@@ -368,85 +537,121 @@ U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnOut_out(FwIndexType portNum
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveNoArgsPortsOnlyComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveNoArgsPortsOnlyComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveNoArgsPortsOnlyComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveNoArgsPortsOnlyComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVENOARGSPORTSONLY_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVENOARGSPORTSONLY_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
 
-    switch (_msgType) {
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
-    }
-
-    return MSG_DISPATCH_OK;
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                    FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -12,215 +12,133 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVENOARGSPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     NOARGSASYNC_NOARGS,
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = 0,
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveNoArgsPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -229,48 +147,33 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
 #endif
@@ -281,32 +184,19 @@ Ports::InputNoArgsReturnPort* ActiveNoArgsPortsOnlyComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -317,18 +207,11 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -337,18 +220,10 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveNoArgsPortsOnlyComponentBase ::
-  ActiveNoArgsPortsOnlyComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveNoArgsPortsOnlyComponentBase ::ActiveNoArgsPortsOnlyComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveNoArgsPortsOnlyComponentBase ::
-  ~ActiveNoArgsPortsOnlyComponentBase()
-{
-
-}
+ActiveNoArgsPortsOnlyComponentBase ::~ActiveNoArgsPortsOnlyComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -356,26 +231,18 @@ ActiveNoArgsPortsOnlyComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveNoArgsPortsOnlyComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveNoArgsPortsOnlyComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveNoArgsPortsOnlyComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveNoArgsPortsOnlyComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -386,103 +253,76 @@ bool ActiveNoArgsPortsOnlyComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveNoArgsPortsOnlyComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveNoArgsPortsOnlyComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
 // ----------------------------------------------------------------------
@@ -493,10 +333,8 @@ U32 ActiveNoArgsPortsOnlyComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveNoArgsPortsOnlyComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -505,34 +343,20 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveNoArgsPortsOnlyComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveNoArgsPortsOnlyComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
 #endif
@@ -544,121 +368,85 @@ U32 ActiveNoArgsPortsOnlyComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveNoArgsPortsOnlyComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveNoArgsPortsOnlyComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveNoArgsPortsOnlyComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveNoArgsPortsOnlyComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVENOARGSPORTSONLY_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
-
-      break;
+    if (_msgType == ACTIVENOARGSPORTSONLY_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  return MSG_DISPATCH_OK;
+    switch (_msgType) {
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
+    }
+
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                    FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -34,9 +34,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEOVERFLOW_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVINHOOK_DPRESPONSE,
     ASSERTASYNC_TYPED,
@@ -23,433 +23,268 @@ namespace {
     CMD_CMD_HOOK,
     CMD_CMD_PARAMS_PRIORITY_HOOK,
     INT_IF_INTERNALHOOKDROP,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE productRecvInHookPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE assertAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE blockAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE dropAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE hookAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwSizeType msgSize,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveOverflowComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvInHook
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts());
-    port++
-  ) {
-    this->m_productRecvInHook_InputPort[port].init();
-    this->m_productRecvInHook_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvInHook_in
-    );
-    this->m_productRecvInHook_InputPort[port].setPortNum(port);
+    // Connect input port productRecvInHook
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts()); port++) {
+        this->m_productRecvInHook_InputPort[port].init();
+        this->m_productRecvInHook_InputPort[port].addCallComp(this, m_p_productRecvInHook_in);
+        this->m_productRecvInHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port assertAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts());
-    port++
-  ) {
-    this->m_assertAsync_InputPort[port].init();
-    this->m_assertAsync_InputPort[port].addCallComp(
-      this,
-      m_p_assertAsync_in
-    );
-    this->m_assertAsync_InputPort[port].setPortNum(port);
+    // Connect input port assertAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts()); port++) {
+        this->m_assertAsync_InputPort[port].init();
+        this->m_assertAsync_InputPort[port].addCallComp(this, m_p_assertAsync_in);
+        this->m_assertAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_assertAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_assertAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port blockAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts());
-    port++
-  ) {
-    this->m_blockAsync_InputPort[port].init();
-    this->m_blockAsync_InputPort[port].addCallComp(
-      this,
-      m_p_blockAsync_in
-    );
-    this->m_blockAsync_InputPort[port].setPortNum(port);
+    // Connect input port blockAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts()); port++) {
+        this->m_blockAsync_InputPort[port].init();
+        this->m_blockAsync_InputPort[port].addCallComp(this, m_p_blockAsync_in);
+        this->m_blockAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_blockAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_blockAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port dropAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts());
-    port++
-  ) {
-    this->m_dropAsync_InputPort[port].init();
-    this->m_dropAsync_InputPort[port].addCallComp(
-      this,
-      m_p_dropAsync_in
-    );
-    this->m_dropAsync_InputPort[port].setPortNum(port);
+    // Connect input port dropAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts()); port++) {
+        this->m_dropAsync_InputPort[port].init();
+        this->m_dropAsync_InputPort[port].addCallComp(this, m_p_dropAsync_in);
+        this->m_dropAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_dropAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_dropAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port hookAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts());
-    port++
-  ) {
-    this->m_hookAsync_InputPort[port].init();
-    this->m_hookAsync_InputPort[port].addCallComp(
-      this,
-      m_p_hookAsync_in
-    );
-    this->m_hookAsync_InputPort[port].setPortNum(port);
+    // Connect input port hookAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts()); port++) {
+        this->m_hookAsync_InputPort[port].init();
+        this->m_hookAsync_InputPort[port].addCallComp(this, m_p_hookAsync_in);
+        this->m_hookAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_hookAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_hookAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncHook
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncHook_InputPort[port].init();
-    this->m_serialAsyncHook_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncHook_in
-    );
-    this->m_serialAsyncHook_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncHook
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts()); port++) {
+        this->m_serialAsyncHook_InputPort[port].init();
+        this->m_serialAsyncHook_InputPort[port].addCallComp(this, m_p_serialAsyncHook_in);
+        this->m_serialAsyncHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Passed-in size added to port number and message type enumeration sizes.
-  this->m_msgSize = FW_MAX(
-    msgSize +
-    static_cast<FwSizeType>(sizeof(FwIndexType)) +
-    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
+    // Passed-in size added to port number and message type enumeration sizes.
+    this->m_msgSize = FW_MAX(
+        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -458,26 +293,17 @@ void ActiveOverflowComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveOverflowComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveOverflowComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveOverflowComponentBase ::
-  get_productRecvInHook_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* ActiveOverflowComponentBase ::get_productRecvInHook_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvInHook_InputPort[portNum];
+    return &this->m_productRecvInHook_InputPort[portNum];
 }
 
 #endif
@@ -488,48 +314,30 @@ Fw::InputDpResponsePort* ActiveOverflowComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::
-  get_assertAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveOverflowComponentBase ::get_assertAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_assertAsync_InputPort[portNum];
+    return &this->m_assertAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::
-  get_blockAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveOverflowComponentBase ::get_blockAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_blockAsync_InputPort[portNum];
+    return &this->m_blockAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::
-  get_dropAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveOverflowComponentBase ::get_dropAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_dropAsync_InputPort[portNum];
+    return &this->m_dropAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::
-  get_hookAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveOverflowComponentBase ::get_hookAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_hookAsync_InputPort[portNum];
+    return &this->m_hookAsync_InputPort[portNum];
 }
 
 #endif
@@ -540,15 +348,11 @@ Ports::InputTypedPort* ActiveOverflowComponentBase ::
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* ActiveOverflowComponentBase ::
-  get_serialAsyncHook_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* ActiveOverflowComponentBase ::get_serialAsyncHook_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncHook_InputPort[portNum];
+    return &this->m_serialAsyncHook_InputPort[portNum];
 }
 
 #endif
@@ -559,120 +363,62 @@ Fw::InputSerializePort* ActiveOverflowComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveOverflowComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveOverflowComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -683,106 +429,55 @@ void ActiveOverflowComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveOverflowComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveOverflowComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -791,38 +486,21 @@ void ActiveOverflowComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveOverflowComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_HOOK
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_HOOK);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK);
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveOverflowComponentBase ::
-  ActiveOverflowComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveOverflowComponentBase ::ActiveOverflowComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveOverflowComponentBase ::
-  ~ActiveOverflowComponentBase()
-{
-
-}
+ActiveOverflowComponentBase ::~ActiveOverflowComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -830,96 +508,62 @@ ActiveOverflowComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveOverflowComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveOverflowComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveOverflowComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveOverflowComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -930,117 +574,73 @@ bool ActiveOverflowComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveOverflowComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                     FwOpcodeType opCode,
+                                                     U32 cmdSeq,
+                                                     Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_CMD_HOOK: {
+            this->CMD_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_CMD_HOOK: {
-      this->CMD_HOOK_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
+        case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
+            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
-      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
-void ActiveOverflowComponentBase ::
-  productRecvInHook_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::productRecvInHook_handlerBase(FwIndexType portNum,
+                                                                 FwDpIdType id,
+                                                                 const Fw::Buffer& buffer,
+                                                                 const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  productRecvInHook_preMsgHook(
-    portNum,
-    id,
-    buffer,
-    status
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    productRecvInHook_preMsgHook(portNum, id, buffer, status);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument id
-  _status = msg.serializeFrom(id);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument id
+    _status = msg.serializeFrom(id);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msg.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msg.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument status
-  _status = msg.serializeFrom(status);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument status
+    _status = msg.serializeFrom(status);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->productRecvInHook_overflowHook(portNum, id, buffer, status);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->productRecvInHook_overflowHook(portNum, id, buffer, status);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1049,442 +649,252 @@ void ActiveOverflowComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  assertAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::assertAsync_handlerBase(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  assertAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    assertAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveOverflowComponentBase ::
-  blockAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::blockAsync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  blockAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    blockAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveOverflowComponentBase ::
-  dropAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::dropAsync_handlerBase(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  dropAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    dropAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(DROPASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(DROPASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveOverflowComponentBase ::
-  hookAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::hookAsync_handlerBase(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  hookAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    hookAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(HOOKASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(HOOKASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1493,62 +903,38 @@ void ActiveOverflowComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  serialAsyncHook_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::serialAsyncHook_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncHook
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncHook
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->serialAsyncHook_overflowHook(portNum, buffer);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->serialAsyncHook_overflowHook(portNum, buffer);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1559,15 +945,11 @@ void ActiveOverflowComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  productRecvInHook_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
+void ActiveOverflowComponentBase ::productRecvInHook_preMsgHook(FwIndexType portNum,
+                                                                FwDpIdType id,
+                                                                const Fw::Buffer& buffer,
+                                                                const Fw::Success& status) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1578,64 +960,48 @@ void ActiveOverflowComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  assertAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveOverflowComponentBase ::assertAsync_preMsgHook(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Default: no-op
 }
 
-void ActiveOverflowComponentBase ::
-  blockAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveOverflowComponentBase ::blockAsync_preMsgHook(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Default: no-op
 }
 
-void ActiveOverflowComponentBase ::
-  dropAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveOverflowComponentBase ::dropAsync_preMsgHook(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Default: no-op
 }
 
-void ActiveOverflowComponentBase ::
-  hookAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveOverflowComponentBase ::hookAsync_preMsgHook(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1646,13 +1012,8 @@ void ActiveOverflowComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  serialAsyncHook_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void ActiveOverflowComponentBase ::serialAsyncHook_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1667,54 +1028,37 @@ void ActiveOverflowComponentBase ::
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  internalHookDrop_internalInterfaceInvoke()
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveOverflowComponentBase ::internalHookDrop_internalInterfaceInvoke() {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->internalHookDrop_overflowHook();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->internalHookDrop_overflowHook();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveOverflowComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -1723,132 +1067,86 @@ void ActiveOverflowComponentBase ::
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  CMD_HOOK_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_HOOK_preMsgHook(opCode,cmdSeq);
+void ActiveOverflowComponentBase ::CMD_HOOK_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_HOOK_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveOverflowComponentBase ::
-  CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode,cmdSeq);
+void ActiveOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(FwOpcodeType opCode,
+                                                                           U32 cmdSeq,
+                                                                           Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1859,725 +1157,460 @@ void ActiveOverflowComponentBase ::
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  CMD_HOOK_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveOverflowComponentBase ::CMD_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveOverflowComponentBase ::
-  CMD_PARAMS_PRIORITY_HOOK_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveOverflowComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveOverflowComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
-  doDispatch()
-{
-  U8 _msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer _msg(
-    _msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::doDispatch() {
+    U8 _msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEOVERFLOW_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port productRecvInHook
-    case PRODUCTRECVINHOOK_DPRESPONSE: {
-      // Deserialize argument id
-      FwDpIdType id;
-      _deserStatus = _msg.deserializeTo(id);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument buffer
-      Fw::Buffer buffer;
-      _deserStatus = _msg.deserializeTo(buffer);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument status
-      Fw::Success status;
-      _deserStatus = _msg.deserializeTo(status);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->productRecvInHook_handler(
-        portNum,
-        id,
-        buffer,
-        status
-      );
-
-      break;
+    if (_msgType == ACTIVEOVERFLOW_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port assertAsync
-    case ASSERTASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port productRecvInHook
+        case PRODUCTRECVINHOOK_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvInHook_handler(portNum, id, buffer, status);
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->assertAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port blockAsync
-    case BLOCKASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->blockAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port dropAsync
-    case DROPASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->dropAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port hookAsync
-    case HOOKASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->hookAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port serialAsyncHook
-    case SERIALASYNCHOOK_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncHook_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle command CMD_HOOK
-    case CMD_CMD_HOOK: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle async input port assertAsync
+        case ASSERTASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->assertAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port blockAsync
+        case BLOCKASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->blockAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port dropAsync
+        case DROPASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->dropAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port hookAsync
+        case HOOKASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->hookAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncHook
+        case SERIALASYNCHOOK_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncHook_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle command CMD_HOOK
+        case CMD_CMD_HOOK: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY_HOOK
-    case CMD_CMD_PARAMS_PRIORITY_HOOK: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_HOOK
+        case CMD_CMD_PARAMS_PRIORITY_HOOK: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
+            break;
+        }
+
+        // Handle internal interface internalHookDrop
+        case INT_IF_INTERNALHOOKDROP: {
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalHookDrop_internalInterfaceHandler();
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle internal interface internalHookDrop
-    case INT_IF_INTERNALHOOKDROP: {
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalHookDrop_internalInterfaceHandler();
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveOverflowComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                FwIndexType portNum,
+                                                FwOpcodeType opCode,
+                                                U32 cmdSeq,
+                                                Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void ActiveOverflowComponentBase ::
-  m_p_productRecvInHook_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-  compPtr->productRecvInHook_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void ActiveOverflowComponentBase ::m_p_productRecvInHook_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            FwDpIdType id,
+                                                            const Fw::Buffer& buffer,
+                                                            const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+    compPtr->productRecvInHook_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  m_p_assertAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-  compPtr->assertAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveOverflowComponentBase ::m_p_assertAsync_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) {
+    FW_ASSERT(callComp);
+    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+    compPtr->assertAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveOverflowComponentBase ::
-  m_p_blockAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-  compPtr->blockAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveOverflowComponentBase ::m_p_blockAsync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+    compPtr->blockAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveOverflowComponentBase ::
-  m_p_dropAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-  compPtr->dropAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveOverflowComponentBase ::m_p_dropAsync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) {
+    FW_ASSERT(callComp);
+    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+    compPtr->dropAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveOverflowComponentBase ::
-  m_p_hookAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-  compPtr->hookAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveOverflowComponentBase ::m_p_hookAsync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) {
+    FW_ASSERT(callComp);
+    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+    compPtr->hookAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -2586,19 +1619,12 @@ void ActiveOverflowComponentBase ::
 
 #if FW_PORT_SERIALIZATION
 
-void ActiveOverflowComponentBase ::
-  m_p_serialAsyncHook_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-  compPtr->serialAsyncHook_handlerBase(
-    portNum,
-    buffer
-  );
+void ActiveOverflowComponentBase ::m_p_serialAsyncHook_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+    compPtr->serialAsyncHook_handlerBase(portNum, buffer);
 }
 
 #endif
@@ -2609,68 +1635,31 @@ void ActiveOverflowComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void ActiveOverflowComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-void ActiveOverflowComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveOverflowComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -2679,17 +1668,13 @@ void ActiveOverflowComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::
-  productRecvInHook_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  (void) portNum;
-  (void) id;
-  (void) buffer;
-  (void) status;
-  // No data products defined
+void ActiveOverflowComponentBase ::productRecvInHook_handler(const FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer,
+                                                             const Fw::Success& status) {
+    (void)portNum;
+    (void)id;
+    (void)buffer;
+    (void)status;
+    // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEOVERFLOW_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVINHOOK_DPRESPONSE,
     ASSERTASYNC_TYPED,
@@ -23,268 +23,426 @@ enum MsgTypeEnum {
     CMD_CMD_HOOK,
     CMD_CMD_PARAMS_PRIORITY_HOOK,
     INT_IF_INTERNALHOOKDROP,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE productRecvInHookPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE assertAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE blockAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE dropAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE hookAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveOverflowComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwSizeType msgSize,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvInHook
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts()); port++) {
-        this->m_productRecvInHook_InputPort[port].init();
-        this->m_productRecvInHook_InputPort[port].addCallComp(this, m_p_productRecvInHook_in);
-        this->m_productRecvInHook_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port assertAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts()); port++) {
-        this->m_assertAsync_InputPort[port].init();
-        this->m_assertAsync_InputPort[port].addCallComp(this, m_p_assertAsync_in);
-        this->m_assertAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_assertAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port blockAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts()); port++) {
-        this->m_blockAsync_InputPort[port].init();
-        this->m_blockAsync_InputPort[port].addCallComp(this, m_p_blockAsync_in);
-        this->m_blockAsync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvInHook
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts());
+    port++
+  ) {
+    this->m_productRecvInHook_InputPort[port].init();
+    this->m_productRecvInHook_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvInHook_in
+    );
+    this->m_productRecvInHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_blockAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port dropAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts()); port++) {
-        this->m_dropAsync_InputPort[port].init();
-        this->m_dropAsync_InputPort[port].addCallComp(this, m_p_dropAsync_in);
-        this->m_dropAsync_InputPort[port].setPortNum(port);
+  // Connect input port assertAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts());
+    port++
+  ) {
+    this->m_assertAsync_InputPort[port].init();
+    this->m_assertAsync_InputPort[port].addCallComp(
+      this,
+      m_p_assertAsync_in
+    );
+    this->m_assertAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_dropAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_assertAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port hookAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts()); port++) {
-        this->m_hookAsync_InputPort[port].init();
-        this->m_hookAsync_InputPort[port].addCallComp(this, m_p_hookAsync_in);
-        this->m_hookAsync_InputPort[port].setPortNum(port);
+  // Connect input port blockAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts());
+    port++
+  ) {
+    this->m_blockAsync_InputPort[port].init();
+    this->m_blockAsync_InputPort[port].addCallComp(
+      this,
+      m_p_blockAsync_in
+    );
+    this->m_blockAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_hookAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_blockAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncHook
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts()); port++) {
-        this->m_serialAsyncHook_InputPort[port].init();
-        this->m_serialAsyncHook_InputPort[port].addCallComp(this, m_p_serialAsyncHook_in);
-        this->m_serialAsyncHook_InputPort[port].setPortNum(port);
+  // Connect input port dropAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts());
+    port++
+  ) {
+    this->m_dropAsync_InputPort[port].init();
+    this->m_dropAsync_InputPort[port].addCallComp(
+      this,
+      m_p_dropAsync_in
+    );
+    this->m_dropAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_dropAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port hookAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts());
+    port++
+  ) {
+    this->m_hookAsync_InputPort[port].init();
+    this->m_hookAsync_InputPort[port].addCallComp(
+      this,
+      m_p_hookAsync_in
+    );
+    this->m_hookAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_hookAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port serialAsyncHook
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncHook_InputPort[port].init();
+    this->m_serialAsyncHook_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncHook_in
+    );
+    this->m_serialAsyncHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Passed-in size added to port number and message type enumeration sizes.
-    this->m_msgSize = FW_MAX(
-        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+  // Passed-in size added to port number and message type enumeration sizes.
+  this->m_msgSize = FW_MAX(
+    msgSize +
+    static_cast<FwSizeType>(sizeof(FwIndexType)) +
+    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
 
-    // Create the queue
-    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -293,17 +451,26 @@ void ActiveOverflowComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSiz
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveOverflowComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveOverflowComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveOverflowComponentBase ::get_productRecvInHook_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* ActiveOverflowComponentBase ::
+  get_productRecvInHook_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvInHook_InputPort[portNum];
+  return &this->m_productRecvInHook_InputPort[portNum];
 }
 
 #endif
@@ -314,30 +481,48 @@ Fw::InputDpResponsePort* ActiveOverflowComponentBase ::get_productRecvInHook_Inp
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::get_assertAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveOverflowComponentBase ::
+  get_assertAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_assertAsync_InputPort[portNum];
+  return &this->m_assertAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::get_blockAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveOverflowComponentBase ::
+  get_blockAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_blockAsync_InputPort[portNum];
+  return &this->m_blockAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::get_dropAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveOverflowComponentBase ::
+  get_dropAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_dropAsync_InputPort[portNum];
+  return &this->m_dropAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveOverflowComponentBase ::get_hookAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveOverflowComponentBase ::
+  get_hookAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_hookAsync_InputPort[portNum];
+  return &this->m_hookAsync_InputPort[portNum];
 }
 
 #endif
@@ -348,11 +533,15 @@ Ports::InputTypedPort* ActiveOverflowComponentBase ::get_hookAsync_InputPort(FwI
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* ActiveOverflowComponentBase ::get_serialAsyncHook_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* ActiveOverflowComponentBase ::
+  get_serialAsyncHook_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncHook_InputPort[portNum];
+  return &this->m_serialAsyncHook_InputPort[portNum];
 }
 
 #endif
@@ -363,62 +552,120 @@ Fw::InputSerializePort* ActiveOverflowComponentBase ::get_serialAsyncHook_InputP
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -429,55 +676,106 @@ void ActiveOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -486,21 +784,38 @@ void ActiveOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveOverflowComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_HOOK);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_HOOK
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK
+  );
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveOverflowComponentBase ::ActiveOverflowComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
+ActiveOverflowComponentBase ::
+  ActiveOverflowComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveOverflowComponentBase ::~ActiveOverflowComponentBase() {}
+}
+
+ActiveOverflowComponentBase ::
+  ~ActiveOverflowComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -508,62 +823,96 @@ ActiveOverflowComponentBase ::~ActiveOverflowComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveOverflowComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveOverflowComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveOverflowComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveOverflowComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveOverflowComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -574,73 +923,117 @@ bool ActiveOverflowComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType por
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                     FwOpcodeType opCode,
-                                                     U32 cmdSeq,
-                                                     Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveOverflowComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_CMD_HOOK: {
-            this->CMD_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
-            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_CMD_HOOK: {
+      this->CMD_HOOK_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
     }
+
+    case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
+      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void ActiveOverflowComponentBase ::productRecvInHook_handlerBase(FwIndexType portNum,
-                                                                 FwDpIdType id,
-                                                                 const Fw::Buffer& buffer,
-                                                                 const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  productRecvInHook_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    productRecvInHook_preMsgHook(portNum, id, buffer, status);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  productRecvInHook_preMsgHook(
+    portNum,
+    id,
+    buffer,
+    status
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument id
-    _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument id
+  _status = msg.serializeFrom(id);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msg.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument status
-    _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument status
+  _status = msg.serializeFrom(status);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->productRecvInHook_overflowHook(portNum, id, buffer, status);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->productRecvInHook_overflowHook(portNum, id, buffer, status);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -649,252 +1042,442 @@ void ActiveOverflowComponentBase ::productRecvInHook_handlerBase(FwIndexType por
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::assertAsync_handlerBase(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  assertAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    assertAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  assertAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveOverflowComponentBase ::blockAsync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  blockAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    blockAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  blockAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveOverflowComponentBase ::dropAsync_handlerBase(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  dropAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    dropAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  dropAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(DROPASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(DROPASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveOverflowComponentBase ::hookAsync_handlerBase(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  hookAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    hookAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  hookAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(HOOKASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(HOOKASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -903,38 +1486,62 @@ void ActiveOverflowComponentBase ::hookAsync_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::serialAsyncHook_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  serialAsyncHook_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncHook
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncHook
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->serialAsyncHook_overflowHook(portNum, buffer);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->serialAsyncHook_overflowHook(portNum, buffer);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -945,11 +1552,15 @@ void ActiveOverflowComponentBase ::serialAsyncHook_handlerBase(FwIndexType portN
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::productRecvInHook_preMsgHook(FwIndexType portNum,
-                                                                FwDpIdType id,
-                                                                const Fw::Buffer& buffer,
-                                                                const Fw::Success& status) {
-    // Default: no-op
+void ActiveOverflowComponentBase ::
+  productRecvInHook_preMsgHook(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -960,48 +1571,64 @@ void ActiveOverflowComponentBase ::productRecvInHook_preMsgHook(FwIndexType port
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::assertAsync_preMsgHook(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Default: no-op
+void ActiveOverflowComponentBase ::
+  assertAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveOverflowComponentBase ::blockAsync_preMsgHook(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Default: no-op
+void ActiveOverflowComponentBase ::
+  blockAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveOverflowComponentBase ::dropAsync_preMsgHook(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Default: no-op
+void ActiveOverflowComponentBase ::
+  dropAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveOverflowComponentBase ::hookAsync_preMsgHook(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Default: no-op
+void ActiveOverflowComponentBase ::
+  hookAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1012,8 +1639,13 @@ void ActiveOverflowComponentBase ::hookAsync_preMsgHook(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::serialAsyncHook_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void ActiveOverflowComponentBase ::
+  serialAsyncHook_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1028,37 +1660,54 @@ void ActiveOverflowComponentBase ::serialAsyncHook_preMsgHook(FwIndexType portNu
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::internalHookDrop_internalInterfaceInvoke() {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveOverflowComponentBase ::
+  internalHookDrop_internalInterfaceInvoke()
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->internalHookDrop_overflowHook();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->internalHookDrop_overflowHook();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveOverflowComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -1067,86 +1716,132 @@ void ActiveOverflowComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdS
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::CMD_HOOK_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_HOOK_preMsgHook(opCode, cmdSeq);
+void ActiveOverflowComponentBase ::
+  CMD_HOOK_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_HOOK_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(FwOpcodeType opCode,
-                                                                           U32 cmdSeq,
-                                                                           Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode, cmdSeq);
+void ActiveOverflowComponentBase ::
+  CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1157,460 +1852,725 @@ void ActiveOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(FwOpc
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::CMD_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveOverflowComponentBase ::
+  CMD_HOOK_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveOverflowComponentBase ::
+  CMD_PARAMS_PRIORITY_HOOK_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveOverflowComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveOverflowComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::doDispatch() {
-    U8 _msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
+  doDispatch()
+{
+  U8 _msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer _msg(
+    _msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEOVERFLOW_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEOVERFLOW_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port productRecvInHook
+    case PRODUCTRECVINHOOK_DPRESPONSE: {
+      // Deserialize argument id
+      FwDpIdType id;
+      _deserStatus = _msg.deserializeTo(id);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument buffer
+      Fw::Buffer buffer;
+      _deserStatus = _msg.deserializeTo(buffer);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument status
+      Fw::Success status;
+      _deserStatus = _msg.deserializeTo(status);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->productRecvInHook_handler(
+        portNum,
+        id,
+        buffer,
+        status
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port assertAsync
+    case ASSERTASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port productRecvInHook
-        case PRODUCTRECVINHOOK_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvInHook_handler(portNum, id, buffer, status);
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            break;
-        }
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-        // Handle async input port assertAsync
-        case ASSERTASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->assertAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->assertAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port blockAsync
-        case BLOCKASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->blockAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port dropAsync
-        case DROPASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->dropAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port hookAsync
-        case HOOKASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->hookAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncHook
-        case SERIALASYNCHOOK_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncHook_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle command CMD_HOOK
-        case CMD_CMD_HOOK: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY_HOOK
-        case CMD_CMD_PARAMS_PRIORITY_HOOK: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle internal interface internalHookDrop
-        case INT_IF_INTERNALHOOKDROP: {
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalHookDrop_internalInterfaceHandler();
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port blockAsync
+    case BLOCKASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->blockAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port dropAsync
+    case DROPASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->dropAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port hookAsync
+    case HOOKASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->hookAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port serialAsyncHook
+    case SERIALASYNCHOOK_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncHook_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle command CMD_HOOK
+    case CMD_CMD_HOOK: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY_HOOK
+    case CMD_CMD_PARAMS_PRIORITY_HOOK: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalHookDrop
+    case INT_IF_INTERNALHOOKDROP: {
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalHookDrop_internalInterfaceHandler();
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                FwIndexType portNum,
-                                                FwOpcodeType opCode,
-                                                U32 cmdSeq,
-                                                Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveOverflowComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void ActiveOverflowComponentBase ::m_p_productRecvInHook_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            FwDpIdType id,
-                                                            const Fw::Buffer& buffer,
-                                                            const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-    compPtr->productRecvInHook_handlerBase(portNum, id, buffer, status);
+void ActiveOverflowComponentBase ::
+  m_p_productRecvInHook_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+  compPtr->productRecvInHook_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::m_p_assertAsync_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) {
-    FW_ASSERT(callComp);
-    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-    compPtr->assertAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveOverflowComponentBase ::
+  m_p_assertAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+  compPtr->assertAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveOverflowComponentBase ::m_p_blockAsync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-    compPtr->blockAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveOverflowComponentBase ::
+  m_p_blockAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+  compPtr->blockAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveOverflowComponentBase ::m_p_dropAsync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) {
-    FW_ASSERT(callComp);
-    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-    compPtr->dropAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveOverflowComponentBase ::
+  m_p_dropAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+  compPtr->dropAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveOverflowComponentBase ::m_p_hookAsync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) {
-    FW_ASSERT(callComp);
-    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-    compPtr->hookAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveOverflowComponentBase ::
+  m_p_hookAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+  compPtr->hookAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1619,12 +2579,19 @@ void ActiveOverflowComponentBase ::m_p_hookAsync_in(Fw::PassiveComponentBase* ca
 
 #if FW_PORT_SERIALIZATION
 
-void ActiveOverflowComponentBase ::m_p_serialAsyncHook_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
-    compPtr->serialAsyncHook_handlerBase(portNum, buffer);
+void ActiveOverflowComponentBase ::
+  m_p_serialAsyncHook_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
+  compPtr->serialAsyncHook_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
 #endif
@@ -1635,31 +2602,68 @@ void ActiveOverflowComponentBase ::m_p_serialAsyncHook_in(Fw::PassiveComponentBa
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void ActiveOverflowComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-void ActiveOverflowComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveOverflowComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -1668,13 +2672,17 @@ void ActiveOverflowComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time&
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveOverflowComponentBase ::productRecvInHook_handler(const FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer,
-                                                             const Fw::Success& status) {
-    (void)portNum;
-    (void)id;
-    (void)buffer;
-    (void)status;
-    // No data products defined
+void ActiveOverflowComponentBase ::
+  productRecvInHook_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  (void) portNum;
+  (void) id;
+  (void) buffer;
+  (void) status;
+  // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -53,9 +53,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVEPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void ActiveParamsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveParamsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,139 @@ Fw::InputCmdPort* ActiveParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveParamsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveParamsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveParamsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveParamsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveParamsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveParamsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveParamsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveParamsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveParamsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveParamsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +754,62 @@ Ports::InputTypedPort* ActiveParamsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +820,64 @@ void ActiveParamsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +888,55 @@ void ActiveParamsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +947,24 @@ void ActiveParamsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,244 +973,169 @@ void ActiveParamsComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveParamsComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  loadParameters()
-{
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void ActiveParamsComponentBase ::loadParameters() {
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-  FwPrmIdType _id{};
-  Fw::ParamBuffer _paramBuffer;
+    FwPrmIdType _id{};
+    Fw::ParamBuffer _paramBuffer;
 
-  _id = _baseId + PARAMID_PARAMU32;
+    _id = _baseId + PARAMID_PARAMU32;
 
-  // Get serialized parameter ParamU32
-  this->m_param_ParamU32_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamU32
+    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64;
+    _id = _baseId + PARAMID_PARAMF64;
 
-  // Get serialized parameter ParamF64
-  this->m_param_ParamF64_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamF64
+    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRING;
+    _id = _baseId + PARAMID_PARAMSTRING;
 
-  // Get serialized parameter ParamString
-  this->m_param_ParamString_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamString
+    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
-  }
-  else {
-    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamString = Fw::String("default");
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMENUM;
-
-  // Get serialized parameter ParamEnum
-  this->m_param_ParamEnum_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamString = Fw::String("default");
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAY;
+    _id = _baseId + PARAMID_PARAMENUM;
 
-  // Get serialized parameter ParamArray
-  this->m_param_ParamArray_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnum
+    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter
+    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  else {
-    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamArray = A({1, 2, 3});
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCT;
+    _id = _baseId + PARAMID_PARAMARRAY;
 
-  // Get serialized parameter ParamStruct
-  this->m_param_ParamStruct_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamArray
+    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
-  }
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamArray = A({1, 2, 3});
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parametersLoaded();
+    _id = _baseId + PARAMID_PARAMSTRUCT;
+
+    // Get serialized parameter ParamStruct
+    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
+    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+        }
+    }
+
+    this->m_paramLock.unlock();
+
+    // Call notifier
+    this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveParamsComponentBase ::
-  ActiveParamsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveParamsComponentBase ::ActiveParamsComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveParamsComponentBase ::
-  ~ActiveParamsComponentBase()
-{
-
-}
+ActiveParamsComponentBase ::~ActiveParamsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1838,96 +1143,62 @@ ActiveParamsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveParamsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveParamsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveParamsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1938,92 +1209,59 @@ bool ActiveParamsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveParamsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2034,143 +1272,90 @@ bool ActiveParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_PARAMU32_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_PARAMU32_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
+        case OPCODE_PARAMU32_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamString();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_PARAMU32_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamString();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -2179,941 +1364,561 @@ void ActiveParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveParamsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveParamsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveParamsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveParamsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveParamsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveParamsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveParamsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveParamsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveParamsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveParamsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveParamsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveParamsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveParamsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveParamsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveParamsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveParamsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveParamsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveParamsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3124,85 +1929,63 @@ void ActiveParamsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveParamsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveParamsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Default: no-op
 }
 
-void ActiveParamsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void ActiveParamsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void ActiveParamsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3211,209 +1994,103 @@ void ActiveParamsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveParamsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveParamsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveParamsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                   AliasPrim1 u32,
+                                                   AliasPrim2 f32,
+                                                   AliasBool b,
+                                                   const Fw::StringBase& str2,
+                                                   const AliasEnum& e,
+                                                   const AliasArray& a,
+                                                   const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveParamsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveParamsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveParamsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::typedOut_out(FwIndexType portNum,
+                                              U32 u32,
+                                              F32 f32,
+                                              bool b,
+                                              const Fw::StringBase& str1,
+                                              const E& e,
+                                              const A& a,
+                                              const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveParamsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str2,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3422,130 +2099,105 @@ F32 ActiveParamsComponentBase ::
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  parameterUpdated(FwPrmIdType id)
-{
-  // Do nothing by default
+void ActiveParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
+    // Do nothing by default
 }
 
-void ActiveParamsComponentBase ::
-  parametersLoaded()
-{
-  // Do nothing by default
+void ActiveParamsComponentBase ::parametersLoaded() {
+    // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 ActiveParamsComponentBase ::
-  paramGet_ParamU32(Fw::ParamValid& valid)
-{
-  U32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamU32_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamU32;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+U32 ActiveParamsComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
+    U32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamU32_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamU32;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-F64 ActiveParamsComponentBase ::
-  paramGet_ParamF64(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamF64;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+F64 ActiveParamsComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamF64;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-Fw::ParamString ActiveParamsComponentBase ::
-  paramGet_ParamString(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamString_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamString;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+Fw::ParamString ActiveParamsComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamString_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamString;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-E ActiveParamsComponentBase ::
-  paramGet_ParamEnum(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnum_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamEnum;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+E ActiveParamsComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnum_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamEnum;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-A ActiveParamsComponentBase ::
-  paramGet_ParamArray(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArray_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamArray;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+A ActiveParamsComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArray_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamArray;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-S ActiveParamsComponentBase ::
-  paramGet_ParamStruct(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStruct_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamStruct;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+S ActiveParamsComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStruct_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamStruct;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveParamsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveParamsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3555,868 +2207,505 @@ Fw::Time ActiveParamsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveParamsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveParamsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveParamsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVEPARAMS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVEPARAMS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                              FwIndexType portNum,
+                                              FwOpcodeType opCode,
+                                              U32 cmdSeq,
+                                              Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveParamsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveParamsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveParamsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveParamsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveParamsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveParamsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveParamsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveParamsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str2,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveParamsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                  FwIndexType portNum,
+                                                  U32 u32,
+                                                  F32 f32,
+                                                  bool b,
+                                                  const Fw::StringBase& str1,
+                                                  const E& e,
+                                                  const A& a,
+                                                  const S& s) {
+    FW_ASSERT(callComp);
+    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4425,112 +2714,49 @@ void ActiveParamsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void ActiveParamsComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                    FwOpcodeType opCode,
+                                                    U32 cmdSeq,
+                                                    const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-Fw::ParamValid ActiveParamsComponentBase ::
-  prmGetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::ParamValid ActiveParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                         FwPrmIdType id,
+                                                         Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_prmGetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void ActiveParamsComponentBase ::
-  prmSetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmSetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_prmSetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void ActiveParamsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4539,294 +2765,252 @@ void ActiveParamsComponentBase ::
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSet_ParamU32(Fw::SerialBufferBase& val)
-{
-  U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
+    U32 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamU32 = _localVal;
-  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamU32 = _localVal;
+    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMU32);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMU32);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSet_ParamF64(Fw::SerialBufferBase& val)
-{
-  F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
+    F64 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamF64 = _localVal;
-  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamF64 = _localVal;
+    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMF64);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMF64);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSet_ParamString(Fw::SerialBufferBase& val)
-{
-  Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
+    Fw::ParamString _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamString = _localVal;
-  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamString = _localVal;
+    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSet_ParamEnum(Fw::SerialBufferBase& val)
-{
-  E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
+    E _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamEnum = _localVal;
-  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamEnum = _localVal;
+    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMENUM);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSet_ParamArray(Fw::SerialBufferBase& val)
-{
-  A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
+    A _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamArray = _localVal;
-  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamArray = _localVal;
+    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSet_ParamStruct(Fw::SerialBufferBase& val)
-{
-  S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
+    S _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamStruct = _localVal;
-  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamStruct = _localVal;
+    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+    return Fw::CmdResponse::OK;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSave_ParamU32()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamU32);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamU32() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamU32);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSave_ParamF64()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamF64);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamF64() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamF64);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSave_ParamString()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamString);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamString() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamString);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSave_ParamEnum()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamEnum() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSave_ParamArray()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamArray);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamArray() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamArray);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::
-  paramSave_ParamStruct()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamStruct() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVEPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveParamsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void ActiveParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType ins
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveParamsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,139 +967,213 @@ Fw::InputCmdPort* ActiveParamsComponentBase ::get_cmdIn_InputPort(FwIndexType po
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveParamsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveParamsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveParamsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveParamsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveParamsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveParamsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveParamsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveParamsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveParamsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveParamsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveParamsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveParamsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveParamsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -754,62 +1184,120 @@ Ports::InputTypedPort* ActiveParamsComponentBase ::get_typedSync_InputPort(FwInd
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -820,64 +1308,116 @@ void ActiveParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -888,55 +1428,106 @@ void ActiveParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portN
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -947,24 +1538,46 @@ void ActiveParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -973,169 +1586,244 @@ void ActiveParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveParamsComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+  );
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::loadParameters() {
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void ActiveParamsComponentBase ::
+  loadParameters()
+{
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-    FwPrmIdType _id{};
-    Fw::ParamBuffer _paramBuffer;
+  FwPrmIdType _id{};
+  Fw::ParamBuffer _paramBuffer;
 
-    _id = _baseId + PARAMID_PARAMU32;
+  _id = _baseId + PARAMID_PARAMU32;
 
-    // Get serialized parameter ParamU32
-    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamU32
+  this->m_param_ParamU32_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
-        }
+  // Deserialize parameter
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMF64;
+  _id = _baseId + PARAMID_PARAMF64;
 
-    // Get serialized parameter ParamF64
-    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamF64
+  this->m_param_ParamF64_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
-        }
+  // Deserialize parameter
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRING;
+  _id = _baseId + PARAMID_PARAMSTRING;
 
-    // Get serialized parameter ParamString
-    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamString
+  this->m_param_ParamString_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
-    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamString = Fw::String("default");
+  }
+  else {
+    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamString = Fw::String("default");
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMENUM;
+
+  // Get serialized parameter ParamEnum
+  this->m_param_ParamEnum_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMENUM;
+  _id = _baseId + PARAMID_PARAMARRAY;
 
-    // Get serialized parameter ParamEnum
-    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamArray
+  this->m_param_ParamArray_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
-        }
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
+  }
+  else {
+    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamArray = A({1, 2, 3});
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMARRAY;
+  _id = _baseId + PARAMID_PARAMSTRUCT;
 
-    // Get serialized parameter ParamArray
-    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamStruct
+  this->m_param_ParamStruct_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+  // Deserialize parameter
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamArray = A({1, 2, 3});
-    }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRUCT;
-
-    // Get serialized parameter ParamStruct
-    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    // Call notifier
-    this->parametersLoaded();
+  // Call notifier
+  this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveParamsComponentBase ::ActiveParamsComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
+ActiveParamsComponentBase ::
+  ActiveParamsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveParamsComponentBase ::~ActiveParamsComponentBase() {}
+}
+
+ActiveParamsComponentBase ::
+  ~ActiveParamsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1143,62 +1831,96 @@ ActiveParamsComponentBase ::~ActiveParamsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1209,59 +1931,92 @@ bool ActiveParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portN
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveParamsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1272,90 +2027,143 @@ bool ActiveParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexTy
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveParamsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_PARAMU32_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_PARAMU32_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamString();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_PARAMU32_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
     }
+
+    case OPCODE_PARAMU32_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamString();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1364,561 +2172,941 @@ void ActiveParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveParamsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveParamsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveParamsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveParamsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveParamsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveParamsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveParamsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveParamsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1929,63 +3117,85 @@ void ActiveParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    // Default: no-op
+void ActiveParamsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveParamsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Default: no-op
+void ActiveParamsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void ActiveParamsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void ActiveParamsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void ActiveParamsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1994,103 +3204,209 @@ void ActiveParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType p
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveParamsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveParamsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                   AliasPrim1 u32,
-                                                   AliasPrim2 f32,
-                                                   AliasBool b,
-                                                   const Fw::StringBase& str2,
-                                                   const AliasEnum& e,
-                                                   const AliasArray& a,
-                                                   const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveParamsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveParamsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveParamsComponentBase ::typedOut_out(FwIndexType portNum,
-                                              U32 u32,
-                                              F32 f32,
-                                              bool b,
-                                              const Fw::StringBase& str1,
-                                              const E& e,
-                                              const A& a,
-                                              const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str2,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveParamsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2099,105 +3415,130 @@ F32 ActiveParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveParamsComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
-    // Do nothing by default
+void ActiveParamsComponentBase ::
+  parameterUpdated(FwPrmIdType id)
+{
+  // Do nothing by default
 }
 
-void ActiveParamsComponentBase ::parametersLoaded() {
-    // Do nothing by default
+void ActiveParamsComponentBase ::
+  parametersLoaded()
+{
+  // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 ActiveParamsComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
-    U32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamU32_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamU32;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+U32 ActiveParamsComponentBase ::
+  paramGet_ParamU32(Fw::ParamValid& valid)
+{
+  U32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamU32_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamU32;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 ActiveParamsComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamF64;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+F64 ActiveParamsComponentBase ::
+  paramGet_ParamF64(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamF64;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString ActiveParamsComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamString_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamString;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+Fw::ParamString ActiveParamsComponentBase ::
+  paramGet_ParamString(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamString_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamString;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E ActiveParamsComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnum_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamEnum;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+E ActiveParamsComponentBase ::
+  paramGet_ParamEnum(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnum_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamEnum;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A ActiveParamsComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArray_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamArray;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+A ActiveParamsComponentBase ::
+  paramGet_ParamArray(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArray_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamArray;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S ActiveParamsComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStruct_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamStruct;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+S ActiveParamsComponentBase ::
+  paramGet_ParamStruct(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStruct_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamStruct;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveParamsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveParamsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2207,505 +3548,868 @@ Fw::Time ActiveParamsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveParamsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveParamsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveParamsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVEPARAMS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVEPARAMS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                              FwIndexType portNum,
-                                              FwOpcodeType opCode,
-                                              U32 cmdSeq,
-                                              Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveParamsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveParamsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveParamsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveParamsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveParamsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveParamsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveParamsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveParamsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveParamsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveParamsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveParamsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str2,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveParamsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                  FwIndexType portNum,
-                                                  U32 u32,
-                                                  F32 f32,
-                                                  bool b,
-                                                  const Fw::StringBase& str1,
-                                                  const E& e,
-                                                  const A& a,
-                                                  const S& s) {
-    FW_ASSERT(callComp);
-    ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveParamsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2714,49 +4418,112 @@ void ActiveParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* call
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void ActiveParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                    FwOpcodeType opCode,
-                                                    U32 cmdSeq,
-                                                    const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-Fw::ParamValid ActiveParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                         FwPrmIdType id,
-                                                         Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::ParamValid ActiveParamsComponentBase ::
+  prmGetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_prmGetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void ActiveParamsComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  prmSetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmSetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_prmSetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void ActiveParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveParamsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2765,252 +4532,294 @@ void ActiveParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& t
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
-    U32 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSet_ParamU32(Fw::SerialBufferBase& val)
+{
+  U32 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamU32 = _localVal;
-    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamU32 = _localVal;
+  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMU32);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMU32);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
-    F64 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSet_ParamF64(Fw::SerialBufferBase& val)
+{
+  F64 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamF64 = _localVal;
-    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamF64 = _localVal;
+  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMF64);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMF64);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
-    Fw::ParamString _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSet_ParamString(Fw::SerialBufferBase& val)
+{
+  Fw::ParamString _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamString = _localVal;
-    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamString = _localVal;
+  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
-    E _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSet_ParamEnum(Fw::SerialBufferBase& val)
+{
+  E _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamEnum = _localVal;
-    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamEnum = _localVal;
+  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMENUM);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
-    A _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSet_ParamArray(Fw::SerialBufferBase& val)
+{
+  A _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamArray = _localVal;
-    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamArray = _localVal;
+  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
-    S _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSet_ParamStruct(Fw::SerialBufferBase& val)
+{
+  S _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamStruct = _localVal;
-    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamStruct = _localVal;
+  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  return Fw::CmdResponse::OK;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamU32() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamU32);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSave_ParamU32()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamU32);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamF64() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamF64);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSave_ParamF64()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamF64);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamString() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamString);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSave_ParamString()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamString);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamEnum() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSave_ParamEnum()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamArray() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamArray);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSave_ParamArray()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamArray);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveParamsComponentBase ::paramSave_ParamStruct() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveParamsComponentBase ::
+  paramSave_ParamStruct()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVESERIAL_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -35,11 +35,11 @@ namespace {
     INT_IF_INTERNALPRIORITYDROP,
     INT_IF_INTERNALSTRING,
     INT_IF_INTERNALSTRUCT,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -47,1127 +47,683 @@ namespace {
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
     // Size of internalArray argument list
-    BYTE internalArrayIntIfSize[
-      A::SERIALIZED_SIZE
-    ];
+    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
     // Size of internalEnum argument list
-    BYTE internalEnumIntIfSize[
-      E::SERIALIZED_SIZE
-    ];
+    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
     // Size of internalPrimitive argument list
-    BYTE internalPrimitiveIntIfSize[
-      sizeof(U32) +
-      sizeof(F32) +
-      sizeof(U8)
-    ];
+    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
     // Size of internalString argument list
-    BYTE internalStringIntIfSize[
-      Fw::InternalInterfaceString::SERIALIZED_SIZE +
-      Fw::InternalInterfaceString::SERIALIZED_SIZE
-    ];
+    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
+                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
     // Size of internalStruct argument list
-    BYTE internalStructIntIfSize[
-      S::SERIALIZED_SIZE
-    ];
-  };
+    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwSizeType msgSize,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveSerialComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts());
-    port++
-  ) {
-    this->m_serialAsync_InputPort[port].init();
-    this->m_serialAsync_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsync_in
-    );
-    this->m_serialAsync_InputPort[port].setPortNum(port);
+    // Connect input port serialAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts()); port++) {
+        this->m_serialAsync_InputPort[port].init();
+        this->m_serialAsync_InputPort[port].addCallComp(this, m_p_serialAsync_in);
+        this->m_serialAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncAssert_InputPort[port].init();
-    this->m_serialAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncAssert_in
-    );
-    this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts()); port++) {
+        this->m_serialAsyncAssert_InputPort[port].init();
+        this->m_serialAsyncAssert_InputPort[port].addCallComp(this, m_p_serialAsyncAssert_in);
+        this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncBlockPriority_InputPort[port].init();
-    this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncBlockPriority_in
-    );
-    this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_serialAsyncBlockPriority_InputPort[port].init();
+        this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_serialAsyncBlockPriority_in);
+        this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncDropPriority_InputPort[port].init();
-    this->m_serialAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncDropPriority_in
-    );
-    this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_serialAsyncDropPriority_InputPort[port].init();
+        this->m_serialAsyncDropPriority_InputPort[port].addCallComp(this, m_p_serialAsyncDropPriority_in);
+        this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts());
-    port++
-  ) {
-    this->m_serialGuarded_InputPort[port].init();
-    this->m_serialGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_serialGuarded_in
-    );
-    this->m_serialGuarded_InputPort[port].setPortNum(port);
+    // Connect input port serialGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts()); port++) {
+        this->m_serialGuarded_InputPort[port].init();
+        this->m_serialGuarded_InputPort[port].addCallComp(this, m_p_serialGuarded_in);
+        this->m_serialGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts());
-    port++
-  ) {
-    this->m_serialSync_InputPort[port].init();
-    this->m_serialSync_InputPort[port].addCallComp(
-      this,
-      m_p_serialSync_in
-    );
-    this->m_serialSync_InputPort[port].setPortNum(port);
+    // Connect input port serialSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts()); port++) {
+        this->m_serialSync_InputPort[port].init();
+        this->m_serialSync_InputPort[port].addCallComp(this, m_p_serialSync_in);
+        this->m_serialSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port serialOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts());
-    port++
-  ) {
-    this->m_serialOut_OutputPort[port].init();
+    // Connect output port serialOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts()); port++) {
+        this->m_serialOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Passed-in size added to port number and message type enumeration sizes.
-  this->m_msgSize = FW_MAX(
-    msgSize +
-    static_cast<FwSizeType>(sizeof(FwIndexType)) +
-    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
+    // Passed-in size added to port number and message type enumeration sizes.
+    this->m_msgSize = FW_MAX(
+        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1176,15 +732,10 @@ void ActiveSerialComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveSerialComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveSerialComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -1195,213 +746,139 @@ Fw::InputCmdPort* ActiveSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveSerialComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveSerialComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveSerialComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveSerialComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSerialComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSerialComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveSerialComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveSerialComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSerialComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveSerialComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveSerialComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveSerialComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveSerialComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveSerialComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveSerialComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1412,70 +889,46 @@ Ports::InputTypedPort* ActiveSerialComponentBase ::
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::
-  get_serialAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsync_InputPort[portNum];
+    return &this->m_serialAsync_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::
-  get_serialAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncAssert_InputPort[portNum];
+    return &this->m_serialAsyncAssert_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::
-  get_serialAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncBlockPriority_InputPort[portNum];
+    return &this->m_serialAsyncBlockPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::
-  get_serialAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncDropPriority_InputPort[portNum];
+    return &this->m_serialAsyncDropPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::
-  get_serialGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialGuarded_InputPort[portNum];
+    return &this->m_serialGuarded_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::
-  get_serialSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialSync_InputPort[portNum];
+    return &this->m_serialSync_InputPort[portNum];
 }
 
 #endif
@@ -1486,120 +939,62 @@ Fw::InputSerializePort* ActiveSerialComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSerialComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveSerialComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1610,116 +1005,64 @@ void ActiveSerialComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1730,106 +1073,55 @@ void ActiveSerialComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSerialComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveSerialComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1840,46 +1132,24 @@ void ActiveSerialComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1890,18 +1160,11 @@ void ActiveSerialComponentBase ::
 // Connect typed and serial input ports to serial output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  set_serialOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPortBase* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::set_serialOut_OutputPort(FwIndexType portNum, Fw::InputPortBase* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1910,586 +1173,368 @@ void ActiveSerialComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveSerialComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_ASYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  loadParameters()
-{
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void ActiveSerialComponentBase ::loadParameters() {
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-  FwPrmIdType _id{};
-  Fw::ParamBuffer _paramBuffer;
+    FwPrmIdType _id{};
+    Fw::ParamBuffer _paramBuffer;
 
-  _id = _baseId + PARAMID_PARAMU32;
+    _id = _baseId + PARAMID_PARAMU32;
 
-  // Get serialized parameter ParamU32
-  this->m_param_ParamU32_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamU32
+    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64;
+    _id = _baseId + PARAMID_PARAMF64;
 
-  // Get serialized parameter ParamF64
-  this->m_param_ParamF64_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamF64
+    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRING;
+    _id = _baseId + PARAMID_PARAMSTRING;
 
-  // Get serialized parameter ParamString
-  this->m_param_ParamString_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamString
+    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
-  }
-  else {
-    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamString = Fw::String("default");
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMENUM;
-
-  // Get serialized parameter ParamEnum
-  this->m_param_ParamEnum_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamString = Fw::String("default");
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAY;
+    _id = _baseId + PARAMID_PARAMENUM;
 
-  // Get serialized parameter ParamArray
-  this->m_param_ParamArray_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnum
+    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter
+    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  else {
-    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamArray = A({1, 2, 3});
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCT;
+    _id = _baseId + PARAMID_PARAMARRAY;
 
-  // Get serialized parameter ParamStruct
-  this->m_param_ParamStruct_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamArray
+    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
-  }
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamArray = A({1, 2, 3});
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMI32EXT;
+    _id = _baseId + PARAMID_PARAMSTRUCT;
 
-  // Get serialized parameter ParamI32Ext
-  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStruct
+    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMI32EXT,
-    this->m_param_ParamI32Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter
+    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64EXT;
+    _id = _baseId + PARAMID_PARAMI32EXT;
 
-  // Get serialized parameter ParamF64Ext
-  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamI32Ext
+    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMF64EXT,
-    this->m_param_ParamF64Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMSTRINGEXT;
-
-  // Get serialized parameter ParamStringExt
-  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-    Fw::String _val = Fw::String("external default");
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMF64EXT;
+
+    // Get serialized parameter ParamF64Ext
+    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMENUMEXT;
+    _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
-  // Get serialized parameter ParamEnumExt
-  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStringExt
+    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMENUMEXT,
-    this->m_param_ParamEnumExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+        Fw::String _val = Fw::String("external default");
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAYEXT;
+    _id = _baseId + PARAMID_PARAMENUMEXT;
 
-  // Get serialized parameter ParamArrayExt
-  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnumExt
+    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-    A _val = A({1, 2, 3});
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+    // Get serialized parameter ParamArrayExt
+    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+        A _val = A({1, 2, 3});
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+    // Get serialized parameter ParamStructExt
+    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
+                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-  // Get serialized parameter ParamStructExt
-  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMSTRUCTEXT,
-    this->m_param_ParamStructExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  // Call notifier
-  this->parametersLoaded();
+    // Call notifier
+    this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveSerialComponentBase ::
-  ActiveSerialComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
-  this->m_EventActivityLowThrottledThrottle = 0;
-  this->m_EventFatalThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledIntervalThrottle = 0;
+ActiveSerialComponentBase ::ActiveSerialComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {
+    this->m_EventActivityLowThrottledThrottle = 0;
+    this->m_EventFatalThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-ActiveSerialComponentBase ::
-  ~ActiveSerialComponentBase()
-{
-
-}
+ActiveSerialComponentBase ::~ActiveSerialComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -2497,96 +1542,62 @@ ActiveSerialComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSerialComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveSerialComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveSerialComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2597,92 +1608,59 @@ bool ActiveSerialComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSerialComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2693,15 +1671,11 @@ bool ActiveSerialComponentBase ::
 // Connection status queries for serial output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSerialComponentBase ::
-  isConnected_serialOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSerialComponentBase ::isConnected_serialOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_serialOut_OutputPort[portNum].isConnected();
+    return this->m_serialOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2712,416 +1686,247 @@ bool ActiveSerialComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveSerialComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_CMD_SYNC: {
+            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_CMD_SYNC: {
-      this->CMD_SYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
+        case OPCODE_CMD_SYNC_PRIMITIVE: {
+            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRING: {
+            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ENUM: {
+            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ARRAY: {
+            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRUCT: {
+            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED: {
+            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_PRIMITIVE: {
+            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRING: {
+            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ENUM: {
+            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ARRAY: {
+            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRUCT: {
+            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_ASYNC: {
+            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PRIORITY: {
+            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY: {
+            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_DROP: {
+            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_PARAMU32_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMU32_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamString();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMI32EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMI32EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_CMD_SYNC_PRIMITIVE: {
-      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRING: {
-      this->CMD_SYNC_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ENUM: {
-      this->CMD_SYNC_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ARRAY: {
-      this->CMD_SYNC_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRUCT: {
-      this->CMD_SYNC_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED: {
-      this->CMD_GUARDED_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_PRIMITIVE: {
-      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRING: {
-      this->CMD_GUARDED_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ENUM: {
-      this->CMD_GUARDED_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ARRAY: {
-      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRUCT: {
-      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_ASYNC: {
-      this->CMD_ASYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PRIORITY: {
-      this->CMD_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY: {
-      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_DROP: {
-      this->CMD_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_PARAMU32_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMU32_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamString();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMI32EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMI32EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -3130,941 +1935,561 @@ void ActiveSerialComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveSerialComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSerialComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSerialComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveSerialComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveSerialComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveSerialComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveSerialComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveSerialComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSerialComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSerialComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveSerialComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveSerialComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveSerialComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveSerialComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSerialComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSerialComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveSerialComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveSerialComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveSerialComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveSerialComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSerialComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -4073,265 +2498,151 @@ void ActiveSerialComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  serialAsync_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::serialAsync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsync
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsync
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  serialAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::serialAsyncAssert_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncAssert
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncAssert
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  serialAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::serialAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                      Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncBlockPriority
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncBlockPriority
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  serialAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::serialAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                     Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncDropPriority
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncDropPriority
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  serialGuarded_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::serialGuarded_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->serialGuarded_handler(
-    portNum,
-    buffer
-  );
+    // Call handler function
+    this->serialGuarded_handler(portNum, buffer);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-void ActiveSerialComponentBase ::
-  serialSync_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::serialSync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->serialSync_handler(
-    portNum,
-    buffer
-  );
+    // Call handler function
+    this->serialSync_handler(portNum, buffer);
 }
 
 // ----------------------------------------------------------------------
@@ -4342,85 +2653,63 @@ void ActiveSerialComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -4431,40 +2720,21 @@ void ActiveSerialComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  serialAsync_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::serialAsync_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  serialAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::serialAsyncAssert_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  serialAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::serialAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                     Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
-void ActiveSerialComponentBase ::
-  serialAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void ActiveSerialComponentBase ::serialAsyncDropPriority_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4473,209 +2743,103 @@ void ActiveSerialComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveSerialComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveSerialComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveSerialComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSerialComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveSerialComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                   AliasPrim1 u32,
+                                                   AliasPrim2 f32,
+                                                   AliasBool b,
+                                                   const Fw::StringBase& str2,
+                                                   const AliasEnum& e,
+                                                   const AliasArray& a,
+                                                   const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveSerialComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveSerialComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveSerialComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSerialComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveSerialComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::typedOut_out(FwIndexType portNum,
+                                              U32 u32,
+                                              F32 f32,
+                                              bool b,
+                                              const Fw::StringBase& str1,
+                                              const E& e,
+                                              const A& a,
+                                              const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveSerialComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveSerialComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str2,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -4686,24 +2850,12 @@ F32 ActiveSerialComponentBase ::
 // Invocation functions for serial output ports
 // ----------------------------------------------------------------------
 
-Fw::SerializeStatus ActiveSerialComponentBase ::
-  serialOut_out(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::SerializeStatus ActiveSerialComponentBase ::serialOut_out(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_serialOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_serialOut_OutputPort[portNum].invokeSerial(
-    buffer
-  );
+    FW_ASSERT(this->m_serialOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_serialOut_OutputPort[portNum].invokeSerial(buffer);
 }
 
 #endif
@@ -4712,264 +2864,162 @@ Fw::SerializeStatus ActiveSerialComponentBase ::
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  internalArray_internalInterfaceInvoke(const A& a)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  internalEnum_internalInterfaceInvoke(const E& e)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  internalPrimitive_internalInterfaceInvoke(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  internalPriorityDrop_internalInterfaceInvoke()
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  internalString_internalInterfaceInvoke(
-      const Fw::InternalInterfaceString& str1,
-      const Fw::InternalInterfaceString& str2
-  )
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
+                                                                        const Fw::InternalInterfaceString& str2) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(str1);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(str1);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  internalStruct_internalInterfaceInvoke(const S& s)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveSerialComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -4978,965 +3028,619 @@ void ActiveSerialComponentBase ::
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  CMD_SYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveSerialComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void ActiveSerialComponentBase ::
-  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 }
 
-void ActiveSerialComponentBase ::
-  CMD_SYNC_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 }
 
-void ActiveSerialComponentBase ::
-  CMD_SYNC_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
 }
 
-void ActiveSerialComponentBase ::
-  CMD_SYNC_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                               U32 cmdSeq,
+                                                               Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
 }
 
-void ActiveSerialComponentBase ::
-  CMD_SYNC_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
 }
 
-void ActiveSerialComponentBase ::
-  CMD_GUARDED_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveSerialComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveSerialComponentBase ::
-  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                      U32 cmdSeq,
+                                                                      Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveSerialComponentBase ::
-  CMD_GUARDED_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveSerialComponentBase ::
-  CMD_GUARDED_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveSerialComponentBase ::
-  CMD_GUARDED_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveSerialComponentBase ::
-  CMD_GUARDED_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
 
-  this->unLock();
+    this->unLock();
 }
 
-void ActiveSerialComponentBase ::
-  CMD_ASYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
+void ActiveSerialComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  CMD_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+void ActiveSerialComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                    U32 cmdSeq,
+                                                                    Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  CMD_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+void ActiveSerialComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
+                                                                         U32 cmdSeq,
+                                                                         Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -5947,782 +3651,508 @@ void ActiveSerialComponentBase ::
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  CMD_ASYNC_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveSerialComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveSerialComponentBase ::
-  CMD_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveSerialComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveSerialComponentBase ::
-  CMD_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveSerialComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void ActiveSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  log_ACTIVITY_HI_EventActivityHigh() const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
+void ActiveSerialComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
 
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logBuff
-    );
-  }
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
+    }
 
-  // Emit the event on the text log port
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity High occurred";
+        const char* _formatString = "(%s) %s: Event Activity High occurred";
 #else
-    const char* _formatString =
-      "%s: Event Activity High occurred";
+        const char* _formatString = "%s: Event Activity High occurred";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventActivityHigh "
-    );
+                          "EventActivityHigh ");
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
+    }
 #endif
 }
 
-void ActiveSerialComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  // Check throttle value
-  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventActivityLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(3));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(F32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U8))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#else
-    const char* _formatString =
-      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventActivityLowThrottled ",
-      u32,
-      static_cast<F64>(f32),
-      b
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveSerialComponentBase ::
-  log_COMMAND_EventCommand(
-      const Fw::StringBase& str1,
-      const Fw::StringBase& str2
-  ) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(2));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    _status = str1.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = str2.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-    const char* _formatString =
-      "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventCommand ",
-      str1.toChar(),
-      str2.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveSerialComponentBase ::
-  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(E::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-    Fw::String eStr;
-    e.toString(eStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventDiagnostic ",
-      eStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveSerialComponentBase ::
-  log_FATAL_EventFatalThrottled(const A& a)
-{
-  // Check throttle value
-  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventFatalThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serializeFrom(static_cast<U8>(4));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = _logBuff.serializeFrom(static_cast<U32>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(A::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Fatal occurred with argument: %s";
-#endif
-
-    Fw::String aStr;
-    a.toString(aStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventFatalThrottled ",
-      aStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveSerialComponentBase ::
-  log_WARNING_HI_EventWarningHigh(const S& s) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(S::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Warning High occurred with argument: %s";
-#endif
-
-    Fw::String sStr;
-    s.toString(sStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningHigh ",
-      sStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled()
-{
-  // Check throttle value
-  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventWarningLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
-#else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningLowThrottled "
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void ActiveSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval()
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-  // Check throttle value & throttle timeout
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
-    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-      // The counter has overflowed, check if time interval has passed
-      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
-        // Reset the count
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
-      } else {
-        // Throttle the event
+void ActiveSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
+    // Check throttle value
+    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
         return;
-      }
+    } else {
+        this->m_EventActivityLowThrottledThrottle++;
     }
 
-    // Reset the throttle time if needed
-    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-      // This is the first event, reset the throttle time
-      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
     }
 
-    // Increment the count
-    this->m_EventWarningLowThrottledIntervalThrottle++;
-  }
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(3));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(u32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Emit the event on the text log port
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(f32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(b);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
+        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
+        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventWarningLowThrottledInterval "
-    );
+                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
+    }
+#endif
+}
+
+void ActiveSerialComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
+                                                          const Fw::StringBase& str2) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(2));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
+                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventCommand ", str1.toChar(), str2.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
+    }
+#endif
+}
+
+void ActiveSerialComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(e);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+        Fw::String eStr;
+        e.toString(eStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventDiagnostic ", eStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
+    }
+#endif
+}
+
+void ActiveSerialComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
+    // Check throttle value
+    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventFatalThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+        _status = _logBuff.serializeFrom(static_cast<U8>(4));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = _logBuff.serializeFrom(static_cast<U32>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(a);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
+#endif
+
+        Fw::String aStr;
+        a.toString(aStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventFatalThrottled ", aStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
+    }
+#endif
+}
+
+void ActiveSerialComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(s);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
+#endif
+
+        Fw::String sStr;
+        s.toString(sStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningHigh ", sStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
+    }
+#endif
+}
+
+void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
+    // Check throttle value
+    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventWarningLowThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottled ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
+#endif
+}
+
+void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+    // Check throttle value & throttle timeout
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+            // The counter has overflowed, check if time interval has passed
+            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
+                Fw::TimeInterval(10, 0)) {
+                // Reset the count
+                this->m_EventWarningLowThrottledIntervalThrottle = 0;
+            } else {
+                // Throttle the event
+                return;
+            }
+        }
+
+        // Reset the throttle time if needed
+        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+            // This is the first event, reset the throttle time
+            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+        }
+
+        // Increment the count
+        this->m_EventWarningLowThrottledIntervalThrottle++;
+    }
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottledInterval ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
 #endif
 }
 
@@ -6730,662 +4160,438 @@ void ActiveSerialComponentBase ::
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventActivityLowThrottledThrottle = 0;
-}
-
-void ActiveSerialComponentBase ::
-  log_FATAL_EventFatalThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventFatalThrottledThrottle = 0;
-}
-
-void ActiveSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventWarningLowThrottledThrottle = 0;
-}
-
-void ActiveSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
-{
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
+void ActiveSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
     // Reset throttle counter
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    this->m_EventActivityLowThrottledThrottle = 0;
+}
 
-    // Reset the throttle time
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-  }
+void ActiveSerialComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventFatalThrottledThrottle = 0;
+}
+
+void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledThrottle = 0;
+}
+
+void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        // Reset throttle counter
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+
+        // Reset the throttle time
+        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  tlmWrite(
-      FwChanIdType id,
-      Fw::TlmBuffer& _tlmBuff,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    if (
-      this->isConnected_timeGetOut_OutputPort(0) &&
-      (_tlmTime ==  Fw::ZERO_TIME)
-    ) {
-      this->timeGetOut_out(0, _tlmTime);
+void ActiveSerialComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
+            this->timeGetOut_out(0, _tlmTime);
+        }
+
+        FwChanIdType _id;
+        _id = this->getIdBase() + id;
+
+        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
     }
-
-    FwChanIdType _id;
-    _id = this->getIdBase() + id;
-
-    this->tlmOut_out(
-      0,
-      _id,
-      _tlmTime,
-      _tlmBuff
-    );
-  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelU32Format(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+void ActiveSerialComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-    this->tlmWrite(
-      CHANNELID_CHANNELU32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelF32Format(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelStringFormat(
-      const Fw::StringBase& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serializeTo(
-      _tlmBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRINGFORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelEnum(
-      const E& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUM,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelArrayFreq(
-      const A& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELARRAYFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelStructFreq(
-      const S& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRUCTFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelU32Limits(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelF32Limits(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelF64(
-      F64 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF64,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelU32OnChange(
-      U32 arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelU32OnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelU32OnChange) {
-      return;
+        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
     }
-    else {
-      this->m_last_ChannelU32OnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelU32OnChange = false;
-    this->m_last_ChannelU32OnChange = arg;
-  }
-
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32ONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
 }
 
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelEnumOnChange(
-      const E& arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelEnumOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelEnumOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelEnumOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelEnumOnChange = false;
-    this->m_last_ChannelEnumOnChange = arg;
-  }
+void ActiveSerialComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUMONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
+    }
 }
 
-void ActiveSerialComponentBase ::
-  tlmWrite_ChannelBoolOnChange(
-      bool arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelBoolOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelBoolOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelBoolOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelBoolOnChange = false;
-    this->m_last_ChannelBoolOnChange = arg;
-  }
+void ActiveSerialComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat =
+            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
+                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
+    }
+}
 
-    this->tlmWrite(
-      CHANNELID_CHANNELBOOLONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+void ActiveSerialComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelU32OnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelU32OnChange) {
+            return;
+        } else {
+            this->m_last_ChannelU32OnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelU32OnChange = false;
+        this->m_last_ChannelU32OnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelEnumOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelEnumOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelEnumOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelEnumOnChange = false;
+        this->m_last_ChannelEnumOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveSerialComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelBoolOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelBoolOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelBoolOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelBoolOnChange = false;
+        this->m_last_ChannelBoolOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  parameterUpdated(FwPrmIdType id)
-{
-  // Do nothing by default
+void ActiveSerialComponentBase ::parameterUpdated(FwPrmIdType id) {
+    // Do nothing by default
 }
 
-void ActiveSerialComponentBase ::
-  parametersLoaded()
-{
-  // Do nothing by default
+void ActiveSerialComponentBase ::parametersLoaded() {
+    // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 ActiveSerialComponentBase ::
-  paramGet_ParamU32(Fw::ParamValid& valid)
-{
-  U32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamU32_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamU32;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-F64 ActiveSerialComponentBase ::
-  paramGet_ParamF64(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamF64;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-Fw::ParamString ActiveSerialComponentBase ::
-  paramGet_ParamString(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamString_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamString;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-E ActiveSerialComponentBase ::
-  paramGet_ParamEnum(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnum_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamEnum;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-A ActiveSerialComponentBase ::
-  paramGet_ParamArray(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArray_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamArray;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-S ActiveSerialComponentBase ::
-  paramGet_ParamStruct(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStruct_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamStruct;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-I32 ActiveSerialComponentBase ::
-  paramGet_ParamI32Ext(Fw::ParamValid& valid)
-{
-  I32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamI32Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+U32 ActiveSerialComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
+    U32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamU32_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamU32;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-F64 ActiveSerialComponentBase ::
-  paramGet_ParamF64Ext(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+F64 ActiveSerialComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamF64;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-Fw::ParamString ActiveSerialComponentBase ::
-  paramGet_ParamStringExt(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStringExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+Fw::ParamString ActiveSerialComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamString_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamString;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-E ActiveSerialComponentBase ::
-  paramGet_ParamEnumExt(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnumExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+E ActiveSerialComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnum_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamEnum;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-A ActiveSerialComponentBase ::
-  paramGet_ParamArrayExt(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArrayExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+A ActiveSerialComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArray_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamArray;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-S ActiveSerialComponentBase ::
-  paramGet_ParamStructExt(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStructExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+S ActiveSerialComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStruct_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamStruct;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+I32 ActiveSerialComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
+    I32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamI32Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+F64 ActiveSerialComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+Fw::ParamString ActiveSerialComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStringExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+E ActiveSerialComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnumExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+A ActiveSerialComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArrayExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+S ActiveSerialComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStructExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
-{
-  FW_ASSERT(paramExternalDelegatePtr != nullptr);
-  this->paramDelegatePtr = paramExternalDelegatePtr;
+void ActiveSerialComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
+    FW_ASSERT(paramExternalDelegatePtr != nullptr);
+    this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveSerialComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveSerialComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -7395,1390 +4601,886 @@ Fw::Time ActiveSerialComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveSerialComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveSerialComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveSerialComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
-  doDispatch()
-{
-  U8 _msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer _msg(
-    _msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::doDispatch() {
+    U8 _msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVESERIAL_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVESERIAL_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
-    }
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port serialAsync
-    case SERIALASYNC_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsync_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle async input port serialAsyncAssert
-    case SERIALASYNCASSERT_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncAssert_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle async input port serialAsyncBlockPriority
-    case SERIALASYNCBLOCKPRIORITY_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle async input port serialAsyncDropPriority
-    case SERIALASYNCDROPPRIORITY_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncDropPriority_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle command CMD_ASYNC
-    case CMD_CMD_ASYNC: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port serialAsync
+        case SERIALASYNC_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsync_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncAssert
+        case SERIALASYNCASSERT_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncAssert_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncBlockPriority
+        case SERIALASYNCBLOCKPRIORITY_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncDropPriority
+        case SERIALASYNCDROPPRIORITY_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncDropPriority_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle command CMD_ASYNC
+        case CMD_CMD_ASYNC: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PRIORITY
-    case CMD_CMD_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_PRIORITY
+        case CMD_CMD_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY
-    case CMD_CMD_PARAMS_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY
+        case CMD_CMD_PARAMS_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
-    }
-
-    // Handle command CMD_DROP
-    case CMD_CMD_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_DROP
+        case CMD_CMD_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY_DROP
-    case CMD_CMD_PARAMS_PRIORITY_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_DROP
+        case CMD_CMD_PARAMS_PRIORITY_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
+            break;
+        }
+
+        // Handle internal interface internalArray
+        case INT_IF_INTERNALARRAY: {
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalArray_internalInterfaceHandler(a);
+
+            break;
+        }
+
+        // Handle internal interface internalEnum
+        case INT_IF_INTERNALENUM: {
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalEnum_internalInterfaceHandler(e);
+
+            break;
+        }
+
+        // Handle internal interface internalPrimitive
+        case INT_IF_INTERNALPRIMITIVE: {
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
+
+            break;
+        }
+
+        // Handle internal interface internalPriorityDrop
+        case INT_IF_INTERNALPRIORITYDROP: {
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalPriorityDrop_internalInterfaceHandler();
+
+            break;
+        }
+
+        // Handle internal interface internalString
+        case INT_IF_INTERNALSTRING: {
+            Fw::InternalInterfaceString str1;
+            _deserStatus = _msg.deserializeTo(str1);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            Fw::InternalInterfaceString str2;
+            _deserStatus = _msg.deserializeTo(str2);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalString_internalInterfaceHandler(str1, str2);
+
+            break;
+        }
+
+        // Handle internal interface internalStruct
+        case INT_IF_INTERNALSTRUCT: {
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalStruct_internalInterfaceHandler(s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle internal interface internalArray
-    case INT_IF_INTERNALARRAY: {
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalArray_internalInterfaceHandler(
-        a
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalEnum
-    case INT_IF_INTERNALENUM: {
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalEnum_internalInterfaceHandler(
-        e
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalPrimitive
-    case INT_IF_INTERNALPRIMITIVE: {
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalPrimitive_internalInterfaceHandler(
-        u32,
-        f32,
-        b
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalPriorityDrop
-    case INT_IF_INTERNALPRIORITYDROP: {
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalPriorityDrop_internalInterfaceHandler();
-
-      break;
-    }
-
-    // Handle internal interface internalString
-    case INT_IF_INTERNALSTRING: {
-      Fw::InternalInterfaceString str1;
-      _deserStatus = _msg.deserializeTo(str1);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      Fw::InternalInterfaceString str2;
-      _deserStatus = _msg.deserializeTo(str2);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalString_internalInterfaceHandler(
-        str1,
-        str2
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalStruct
-    case INT_IF_INTERNALSTRUCT: {
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalStruct_internalInterfaceHandler(
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveSerialComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                              FwIndexType portNum,
+                                              FwOpcodeType opCode,
+                                              U32 cmdSeq,
+                                              Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveSerialComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSerialComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveSerialComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveSerialComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSerialComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveSerialComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSerialComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveSerialComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveSerialComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSerialComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveSerialComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveSerialComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveSerialComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveSerialComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveSerialComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveSerialComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveSerialComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveSerialComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveSerialComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str2,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSerialComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                  FwIndexType portNum,
+                                                  U32 u32,
+                                                  F32 f32,
+                                                  bool b,
+                                                  const Fw::StringBase& str1,
+                                                  const E& e,
+                                                  const A& a,
+                                                  const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -8787,94 +5489,52 @@ void ActiveSerialComponentBase ::
 
 #if FW_PORT_SERIALIZATION
 
-void ActiveSerialComponentBase ::
-  m_p_serialAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->serialAsync_handlerBase(
-    portNum,
-    buffer
-  );
+void ActiveSerialComponentBase ::m_p_serialAsync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->serialAsync_handlerBase(portNum, buffer);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_serialAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->serialAsyncAssert_handlerBase(
-    portNum,
-    buffer
-  );
+void ActiveSerialComponentBase ::m_p_serialAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->serialAsyncAssert_handlerBase(portNum, buffer);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_serialAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->serialAsyncBlockPriority_handlerBase(
-    portNum,
-    buffer
-  );
+void ActiveSerialComponentBase ::m_p_serialAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->serialAsyncBlockPriority_handlerBase(portNum, buffer);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_serialAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->serialAsyncDropPriority_handlerBase(
-    portNum,
-    buffer
-  );
+void ActiveSerialComponentBase ::m_p_serialAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->serialAsyncDropPriority_handlerBase(portNum, buffer);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_serialGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->serialGuarded_handlerBase(
-    portNum,
-    buffer
-  );
+void ActiveSerialComponentBase ::m_p_serialGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->serialGuarded_handlerBase(portNum, buffer);
 }
 
-void ActiveSerialComponentBase ::
-  m_p_serialSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-  compPtr->serialSync_handlerBase(
-    portNum,
-    buffer
-  );
+void ActiveSerialComponentBase ::m_p_serialSync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+    compPtr->serialSync_handlerBase(portNum, buffer);
 }
 
 #endif
@@ -8885,192 +5545,86 @@ void ActiveSerialComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void ActiveSerialComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                    FwOpcodeType opCode,
+                                                    U32 cmdSeq,
+                                                    const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-void ActiveSerialComponentBase ::
-  eventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::LogBuffer& args
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::eventOut_out(FwIndexType portNum,
+                                              FwEventIdType id,
+                                              Fw::Time& timeTag,
+                                              const Fw::LogSeverity& severity,
+                                              Fw::LogBuffer& args) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_eventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_eventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    args
-  );
+    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
 }
 
-Fw::ParamValid ActiveSerialComponentBase ::
-  prmGetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::ParamValid ActiveSerialComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                         FwPrmIdType id,
+                                                         Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_prmGetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void ActiveSerialComponentBase ::
-  prmSetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmSetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_prmSetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void ActiveSerialComponentBase ::
-  textEventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::TextLogString& text
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::textEventOut_out(FwIndexType portNum,
+                                                  FwEventIdType id,
+                                                  Fw::Time& timeTag,
+                                                  const Fw::LogSeverity& severity,
+                                                  Fw::TextLogString& text) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_textEventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_textEventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    text
-  );
+    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
 }
 
 #endif
 
-void ActiveSerialComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
-void ActiveSerialComponentBase ::
-  tlmOut_out(
-      FwIndexType portNum,
-      FwChanIdType id,
-      Fw::Time& timeTag,
-      Fw::TlmBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSerialComponentBase ::tlmOut_out(FwIndexType portNum,
+                                            FwChanIdType id,
+                                            Fw::Time& timeTag,
+                                            Fw::TlmBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_tlmOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_tlmOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    val
-  );
+    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
 }
 
 #endif
@@ -9079,684 +5633,552 @@ void ActiveSerialComponentBase ::
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamU32(Fw::SerialBufferBase& val)
-{
-  U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
+    U32 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamU32 = _localVal;
-  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamU32 = _localVal;
+    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMU32);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMU32);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamF64(Fw::SerialBufferBase& val)
-{
-  F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
+    F64 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamF64 = _localVal;
-  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamF64 = _localVal;
+    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMF64);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMF64);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamString(Fw::SerialBufferBase& val)
-{
-  Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
+    Fw::ParamString _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamString = _localVal;
-  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamString = _localVal;
+    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamEnum(Fw::SerialBufferBase& val)
-{
-  E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
+    E _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamEnum = _localVal;
-  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamEnum = _localVal;
+    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMENUM);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamArray(Fw::SerialBufferBase& val)
-{
-  A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
+    A _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamArray = _localVal;
-  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamArray = _localVal;
+    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamStruct(Fw::SerialBufferBase& val)
-{
-  S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
+    S _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamStruct = _localVal;
-  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamStruct = _localVal;
+    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMI32EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMI32EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMF64EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMF64EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRINGEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMENUMEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMENUMEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMARRAYEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRUCTEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    }
+    return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamU32()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamU32);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamU32() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamU32);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamF64()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamF64);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamF64() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamF64);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamString()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamString);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamString() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamString);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamEnum()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamEnum() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamArray()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamArray);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamArray() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamArray);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamStruct()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamStruct() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamI32Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamI32Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamF64Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamF64Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamStringExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamStringExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamEnumExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamEnumExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamArrayExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamArrayExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::
-  paramSave_ParamStructExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamStructExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -88,9 +88,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVESERIAL_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -35,11 +35,11 @@ enum MsgTypeEnum {
     INT_IF_INTERNALPRIORITYDROP,
     INT_IF_INTERNALSTRING,
     INT_IF_INTERNALSTRUCT,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -47,683 +47,1120 @@ union BuffUnion {
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
     // Size of internalArray argument list
-    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
+    BYTE internalArrayIntIfSize[
+      A::SERIALIZED_SIZE
+    ];
     // Size of internalEnum argument list
-    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
+    BYTE internalEnumIntIfSize[
+      E::SERIALIZED_SIZE
+    ];
     // Size of internalPrimitive argument list
-    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
+    BYTE internalPrimitiveIntIfSize[
+      sizeof(U32) +
+      sizeof(F32) +
+      sizeof(U8)
+    ];
     // Size of internalString argument list
-    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
-                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
+    BYTE internalStringIntIfSize[
+      Fw::InternalInterfaceString::SERIALIZED_SIZE +
+      Fw::InternalInterfaceString::SERIALIZED_SIZE
+    ];
     // Size of internalStruct argument list
-    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
-};
+    BYTE internalStructIntIfSize[
+      S::SERIALIZED_SIZE
+    ];
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveSerialComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwSizeType msgSize,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts()); port++) {
-        this->m_serialAsync_InputPort[port].init();
-        this->m_serialAsync_InputPort[port].addCallComp(this, m_p_serialAsync_in);
-        this->m_serialAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts()); port++) {
-        this->m_serialAsyncAssert_InputPort[port].init();
-        this->m_serialAsyncAssert_InputPort[port].addCallComp(this, m_p_serialAsyncAssert_in);
-        this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_serialAsyncBlockPriority_InputPort[port].init();
-        this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_serialAsyncBlockPriority_in);
-        this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port serialAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts());
+    port++
+  ) {
+    this->m_serialAsync_InputPort[port].init();
+    this->m_serialAsync_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsync_in
+    );
+    this->m_serialAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_serialAsyncDropPriority_InputPort[port].init();
-        this->m_serialAsyncDropPriority_InputPort[port].addCallComp(this, m_p_serialAsyncDropPriority_in);
-        this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port serialAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncAssert_InputPort[port].init();
+    this->m_serialAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncAssert_in
+    );
+    this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts()); port++) {
-        this->m_serialGuarded_InputPort[port].init();
-        this->m_serialGuarded_InputPort[port].addCallComp(this, m_p_serialGuarded_in);
-        this->m_serialGuarded_InputPort[port].setPortNum(port);
+  // Connect input port serialAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncBlockPriority_InputPort[port].init();
+    this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncBlockPriority_in
+    );
+    this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts()); port++) {
-        this->m_serialSync_InputPort[port].init();
-        this->m_serialSync_InputPort[port].addCallComp(this, m_p_serialSync_in);
-        this->m_serialSync_InputPort[port].setPortNum(port);
+  // Connect input port serialAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncDropPriority_InputPort[port].init();
+    this->m_serialAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncDropPriority_in
+    );
+    this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port serialGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts());
+    port++
+  ) {
+    this->m_serialGuarded_InputPort[port].init();
+    this->m_serialGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_serialGuarded_in
+    );
+    this->m_serialGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port serialSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts());
+    port++
+  ) {
+    this->m_serialSync_InputPort[port].init();
+    this->m_serialSync_InputPort[port].addCallComp(
+      this,
+      m_p_serialSync_in
+    );
+    this->m_serialSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port serialOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts()); port++) {
-        this->m_serialOut_OutputPort[port].init();
+  // Connect output port serialOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts());
+    port++
+  ) {
+    this->m_serialOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Passed-in size added to port number and message type enumeration sizes.
-    this->m_msgSize = FW_MAX(
-        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+  // Passed-in size added to port number and message type enumeration sizes.
+  this->m_msgSize = FW_MAX(
+    msgSize +
+    static_cast<FwSizeType>(sizeof(FwIndexType)) +
+    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
 
-    // Create the queue
-    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -732,10 +1169,15 @@ void ActiveSerialComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize,
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveSerialComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveSerialComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -746,139 +1188,213 @@ Fw::InputCmdPort* ActiveSerialComponentBase ::get_cmdIn_InputPort(FwIndexType po
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveSerialComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveSerialComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveSerialComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveSerialComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSerialComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSerialComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveSerialComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveSerialComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSerialComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveSerialComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveSerialComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveSerialComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveSerialComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveSerialComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveSerialComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSerialComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSerialComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSerialComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSerialComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSerialComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSerialComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSerialComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSerialComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -889,46 +1405,70 @@ Ports::InputTypedPort* ActiveSerialComponentBase ::get_typedSync_InputPort(FwInd
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* ActiveSerialComponentBase ::
+  get_serialAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsync_InputPort[portNum];
+  return &this->m_serialAsync_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* ActiveSerialComponentBase ::
+  get_serialAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncAssert_InputPort[portNum];
+  return &this->m_serialAsyncAssert_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* ActiveSerialComponentBase ::
+  get_serialAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncBlockPriority_InputPort[portNum];
+  return &this->m_serialAsyncBlockPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* ActiveSerialComponentBase ::
+  get_serialAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncDropPriority_InputPort[portNum];
+  return &this->m_serialAsyncDropPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* ActiveSerialComponentBase ::
+  get_serialGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialGuarded_InputPort[portNum];
+  return &this->m_serialGuarded_InputPort[portNum];
 }
 
-Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* ActiveSerialComponentBase ::
+  get_serialSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialSync_InputPort[portNum];
+  return &this->m_serialSync_InputPort[portNum];
 }
 
 #endif
@@ -939,62 +1479,120 @@ Fw::InputSerializePort* ActiveSerialComponentBase ::get_serialSync_InputPort(FwI
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1005,64 +1603,116 @@ void ActiveSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSerialComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1073,55 +1723,106 @@ void ActiveSerialComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portN
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1132,24 +1833,46 @@ void ActiveSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1160,11 +1883,18 @@ void ActiveSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw
 // Connect typed and serial input ports to serial output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::set_serialOut_OutputPort(FwIndexType portNum, Fw::InputPortBase* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  set_serialOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPortBase* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1173,368 +1903,586 @@ void ActiveSerialComponentBase ::set_serialOut_OutputPort(FwIndexType portNum, F
 // Command registration
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void ActiveSerialComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_ASYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+  );
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::loadParameters() {
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void ActiveSerialComponentBase ::
+  loadParameters()
+{
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-    FwPrmIdType _id{};
-    Fw::ParamBuffer _paramBuffer;
+  FwPrmIdType _id{};
+  Fw::ParamBuffer _paramBuffer;
 
-    _id = _baseId + PARAMID_PARAMU32;
+  _id = _baseId + PARAMID_PARAMU32;
 
-    // Get serialized parameter ParamU32
-    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamU32
+  this->m_param_ParamU32_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMF64;
-
-    // Get serialized parameter ParamF64
-    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRING;
-
-    // Get serialized parameter ParamString
-    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamString = Fw::String("default");
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMENUM;
-
-    // Get serialized parameter ParamEnum
-    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMARRAY;
-
-    // Get serialized parameter ParamArray
-    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamArray = A({1, 2, 3});
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCT;
-
-    // Get serialized parameter ParamStruct
-    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMI32EXT;
-
-    // Get serialized parameter ParamI32Ext
-    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMF64EXT;
+  _id = _baseId + PARAMID_PARAMF64;
 
-    // Get serialized parameter ParamF64Ext
-    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamF64
+  this->m_param_ParamF64_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRINGEXT;
+  _id = _baseId + PARAMID_PARAMSTRING;
 
-    // Get serialized parameter ParamStringExt
-    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamString
+  this->m_param_ParamString_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-        Fw::String _val = Fw::String("external default");
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMENUMEXT;
-
-    // Get serialized parameter ParamEnumExt
-    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
+  }
+  else {
+    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamString = Fw::String("default");
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMARRAYEXT;
+  _id = _baseId + PARAMID_PARAMENUM;
 
-    // Get serialized parameter ParamArrayExt
-    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamEnum
+  this->m_param_ParamEnum_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-        A _val = A({1, 2, 3});
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-    // Get serialized parameter ParamStructExt
-    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
-                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parametersLoaded();
+  _id = _baseId + PARAMID_PARAMARRAY;
+
+  // Get serialized parameter ParamArray
+  this->m_param_ParamArray_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamArray = A({1, 2, 3});
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRUCT;
+
+  // Get serialized parameter ParamStruct
+  this->m_param_ParamStruct_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMI32EXT;
+
+  // Get serialized parameter ParamI32Ext
+  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMI32EXT,
+    this->m_param_ParamI32Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMF64EXT;
+
+  // Get serialized parameter ParamF64Ext
+  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMF64EXT,
+    this->m_param_ParamF64Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRINGEXT;
+
+  // Get serialized parameter ParamStringExt
+  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+    Fw::String _val = Fw::String("external default");
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMENUMEXT;
+
+  // Get serialized parameter ParamEnumExt
+  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMENUMEXT,
+    this->m_param_ParamEnumExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+  // Get serialized parameter ParamArrayExt
+  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+    A _val = A({1, 2, 3});
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+  // Get serialized parameter ParamStructExt
+  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMSTRUCTEXT,
+    this->m_param_ParamStructExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  // Call notifier
+  this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveSerialComponentBase ::ActiveSerialComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {
-    this->m_EventActivityLowThrottledThrottle = 0;
-    this->m_EventFatalThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+ActiveSerialComponentBase ::
+  ActiveSerialComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
+  this->m_EventActivityLowThrottledThrottle = 0;
+  this->m_EventFatalThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-ActiveSerialComponentBase ::~ActiveSerialComponentBase() {}
+ActiveSerialComponentBase ::
+  ~ActiveSerialComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1542,62 +2490,96 @@ ActiveSerialComponentBase ::~ActiveSerialComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSerialComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveSerialComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveSerialComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1608,59 +2590,92 @@ bool ActiveSerialComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portN
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSerialComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSerialComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1671,11 +2686,15 @@ bool ActiveSerialComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexTy
 // Connection status queries for serial output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSerialComponentBase ::isConnected_serialOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSerialComponentBase ::
+  isConnected_serialOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_serialOut_OutputPort[portNum].isConnected();
+  return this->m_serialOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1686,247 +2705,416 @@ bool ActiveSerialComponentBase ::isConnected_serialOut_OutputPort(FwIndexType po
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveSerialComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_CMD_SYNC: {
-            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_CMD_SYNC_PRIMITIVE: {
-            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRING: {
-            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ENUM: {
-            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ARRAY: {
-            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRUCT: {
-            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED: {
-            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_PRIMITIVE: {
-            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRING: {
-            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ENUM: {
-            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ARRAY: {
-            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRUCT: {
-            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_ASYNC: {
-            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PRIORITY: {
-            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY: {
-            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_DROP: {
-            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_PARAMU32_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMU32_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamString();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMI32EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMI32EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_CMD_SYNC: {
+      this->CMD_SYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
     }
+
+    case OPCODE_CMD_SYNC_PRIMITIVE: {
+      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRING: {
+      this->CMD_SYNC_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ENUM: {
+      this->CMD_SYNC_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ARRAY: {
+      this->CMD_SYNC_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRUCT: {
+      this->CMD_SYNC_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED: {
+      this->CMD_GUARDED_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_PRIMITIVE: {
+      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRING: {
+      this->CMD_GUARDED_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ENUM: {
+      this->CMD_GUARDED_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ARRAY: {
+      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRUCT: {
+      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_ASYNC: {
+      this->CMD_ASYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PRIORITY: {
+      this->CMD_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY: {
+      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_DROP: {
+      this->CMD_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_PARAMU32_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMU32_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamString();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMI32EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMI32EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1935,561 +3123,941 @@ void ActiveSerialComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveSerialComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSerialComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSerialComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveSerialComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveSerialComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveSerialComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveSerialComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveSerialComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSerialComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSerialComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveSerialComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveSerialComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveSerialComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveSerialComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSerialComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSerialComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveSerialComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveSerialComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveSerialComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveSerialComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSerialComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2498,151 +4066,265 @@ void ActiveSerialComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::serialAsync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  serialAsync_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsync
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsync
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::serialAsyncAssert_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  serialAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncAssert
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncAssert
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::serialAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                      Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  serialAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncBlockPriority
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncBlockPriority
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::serialAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                     Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  serialAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncDropPriority
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncDropPriority
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::serialGuarded_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  serialGuarded_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->serialGuarded_handler(portNum, buffer);
+  // Call handler function
+  this->serialGuarded_handler(
+    portNum,
+    buffer
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-void ActiveSerialComponentBase ::serialSync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  serialSync_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->serialSync_handler(portNum, buffer);
+  // Call handler function
+  this->serialSync_handler(
+    portNum,
+    buffer
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2653,63 +4335,85 @@ void ActiveSerialComponentBase ::serialSync_handlerBase(FwIndexType portNum, Fw:
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -2720,21 +4424,40 @@ void ActiveSerialComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType p
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::serialAsync_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  serialAsync_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::serialAsyncAssert_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  serialAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::serialAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                     Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  serialAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSerialComponentBase ::serialAsyncDropPriority_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void ActiveSerialComponentBase ::
+  serialAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2743,103 +4466,209 @@ void ActiveSerialComponentBase ::serialAsyncDropPriority_preMsgHook(FwIndexType 
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveSerialComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveSerialComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveSerialComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSerialComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveSerialComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                   AliasPrim1 u32,
-                                                   AliasPrim2 f32,
-                                                   AliasBool b,
-                                                   const Fw::StringBase& str2,
-                                                   const AliasEnum& e,
-                                                   const AliasArray& a,
-                                                   const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveSerialComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveSerialComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveSerialComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSerialComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::typedOut_out(FwIndexType portNum,
-                                              U32 u32,
-                                              F32 f32,
-                                              bool b,
-                                              const Fw::StringBase& str1,
-                                              const E& e,
-                                              const A& a,
-                                              const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveSerialComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str2,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveSerialComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2850,12 +4679,24 @@ F32 ActiveSerialComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Invocation functions for serial output ports
 // ----------------------------------------------------------------------
 
-Fw::SerializeStatus ActiveSerialComponentBase ::serialOut_out(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::SerializeStatus ActiveSerialComponentBase ::
+  serialOut_out(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_serialOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_serialOut_OutputPort[portNum].invokeSerial(buffer);
+  FW_ASSERT(
+    this->m_serialOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_serialOut_OutputPort[portNum].invokeSerial(
+    buffer
+  );
 }
 
 #endif
@@ -2864,162 +4705,264 @@ Fw::SerializeStatus ActiveSerialComponentBase ::serialOut_out(FwIndexType portNu
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  internalArray_internalInterfaceInvoke(const A& a)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  internalEnum_internalInterfaceInvoke(const E& e)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  internalPrimitive_internalInterfaceInvoke(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  internalPriorityDrop_internalInterfaceInvoke()
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
-                                                                        const Fw::InternalInterfaceString& str2) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  internalString_internalInterfaceInvoke(
+      const Fw::InternalInterfaceString& str1,
+      const Fw::InternalInterfaceString& str2
+  )
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(str1);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(str1);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSerialComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  internalStruct_internalInterfaceInvoke(const S& s)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void ActiveSerialComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -3028,619 +4971,965 @@ void ActiveSerialComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void ActiveSerialComponentBase ::
+  CMD_SYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void ActiveSerialComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
+  this->CMD_SYNC_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 }
 
-void ActiveSerialComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_SYNC_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_SYNC_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 }
 
-void ActiveSerialComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_SYNC_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_SYNC_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 }
 
-void ActiveSerialComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                               U32 cmdSeq,
-                                                               Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_SYNC_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_SYNC_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 }
 
-void ActiveSerialComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_SYNC_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_SYNC_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void ActiveSerialComponentBase ::
+  CMD_GUARDED_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveSerialComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                      U32 cmdSeq,
-                                                                      Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
-
-#if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-#endif
-
-    this->lock();
-
-    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
-
-    this->unLock();
-}
-
-void ActiveSerialComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Reset the buffer
-    args.resetDeser();
-
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveSerialComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_GUARDED_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
+
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_GUARDED_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveSerialComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_GUARDED_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_GUARDED_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveSerialComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void ActiveSerialComponentBase ::
+  CMD_GUARDED_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_GUARDED_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void ActiveSerialComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
+void ActiveSerialComponentBase ::
+  CMD_GUARDED_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Reset the buffer
+  args.resetDeser();
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void ActiveSerialComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                    U32 cmdSeq,
-                                                                    Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void ActiveSerialComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+#if FW_CMD_CHECK_RESIDUAL
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
+#endif
+
+  this->lock();
+
+  this->CMD_GUARDED_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
+
+  this->unLock();
 }
 
-void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
-                                                                         U32 cmdSeq,
-                                                                         Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
+void ActiveSerialComponentBase ::
+  CMD_ASYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+void ActiveSerialComponentBase ::
+  CMD_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void ActiveSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void ActiveSerialComponentBase ::
+  CMD_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void ActiveSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -3651,508 +5940,782 @@ void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcod
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveSerialComponentBase ::
+  CMD_ASYNC_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveSerialComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveSerialComponentBase ::
+  CMD_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveSerialComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveSerialComponentBase ::
+  CMD_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void ActiveSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void ActiveSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
+void ActiveSerialComponentBase ::
+  log_ACTIVITY_HI_EventActivityHigh() const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
-    }
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logBuff
+    );
+  }
 
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity High occurred";
+    const char* _formatString =
+      "(%s) %s: Event Activity High occurred";
 #else
-        const char* _formatString = "%s: Event Activity High occurred";
+    const char* _formatString =
+      "%s: Event Activity High occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityHigh ");
+      "EventActivityHigh "
+    );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
-    }
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logString
+    );
+  }
 #endif
 }
 
-void ActiveSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
-    // Check throttle value
-    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+void ActiveSerialComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  // Check throttle value
+  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventActivityLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(u32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(F32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(f32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U8))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(b);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#else
+    const char* _formatString =
+      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventActivityLowThrottled ",
+      u32,
+      static_cast<F64>(f32),
+      b
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveSerialComponentBase ::
+  log_COMMAND_EventCommand(
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
+  ) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    _status = str1.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = str2.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+    const char* _formatString =
+      "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventCommand ",
+      str1.toChar(),
+      str2.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveSerialComponentBase ::
+  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(E::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(e);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+    Fw::String eStr;
+    e.toString(eStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventDiagnostic ",
+      eStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveSerialComponentBase ::
+  log_FATAL_EventFatalThrottled(const A& a)
+{
+  // Check throttle value
+  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventFatalThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(A::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(a);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Fatal occurred with argument: %s";
+#endif
+
+    Fw::String aStr;
+    a.toString(aStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventFatalThrottled ",
+      aStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveSerialComponentBase ::
+  log_WARNING_HI_EventWarningHigh(const S& s) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(S::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(s);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Warning High occurred with argument: %s";
+#endif
+
+    Fw::String sStr;
+    s.toString(sStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningHigh ",
+      sStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled()
+{
+  // Check throttle value
+  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventWarningLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
+#else
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningLowThrottled "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void ActiveSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval()
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+  // Check throttle value & throttle timeout
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
+
+    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+      // The counter has overflowed, check if time interval has passed
+      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
+        // Reset the count
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+      } else {
+        // Throttle the event
         return;
-    } else {
-        this->m_EventActivityLowThrottledThrottle++;
+      }
     }
 
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+    // Reset the throttle time if needed
+    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+      // This is the first event, reset the throttle time
+      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
     }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+    // Increment the count
+    this->m_EventWarningLowThrottledIntervalThrottle++;
+  }
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(3));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
-        _status = _logBuff.serializeFrom(u32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(f32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(b);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
 #else
-        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
-    }
-#endif
-}
-
-void ActiveSerialComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
-                                                          const Fw::StringBase& str2) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(2));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
-                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventCommand ", str1.toChar(), str2.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
-    }
-#endif
-}
-
-void ActiveSerialComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(e);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-        Fw::String eStr;
-        e.toString(eStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventDiagnostic ", eStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
-    }
-#endif
-}
-
-void ActiveSerialComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
-    // Check throttle value
-    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventFatalThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-        _status = _logBuff.serializeFrom(static_cast<U8>(4));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = _logBuff.serializeFrom(static_cast<U32>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(a);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
-#endif
-
-        Fw::String aStr;
-        a.toString(aStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventFatalThrottled ", aStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
-    }
-#endif
-}
-
-void ActiveSerialComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(s);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
-#endif
-
-        Fw::String sStr;
-        s.toString(sStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningHigh ", sStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
-    }
-#endif
-}
-
-void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
-    // Check throttle value
-    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventWarningLowThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottled ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
-#endif
-}
-
-void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-    // Check throttle value & throttle timeout
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
-
-        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-            // The counter has overflowed, check if time interval has passed
-            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
-                Fw::TimeInterval(10, 0)) {
-                // Reset the count
-                this->m_EventWarningLowThrottledIntervalThrottle = 0;
-            } else {
-                // Throttle the event
-                return;
-            }
-        }
-
-        // Reset the throttle time if needed
-        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-            // This is the first event, reset the throttle time
-            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
-        }
-
-        // Increment the count
-        this->m_EventWarningLowThrottledIntervalThrottle++;
-    }
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottledInterval ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
+      "EventWarningLowThrottledInterval "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
 #endif
 }
 
@@ -4160,438 +6723,662 @@ void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventActivityLowThrottledThrottle = 0;
+void ActiveSerialComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventActivityLowThrottledThrottle = 0;
 }
 
-void ActiveSerialComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventFatalThrottledThrottle = 0;
+void ActiveSerialComponentBase ::
+  log_FATAL_EventFatalThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventFatalThrottledThrottle = 0;
 }
 
-void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventWarningLowThrottledThrottle = 0;
+void ActiveSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventWarningLowThrottledThrottle = 0;
 }
 
-void ActiveSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
+void ActiveSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
+{
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
 
-        // Reset throttle counter
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-        // Reset the throttle time
-        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-    }
+    // Reset the throttle time
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
-            this->timeGetOut_out(0, _tlmTime);
-        }
-
-        FwChanIdType _id;
-        _id = this->getIdBase() + id;
-
-        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
+void ActiveSerialComponentBase ::
+  tlmWrite(
+      FwChanIdType id,
+      Fw::TlmBuffer& _tlmBuff,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    if (
+      this->isConnected_timeGetOut_OutputPort(0) &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->timeGetOut_out(0, _tlmTime);
     }
+
+    FwChanIdType _id;
+    _id = this->getIdBase() + id;
+
+    this->tlmOut_out(
+      0,
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelU32Format(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelF32Format(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat =
-            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
-                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelStringFormat(
+      const Fw::StringBase& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = arg.serializeTo(
+      _tlmBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRINGFORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelEnum(
+      const E& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELENUM,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelArrayFreq(
+      const A& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELARRAYFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelStructFreq(
+      const S& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRUCTFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelU32Limits(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelF32Limits(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelF64(
+      F64 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF64,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelU32OnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelU32OnChange) {
-            return;
-        } else {
-            this->m_last_ChannelU32OnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelU32OnChange = false;
-        this->m_last_ChannelU32OnChange = arg;
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelU32OnChange(
+      U32 arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelU32OnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelU32OnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelU32OnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelU32OnChange = false;
+    this->m_last_ChannelU32OnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELU32ONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelEnumOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelEnumOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelEnumOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelEnumOnChange = false;
-        this->m_last_ChannelEnumOnChange = arg;
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelEnumOnChange(
+      const E& arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelEnumOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelEnumOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelEnumOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelEnumOnChange = false;
+    this->m_last_ChannelEnumOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELENUMONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveSerialComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelBoolOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelBoolOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelBoolOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelBoolOnChange = false;
-        this->m_last_ChannelBoolOnChange = arg;
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELBOOLONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::parameterUpdated(FwPrmIdType id) {
-    // Do nothing by default
+void ActiveSerialComponentBase ::
+  parameterUpdated(FwPrmIdType id)
+{
+  // Do nothing by default
 }
 
-void ActiveSerialComponentBase ::parametersLoaded() {
-    // Do nothing by default
+void ActiveSerialComponentBase ::
+  parametersLoaded()
+{
+  // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 ActiveSerialComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
-    U32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamU32_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamU32;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+U32 ActiveSerialComponentBase ::
+  paramGet_ParamU32(Fw::ParamValid& valid)
+{
+  U32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamU32_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamU32;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 ActiveSerialComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamF64;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+F64 ActiveSerialComponentBase ::
+  paramGet_ParamF64(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamF64;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString ActiveSerialComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamString_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamString;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+Fw::ParamString ActiveSerialComponentBase ::
+  paramGet_ParamString(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamString_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamString;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E ActiveSerialComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnum_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamEnum;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+E ActiveSerialComponentBase ::
+  paramGet_ParamEnum(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnum_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamEnum;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A ActiveSerialComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArray_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamArray;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+A ActiveSerialComponentBase ::
+  paramGet_ParamArray(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArray_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamArray;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S ActiveSerialComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStruct_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamStruct;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+S ActiveSerialComponentBase ::
+  paramGet_ParamStruct(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStruct_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamStruct;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-I32 ActiveSerialComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
-    I32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamI32Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+I32 ActiveSerialComponentBase ::
+  paramGet_ParamI32Ext(Fw::ParamValid& valid)
+{
+  I32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamI32Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 ActiveSerialComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+F64 ActiveSerialComponentBase ::
+  paramGet_ParamF64Ext(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString ActiveSerialComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStringExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+Fw::ParamString ActiveSerialComponentBase ::
+  paramGet_ParamStringExt(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStringExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E ActiveSerialComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnumExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+E ActiveSerialComponentBase ::
+  paramGet_ParamEnumExt(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnumExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A ActiveSerialComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArrayExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+A ActiveSerialComponentBase ::
+  paramGet_ParamArrayExt(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArrayExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S ActiveSerialComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStructExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+S ActiveSerialComponentBase ::
+  paramGet_ParamStructExt(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStructExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
-    FW_ASSERT(paramExternalDelegatePtr != nullptr);
-    this->paramDelegatePtr = paramExternalDelegatePtr;
+void ActiveSerialComponentBase ::
+  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
+{
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
+  this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveSerialComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveSerialComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -4601,886 +7388,1390 @@ Fw::Time ActiveSerialComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveSerialComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveSerialComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveSerialComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::doDispatch() {
-    U8 _msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
+  doDispatch()
+{
+  U8 _msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer _msg(
+    _msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVESERIAL_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVESERIAL_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port serialAsync
-        case SERIALASYNC_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsync_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncAssert
-        case SERIALASYNCASSERT_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncAssert_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncBlockPriority
-        case SERIALASYNCBLOCKPRIORITY_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncDropPriority
-        case SERIALASYNCDROPPRIORITY_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncDropPriority_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle command CMD_ASYNC
-        case CMD_CMD_ASYNC: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PRIORITY
-        case CMD_CMD_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY
-        case CMD_CMD_PARAMS_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle command CMD_DROP
-        case CMD_CMD_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY_DROP
-        case CMD_CMD_PARAMS_PRIORITY_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle internal interface internalArray
-        case INT_IF_INTERNALARRAY: {
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalArray_internalInterfaceHandler(a);
-
-            break;
-        }
-
-        // Handle internal interface internalEnum
-        case INT_IF_INTERNALENUM: {
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalEnum_internalInterfaceHandler(e);
-
-            break;
-        }
-
-        // Handle internal interface internalPrimitive
-        case INT_IF_INTERNALPRIMITIVE: {
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
-
-            break;
-        }
-
-        // Handle internal interface internalPriorityDrop
-        case INT_IF_INTERNALPRIORITYDROP: {
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalPriorityDrop_internalInterfaceHandler();
-
-            break;
-        }
-
-        // Handle internal interface internalString
-        case INT_IF_INTERNALSTRING: {
-            Fw::InternalInterfaceString str1;
-            _deserStatus = _msg.deserializeTo(str1);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            Fw::InternalInterfaceString str2;
-            _deserStatus = _msg.deserializeTo(str2);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalString_internalInterfaceHandler(str1, str2);
-
-            break;
-        }
-
-        // Handle internal interface internalStruct
-        case INT_IF_INTERNALSTRUCT: {
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalStruct_internalInterfaceHandler(s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
+
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port serialAsync
+    case SERIALASYNC_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsync_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle async input port serialAsyncAssert
+    case SERIALASYNCASSERT_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncAssert_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle async input port serialAsyncBlockPriority
+    case SERIALASYNCBLOCKPRIORITY_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle async input port serialAsyncDropPriority
+    case SERIALASYNCDROPPRIORITY_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncDropPriority_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle command CMD_ASYNC
+    case CMD_CMD_ASYNC: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PRIORITY
+    case CMD_CMD_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY
+    case CMD_CMD_PARAMS_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle command CMD_DROP
+    case CMD_CMD_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY_DROP
+    case CMD_CMD_PARAMS_PRIORITY_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalArray
+    case INT_IF_INTERNALARRAY: {
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalArray_internalInterfaceHandler(
+        a
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalEnum
+    case INT_IF_INTERNALENUM: {
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalEnum_internalInterfaceHandler(
+        e
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalPrimitive
+    case INT_IF_INTERNALPRIMITIVE: {
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalPrimitive_internalInterfaceHandler(
+        u32,
+        f32,
+        b
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalPriorityDrop
+    case INT_IF_INTERNALPRIORITYDROP: {
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalPriorityDrop_internalInterfaceHandler();
+
+      break;
+    }
+
+    // Handle internal interface internalString
+    case INT_IF_INTERNALSTRING: {
+      Fw::InternalInterfaceString str1;
+      _deserStatus = _msg.deserializeTo(str1);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      Fw::InternalInterfaceString str2;
+      _deserStatus = _msg.deserializeTo(str2);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalString_internalInterfaceHandler(
+        str1,
+        str2
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalStruct
+    case INT_IF_INTERNALSTRUCT: {
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalStruct_internalInterfaceHandler(
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                              FwIndexType portNum,
-                                              FwOpcodeType opCode,
-                                              U32 cmdSeq,
-                                              Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveSerialComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveSerialComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSerialComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveSerialComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveSerialComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSerialComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveSerialComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSerialComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveSerialComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveSerialComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSerialComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveSerialComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveSerialComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveSerialComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveSerialComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveSerialComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveSerialComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveSerialComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveSerialComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveSerialComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str2,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveSerialComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                  FwIndexType portNum,
-                                                  U32 u32,
-                                                  F32 f32,
-                                                  bool b,
-                                                  const Fw::StringBase& str1,
-                                                  const E& e,
-                                                  const A& a,
-                                                  const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSerialComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -5489,52 +8780,94 @@ void ActiveSerialComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* call
 
 #if FW_PORT_SERIALIZATION
 
-void ActiveSerialComponentBase ::m_p_serialAsync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->serialAsync_handlerBase(portNum, buffer);
+void ActiveSerialComponentBase ::
+  m_p_serialAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->serialAsync_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_serialAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->serialAsyncAssert_handlerBase(portNum, buffer);
+void ActiveSerialComponentBase ::
+  m_p_serialAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->serialAsyncAssert_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_serialAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->serialAsyncBlockPriority_handlerBase(portNum, buffer);
+void ActiveSerialComponentBase ::
+  m_p_serialAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->serialAsyncBlockPriority_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_serialAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->serialAsyncDropPriority_handlerBase(portNum, buffer);
+void ActiveSerialComponentBase ::
+  m_p_serialAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->serialAsyncDropPriority_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_serialGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->serialGuarded_handlerBase(portNum, buffer);
+void ActiveSerialComponentBase ::
+  m_p_serialGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->serialGuarded_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void ActiveSerialComponentBase ::m_p_serialSync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
-    compPtr->serialSync_handlerBase(portNum, buffer);
+void ActiveSerialComponentBase ::
+  m_p_serialSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
+  compPtr->serialSync_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
 #endif
@@ -5545,86 +8878,192 @@ void ActiveSerialComponentBase ::m_p_serialSync_in(Fw::PassiveComponentBase* cal
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSerialComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void ActiveSerialComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                    FwOpcodeType opCode,
-                                                    U32 cmdSeq,
-                                                    const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-void ActiveSerialComponentBase ::eventOut_out(FwIndexType portNum,
-                                              FwEventIdType id,
-                                              Fw::Time& timeTag,
-                                              const Fw::LogSeverity& severity,
-                                              Fw::LogBuffer& args) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  eventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::LogBuffer& args
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
+  FW_ASSERT(
+    this->m_eventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_eventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    args
+  );
 }
 
-Fw::ParamValid ActiveSerialComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                         FwPrmIdType id,
-                                                         Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::ParamValid ActiveSerialComponentBase ::
+  prmGetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_prmGetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void ActiveSerialComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  prmSetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmSetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_prmSetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void ActiveSerialComponentBase ::textEventOut_out(FwIndexType portNum,
-                                                  FwEventIdType id,
-                                                  Fw::Time& timeTag,
-                                                  const Fw::LogSeverity& severity,
-                                                  Fw::TextLogString& text) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  textEventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::TextLogString& text
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
+  FW_ASSERT(
+    this->m_textEventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_textEventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    text
+  );
 }
 
 #endif
 
-void ActiveSerialComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
-void ActiveSerialComponentBase ::tlmOut_out(FwIndexType portNum,
-                                            FwChanIdType id,
-                                            Fw::Time& timeTag,
-                                            Fw::TlmBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSerialComponentBase ::
+  tlmOut_out(
+      FwIndexType portNum,
+      FwChanIdType id,
+      Fw::Time& timeTag,
+      Fw::TlmBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
+  FW_ASSERT(
+    this->m_tlmOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_tlmOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    val
+  );
 }
 
 #endif
@@ -5633,552 +9072,684 @@ void ActiveSerialComponentBase ::tlmOut_out(FwIndexType portNum,
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
-    U32 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamU32(Fw::SerialBufferBase& val)
+{
+  U32 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamU32 = _localVal;
-    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamU32 = _localVal;
+  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMU32);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMU32);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
-    F64 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamF64(Fw::SerialBufferBase& val)
+{
+  F64 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamF64 = _localVal;
-    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamF64 = _localVal;
+  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMF64);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMF64);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
-    Fw::ParamString _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamString(Fw::SerialBufferBase& val)
+{
+  Fw::ParamString _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamString = _localVal;
-    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamString = _localVal;
+  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
-    E _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamEnum(Fw::SerialBufferBase& val)
+{
+  E _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamEnum = _localVal;
-    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamEnum = _localVal;
+  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMENUM);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
-    A _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamArray(Fw::SerialBufferBase& val)
+{
+  A _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamArray = _localVal;
-    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamArray = _localVal;
+  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
-    S _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamStruct(Fw::SerialBufferBase& val)
+{
+  S _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamStruct = _localVal;
-    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamStruct = _localVal;
+  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMI32EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMI32EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMF64EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMF64EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRINGEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMENUMEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMENUMEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMARRAYEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRUCTEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
+  return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamU32() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamU32);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamU32()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamU32);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamF64() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamF64);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamF64()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamF64);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamString() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamString);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamString()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamString);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamEnum() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamEnum()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamArray() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamArray);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamArray()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamArray);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamStruct() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamStruct()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamI32Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamI32Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamF64Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamF64Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamStringExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamStringExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamEnumExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamEnumExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamArrayExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamArrayExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse ActiveSerialComponentBase ::paramSave_ParamStructExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse ActiveSerialComponentBase ::
+  paramSave_ParamStructExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVESYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,783 +20,1216 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveSyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+ActiveSyncProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-ActiveSyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const ActiveSyncProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+ActiveSyncProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const ActiveSyncProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const ActiveSyncProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const ActiveSyncProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                  FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                 FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveSyncProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -805,17 +1238,26 @@ void ActiveSyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreTy
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveSyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveSyncProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveSyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* ActiveSyncProductsComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -826,140 +1268,213 @@ Fw::InputDpResponsePort* ActiveSyncProductsComponentBase ::get_productRecvIn_Inp
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveSyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveSyncProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveSyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveSyncProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveSyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveSyncProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveSyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveSyncProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -970,78 +1485,148 @@ Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedSync_InputPort
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1052,66 +1637,116 @@ void ActiveSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                            Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                          Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                     Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1122,72 +1757,134 @@ void ActiveSyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1198,24 +1895,46 @@ void ActiveSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1224,10 +1943,18 @@ void ActiveSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portN
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveSyncProductsComponentBase ::ActiveSyncProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+ActiveSyncProductsComponentBase ::
+  ActiveSyncProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveSyncProductsComponentBase ::~ActiveSyncProductsComponentBase() {}
+}
+
+ActiveSyncProductsComponentBase ::
+  ~ActiveSyncProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1235,76 +1962,118 @@ ActiveSyncProductsComponentBase ::~ActiveSyncProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveSyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveSyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1315,59 +2084,92 @@ bool ActiveSyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveSyncProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1378,31 +2180,47 @@ bool ActiveSyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwI
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                         FwOpcodeType opCode,
-                                                         U32 cmdSeq,
-                                                         Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveSyncProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void ActiveSyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                 FwDpIdType id,
-                                                                 const Fw::Buffer& buffer,
-                                                                 const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->productRecvIn_handler(portNum, id, buffer, status);
+  // Call handler function
+  this->productRecvIn_handler(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1411,561 +2229,941 @@ void ActiveSyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType por
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveSyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSyncProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveSyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveSyncProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveSyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveSyncProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveSyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSyncProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveSyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveSyncProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveSyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                    AliasPrim1 u32,
-                                                                                    AliasPrim2 f32,
-                                                                                    AliasBool b,
-                                                                                    const Fw::StringBase& str2,
-                                                                                    const AliasEnum& e,
-                                                                                    const AliasArray& a,
-                                                                                    const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSyncProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveSyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveSyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveSyncProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveSyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveSyncProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1976,63 +3174,85 @@ void ActiveSyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    // Default: no-op
+void ActiveSyncProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveSyncProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void ActiveSyncProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void ActiveSyncProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Default: no-op
+void ActiveSyncProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    // Default: no-op
+void ActiveSyncProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2041,103 +3261,209 @@ void ActiveSyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndex
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveSyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveSyncProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveSyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSyncProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveSyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                         AliasPrim1 u32,
-                                                         AliasPrim2 f32,
-                                                         AliasBool b,
-                                                         const Fw::StringBase& str2,
-                                                         const AliasEnum& e,
-                                                         const AliasArray& a,
-                                                         const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveSyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveSyncProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveSyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveSyncProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveSyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str2,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveSyncProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2146,39 +3472,47 @@ F32 ActiveSyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void ActiveSyncProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveSyncProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveSyncProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2188,516 +3522,887 @@ Fw::Time ActiveSyncProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveSyncProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveSyncProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveSyncProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVESYNCPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVESYNCPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    FwOpcodeType opCode,
-                                                    U32 cmdSeq,
-                                                    Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveSyncProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void ActiveSyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            FwDpIdType id,
-                                                            const Fw::Buffer& buffer,
-                                                            const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void ActiveSyncProductsComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              AliasPrim1 u32,
-                                                              AliasPrim2 f32,
-                                                              AliasBool b,
-                                                              const Fw::StringBase& str2,
-                                                              const AliasEnum& e,
-                                                              const AliasArray& a,
-                                                              const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveSyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSyncProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveSyncProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveSyncProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveSyncProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveSyncProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveSyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                           FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSyncProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveSyncProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                AliasPrim1 u32,
-                                                                AliasPrim2 f32,
-                                                                AliasBool b,
-                                                                const Fw::StringBase& str2,
-                                                                const AliasEnum& e,
-                                                                const AliasArray& a,
-                                                                const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveSyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveSyncProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveSyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                               FwIndexType portNum,
-                                                                               AliasPrim1 u32,
-                                                                               AliasPrim2 f32,
-                                                                               AliasBool b,
-                                                                               const Fw::StringBase& str2,
-                                                                               const AliasEnum& e,
-                                                                               const AliasArray& a,
-                                                                               const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveSyncProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                      FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveSyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str2,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveSyncProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveSyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str2,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveSyncProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveSyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    FW_ASSERT(callComp);
-    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveSyncProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2706,32 +4411,68 @@ void ActiveSyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  productRequestOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+  FW_ASSERT(
+    this->m_productRequestOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productRequestOut_OutputPort[portNum].invoke(
+    id,
+    dataSize
+  );
 }
 
-void ActiveSyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                          FwDpIdType id,
-                                                          const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void ActiveSyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveSyncProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2740,58 +4481,71 @@ void ActiveSyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::T
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
-    const FwDpIdType globalId = this->getIdBase() + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    this->productRequestOut_out(0, globalId, size);
+void ActiveSyncProductsComponentBase ::
+  dpRequest(
+      ContainerId::T containerId,
+      FwSizeType dataSize
+  )
+{
+  const FwDpIdType globalId = this->getIdBase() + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  this->productRequestOut_out(0, globalId, size);
 }
 
-void ActiveSyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer,
-                                                             const Fw::Success& status) {
-    DpContainer container;
-    if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
-    }
-    // Convert global id to local id
-    const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
-    const FwDpIdType localId = id - idBase;
-    // Switch on the local id
-    switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
-    }
+void ActiveSyncProductsComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  DpContainer container;
+  if (status == Fw::Success::SUCCESS) {
+    container = DpContainer(id, buffer, this->getIdBase());
+  }
+  // Convert global id to local id
+  const FwDpIdType idBase = this->getIdBase();
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
+  const FwDpIdType localId = id - idBase;
+  // Switch on the local id
+  switch (localId) {
+    case ContainerId::Container1:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container1);
+      // Call the handler
+      this->dpRecv_Container1_handler(container, status.e);
+      break;
+    case ContainerId::Container2:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container2);
+      // Call the handler
+      this->dpRecv_Container2_handler(container, status.e);
+      break;
+    case ContainerId::Container3:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container3);
+      // Call the handler
+      this->dpRecv_Container3_handler(container, status.e);
+      break;
+    case ContainerId::Container4:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container4);
+      // Call the handler
+      this->dpRecv_Container4_handler(container, status.e);
+      break;
+    case ContainerId::Container5:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container5);
+      // Call the handler
+      this->dpRecv_Container5_handler(container, status.e);
+      break;
+    default:
+      FW_ASSERT(0);
+      break;
+  }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVESYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,1223 +20,783 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-ActiveSyncProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+ActiveSyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+ActiveSyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-ActiveSyncProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const ActiveSyncProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const ActiveSyncProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const ActiveSyncProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const ActiveSyncProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                  FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                 FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveSyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1245,26 +805,17 @@ void ActiveSyncProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveSyncProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveSyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* ActiveSyncProductsComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* ActiveSyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -1275,213 +826,140 @@ Fw::InputDpResponsePort* ActiveSyncProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveSyncProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveSyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveSyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveSyncProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveSyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveSyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveSyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveSyncProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveSyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveSyncProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveSyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveSyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveSyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1492,148 +970,78 @@ Ports::InputTypedPort* ActiveSyncProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveSyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1644,116 +1052,66 @@ void ActiveSyncProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                            Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                          Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                     Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1764,134 +1122,72 @@ void ActiveSyncProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveSyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveSyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1902,46 +1198,24 @@ void ActiveSyncProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveSyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1950,18 +1224,10 @@ void ActiveSyncProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveSyncProductsComponentBase ::
-  ActiveSyncProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveSyncProductsComponentBase ::ActiveSyncProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveSyncProductsComponentBase ::
-  ~ActiveSyncProductsComponentBase()
-{
-
-}
+ActiveSyncProductsComponentBase ::~ActiveSyncProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1969,118 +1235,76 @@ ActiveSyncProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2091,92 +1315,59 @@ bool ActiveSyncProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveSyncProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveSyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2187,47 +1378,31 @@ bool ActiveSyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveSyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                         FwOpcodeType opCode,
+                                                         U32 cmdSeq,
+                                                         Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
-void ActiveSyncProductsComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                 FwDpIdType id,
+                                                                 const Fw::Buffer& buffer,
+                                                                 const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->productRecvIn_handler(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+    // Call handler function
+    this->productRecvIn_handler(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
@@ -2236,941 +1411,561 @@ void ActiveSyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSyncProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveSyncProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveSyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveSyncProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveSyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveSyncProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveSyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                    AliasPrim1 u32,
+                                                                                    AliasPrim2 f32,
+                                                                                    AliasBool b,
+                                                                                    const Fw::StringBase& str2,
+                                                                                    const AliasEnum& e,
+                                                                                    const AliasArray& a,
+                                                                                    const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveSyncProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveSyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveSyncProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveSyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3181,85 +1976,63 @@ void ActiveSyncProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveSyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveSyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Default: no-op
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveSyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3268,209 +2041,103 @@ void ActiveSyncProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveSyncProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveSyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                         AliasPrim1 u32,
+                                                         AliasPrim2 f32,
+                                                         AliasBool b,
+                                                         const Fw::StringBase& str2,
+                                                         const AliasEnum& e,
+                                                         const AliasArray& a,
+                                                         const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveSyncProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveSyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveSyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveSyncProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveSyncProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveSyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str2,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3479,47 +2146,39 @@ F32 ActiveSyncProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void ActiveSyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveSyncProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveSyncProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3529,887 +2188,516 @@ Fw::Time ActiveSyncProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveSyncProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveSyncProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveSyncProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVESYNCPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVESYNCPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveSyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    FwOpcodeType opCode,
+                                                    U32 cmdSeq,
+                                                    Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void ActiveSyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            FwDpIdType id,
+                                                            const Fw::Buffer& buffer,
+                                                            const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              AliasPrim1 u32,
+                                                              AliasPrim2 f32,
+                                                              AliasBool b,
+                                                              const Fw::StringBase& str2,
+                                                              const AliasEnum& e,
+                                                              const AliasArray& a,
+                                                              const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveSyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveSyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSyncProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveSyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveSyncProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveSyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveSyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                           FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveSyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                AliasPrim1 u32,
+                                                                AliasPrim2 f32,
+                                                                AliasBool b,
+                                                                const Fw::StringBase& str2,
+                                                                const AliasEnum& e,
+                                                                const AliasArray& a,
+                                                                const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveSyncProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveSyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveSyncProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveSyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                               FwIndexType portNum,
+                                                                               AliasPrim1 u32,
+                                                                               AliasPrim2 f32,
+                                                                               AliasBool b,
+                                                                               const Fw::StringBase& str2,
+                                                                               const AliasEnum& e,
+                                                                               const AliasArray& a,
+                                                                               const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                      FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveSyncProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveSyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str2,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveSyncProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveSyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str2,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveSyncProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveSyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    FW_ASSERT(callComp);
+    ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4418,68 +2706,32 @@ void ActiveSyncProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  productRequestOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productRequestOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productRequestOut_OutputPort[portNum].invoke(
-    id,
-    dataSize
-  );
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
 }
 
-void ActiveSyncProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                          FwDpIdType id,
+                                                          const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void ActiveSyncProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveSyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4488,71 +2740,58 @@ void ActiveSyncProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void ActiveSyncProductsComponentBase ::
-  dpRequest(
-      ContainerId::T containerId,
-      FwSizeType dataSize
-  )
-{
-  const FwDpIdType globalId = this->getIdBase() + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  this->productRequestOut_out(0, globalId, size);
+void ActiveSyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+    const FwDpIdType globalId = this->getIdBase() + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    this->productRequestOut_out(0, globalId, size);
 }
 
-void ActiveSyncProductsComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  DpContainer container;
-  if (status == Fw::Success::SUCCESS) {
-    container = DpContainer(id, buffer, this->getIdBase());
-  }
-  // Convert global id to local id
-  const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(
-    id >= idBase,
-    static_cast<FwAssertArgType>(id),
-    static_cast<FwAssertArgType>(idBase)
-  );
-  const FwDpIdType localId = id - idBase;
-  // Switch on the local id
-  switch (localId) {
-    case ContainerId::Container1:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container1);
-      // Call the handler
-      this->dpRecv_Container1_handler(container, status.e);
-      break;
-    case ContainerId::Container2:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container2);
-      // Call the handler
-      this->dpRecv_Container2_handler(container, status.e);
-      break;
-    case ContainerId::Container3:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container3);
-      // Call the handler
-      this->dpRecv_Container3_handler(container, status.e);
-      break;
-    case ContainerId::Container4:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container4);
-      // Call the handler
-      this->dpRecv_Container4_handler(container, status.e);
-      break;
-    case ContainerId::Container5:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container5);
-      // Call the handler
-      this->dpRecv_Container5_handler(container, status.e);
-      break;
-    default:
-      FW_ASSERT(0);
-      break;
-  }
+void ActiveSyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer,
+                                                             const Fw::Success& status) {
+    DpContainer container;
+    if (status == Fw::Success::SUCCESS) {
+        container = DpContainer(id, buffer, this->getIdBase());
+    }
+    // Convert global id to local id
+    const FwDpIdType idBase = this->getIdBase();
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    const FwDpIdType localId = id - idBase;
+    // Switch on the local id
+    switch (localId) {
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
+    }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     ACTIVETELEMETRY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void ActiveTelemetryComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void ActiveTelemetryComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType 
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveTelemetryComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* ActiveTelemetryComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,140 +967,213 @@ Fw::InputCmdPort* ActiveTelemetryComponentBase ::get_cmdIn_InputPort(FwIndexType
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveTelemetryComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* ActiveTelemetryComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveTelemetryComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* ActiveTelemetryComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveTelemetryComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* ActiveTelemetryComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveTelemetryComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* ActiveTelemetryComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -755,62 +1184,120 @@ Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedSync_InputPort(Fw
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -821,66 +1308,116 @@ void ActiveTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, F
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                   Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                 Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                  Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -891,55 +1428,106 @@ void ActiveTelemetryComponentBase ::set_typedReturnOut_OutputPort(FwIndexType po
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -950,24 +1538,46 @@ void ActiveTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, F
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -976,9 +1586,18 @@ void ActiveTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum,
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveTelemetryComponentBase ::ActiveTelemetryComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
+ActiveTelemetryComponentBase ::
+  ActiveTelemetryComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-ActiveTelemetryComponentBase ::~ActiveTelemetryComponentBase() {}
+}
+
+ActiveTelemetryComponentBase ::
+  ~ActiveTelemetryComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -986,62 +1605,96 @@ ActiveTelemetryComponentBase ::~ActiveTelemetryComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveTelemetryComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveTelemetryComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveTelemetryComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1052,59 +1705,92 @@ bool ActiveTelemetryComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType po
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveTelemetryComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool ActiveTelemetryComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1115,19 +1801,24 @@ bool ActiveTelemetryComponentBase ::isConnected_typedReturnOut_OutputPort(FwInde
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void ActiveTelemetryComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1136,561 +1827,941 @@ void ActiveTelemetryComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                AliasPrim1 u32,
-                                                                AliasPrim2 f32,
-                                                                AliasBool b,
-                                                                const Fw::StringBase& str2,
-                                                                const AliasEnum& e,
-                                                                const AliasArray& a,
-                                                                const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String ActiveTelemetryComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveTelemetryComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveTelemetryComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveTelemetryComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 ActiveTelemetryComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveTelemetryComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 ActiveTelemetryComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveTelemetryComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveTelemetryComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveTelemetryComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveTelemetryComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void ActiveTelemetryComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 ActiveTelemetryComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveTelemetryComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String ActiveTelemetryComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                 AliasPrim1 u32,
-                                                                                 AliasPrim2 f32,
-                                                                                 AliasBool b,
-                                                                                 const Fw::StringBase& str2,
-                                                                                 const AliasEnum& e,
-                                                                                 const AliasArray& a,
-                                                                                 const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveTelemetryComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveTelemetryComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveTelemetryComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveTelemetryComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveTelemetryComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void ActiveTelemetryComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 ActiveTelemetryComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveTelemetryComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 ActiveTelemetryComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveTelemetryComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void ActiveTelemetryComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1701,63 +2772,85 @@ void ActiveTelemetryComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Default: no-op
+void ActiveTelemetryComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void ActiveTelemetryComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Default: no-op
+void ActiveTelemetryComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Default: no-op
+void ActiveTelemetryComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Default: no-op
+void ActiveTelemetryComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Default: no-op
+void ActiveTelemetryComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1766,103 +2859,209 @@ void ActiveTelemetryComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexTyp
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveTelemetryComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 ActiveTelemetryComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveTelemetryComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveTelemetryComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveTelemetryComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                      AliasPrim1 u32,
-                                                      AliasPrim2 f32,
-                                                      AliasBool b,
-                                                      const Fw::StringBase& str2,
-                                                      const AliasEnum& e,
-                                                      const AliasArray& a,
-                                                      const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveTelemetryComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 ActiveTelemetryComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveTelemetryComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String ActiveTelemetryComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveTelemetryComponentBase ::typedOut_out(FwIndexType portNum,
-                                                 U32 u32,
-                                                 F32 f32,
-                                                 bool b,
-                                                 const Fw::StringBase& str1,
-                                                 const E& e,
-                                                 const A& a,
-                                                 const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveTelemetryComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str2,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 ActiveTelemetryComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -1871,196 +3070,364 @@ F32 ActiveTelemetryComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
-            this->timeGetOut_out(0, _tlmTime);
-        }
-
-        FwChanIdType _id;
-        _id = this->getIdBase() + id;
-
-        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
+void ActiveTelemetryComponentBase ::
+  tlmWrite(
+      FwChanIdType id,
+      Fw::TlmBuffer& _tlmBuff,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    if (
+      this->isConnected_timeGetOut_OutputPort(0) &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->timeGetOut_out(0, _tlmTime);
     }
+
+    FwChanIdType _id;
+    _id = this->getIdBase() + id;
+
+    this->tlmOut_out(
+      0,
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelU32Format(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelF32Format(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat =
-            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
-                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelStringFormat(
+      const Fw::StringBase& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = arg.serializeTo(
+      _tlmBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRINGFORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelEnum(
+      const E& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELENUM,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelArrayFreq(
+      const A& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELARRAYFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelStructFreq(
+      const S& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRUCTFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelU32Limits(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelF32Limits(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelF64(
+      F64 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF64,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelU32OnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelU32OnChange) {
-            return;
-        } else {
-            this->m_last_ChannelU32OnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelU32OnChange = false;
-        this->m_last_ChannelU32OnChange = arg;
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelU32OnChange(
+      U32 arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelU32OnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelU32OnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelU32OnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelU32OnChange = false;
+    this->m_last_ChannelU32OnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELU32ONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelEnumOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelEnumOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelEnumOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelEnumOnChange = false;
-        this->m_last_ChannelEnumOnChange = arg;
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelEnumOnChange(
+      const E& arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelEnumOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelEnumOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelEnumOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelEnumOnChange = false;
+    this->m_last_ChannelEnumOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELENUMONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void ActiveTelemetryComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelBoolOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelBoolOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelBoolOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelBoolOnChange = false;
-        this->m_last_ChannelBoolOnChange = arg;
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELBOOLONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveTelemetryComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time ActiveTelemetryComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2070,505 +3437,868 @@ Fw::Time ActiveTelemetryComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void ActiveTelemetryComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void ActiveTelemetryComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void ActiveTelemetryComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == ACTIVETELEMETRY_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == ACTIVETELEMETRY_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                 FwIndexType portNum,
-                                                 FwOpcodeType opCode,
-                                                 U32 cmdSeq,
-                                                 Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void ActiveTelemetryComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           AliasPrim1 u32,
-                                                           AliasPrim2 f32,
-                                                           AliasBool b,
-                                                           const Fw::StringBase& str2,
-                                                           const AliasEnum& e,
-                                                           const AliasArray& a,
-                                                           const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveTelemetryComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                             FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveTelemetryComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveTelemetryComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveTelemetryComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveTelemetryComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveTelemetryComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveTelemetryComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveTelemetryComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveTelemetryComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveTelemetryComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void ActiveTelemetryComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 ActiveTelemetryComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                      FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 ActiveTelemetryComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String ActiveTelemetryComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String ActiveTelemetryComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveTelemetryComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveTelemetryComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveTelemetryComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveTelemetryComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveTelemetryComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveTelemetryComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str2,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveTelemetryComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 ActiveTelemetryComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 ActiveTelemetryComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void ActiveTelemetryComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void ActiveTelemetryComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2577,22 +4307,48 @@ void ActiveTelemetryComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* c
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
-void ActiveTelemetryComponentBase ::tlmOut_out(FwIndexType portNum,
-                                               FwChanIdType id,
-                                               Fw::Time& timeTag,
-                                               Fw::TlmBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void ActiveTelemetryComponentBase ::
+  tlmOut_out(
+      FwIndexType portNum,
+      FwChanIdType id,
+      Fw::Time& timeTag,
+      Fw::TlmBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
+  FW_ASSERT(
+    this->m_tlmOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_tlmOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    val
+  );
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #endif
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     ACTIVETELEMETRY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void ActiveTelemetryComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void ActiveTelemetryComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveTelemetryComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* ActiveTelemetryComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,140 @@ Fw::InputCmdPort* ActiveTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveTelemetryComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* ActiveTelemetryComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* ActiveTelemetryComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* ActiveTelemetryComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* ActiveTelemetryComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* ActiveTelemetryComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* ActiveTelemetryComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* ActiveTelemetryComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* ActiveTelemetryComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* ActiveTelemetryComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +755,62 @@ Ports::InputTypedPort* ActiveTelemetryComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveTelemetryComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void ActiveTelemetryComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +821,66 @@ void ActiveTelemetryComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                   Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                 Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                  Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +891,55 @@ void ActiveTelemetryComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveTelemetryComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void ActiveTelemetryComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +950,24 @@ void ActiveTelemetryComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void ActiveTelemetryComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,18 +976,9 @@ void ActiveTelemetryComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-ActiveTelemetryComponentBase ::
-  ActiveTelemetryComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+ActiveTelemetryComponentBase ::ActiveTelemetryComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {}
 
-}
-
-ActiveTelemetryComponentBase ::
-  ~ActiveTelemetryComponentBase()
-{
-
-}
+ActiveTelemetryComponentBase ::~ActiveTelemetryComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1612,96 +986,62 @@ ActiveTelemetryComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1712,92 +1052,59 @@ bool ActiveTelemetryComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool ActiveTelemetryComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool ActiveTelemetryComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1808,24 +1115,19 @@ bool ActiveTelemetryComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void ActiveTelemetryComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1834,941 +1136,561 @@ void ActiveTelemetryComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                AliasPrim1 u32,
+                                                                AliasPrim2 f32,
+                                                                AliasBool b,
+                                                                const Fw::StringBase& str2,
+                                                                const AliasEnum& e,
+                                                                const AliasArray& a,
+                                                                const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveTelemetryComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveTelemetryComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveTelemetryComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 ActiveTelemetryComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveTelemetryComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 ActiveTelemetryComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveTelemetryComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveTelemetryComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveTelemetryComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 ActiveTelemetryComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveTelemetryComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveTelemetryComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                 AliasPrim1 u32,
+                                                                                 AliasPrim2 f32,
+                                                                                 AliasBool b,
+                                                                                 const Fw::StringBase& str2,
+                                                                                 const AliasEnum& e,
+                                                                                 const AliasArray& a,
+                                                                                 const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void ActiveTelemetryComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 ActiveTelemetryComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveTelemetryComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 ActiveTelemetryComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveTelemetryComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void ActiveTelemetryComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -2779,85 +1701,63 @@ void ActiveTelemetryComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void ActiveTelemetryComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void ActiveTelemetryComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveTelemetryComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveTelemetryComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveTelemetryComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Default: no-op
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void ActiveTelemetryComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2866,209 +1766,103 @@ void ActiveTelemetryComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 ActiveTelemetryComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 ActiveTelemetryComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveTelemetryComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void ActiveTelemetryComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                      AliasPrim1 u32,
+                                                      AliasPrim2 f32,
+                                                      AliasBool b,
+                                                      const Fw::StringBase& str2,
+                                                      const AliasEnum& e,
+                                                      const AliasArray& a,
+                                                      const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveTelemetryComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 ActiveTelemetryComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String ActiveTelemetryComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void ActiveTelemetryComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::typedOut_out(FwIndexType portNum,
+                                                 U32 u32,
+                                                 F32 f32,
+                                                 bool b,
+                                                 const Fw::StringBase& str1,
+                                                 const E& e,
+                                                 const A& a,
+                                                 const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveTelemetryComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 ActiveTelemetryComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str2,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3077,364 +1871,196 @@ F32 ActiveTelemetryComponentBase ::
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  tlmWrite(
-      FwChanIdType id,
-      Fw::TlmBuffer& _tlmBuff,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    if (
-      this->isConnected_timeGetOut_OutputPort(0) &&
-      (_tlmTime ==  Fw::ZERO_TIME)
-    ) {
-      this->timeGetOut_out(0, _tlmTime);
+void ActiveTelemetryComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
+            this->timeGetOut_out(0, _tlmTime);
+        }
+
+        FwChanIdType _id;
+        _id = this->getIdBase() + id;
+
+        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
     }
-
-    FwChanIdType _id;
-    _id = this->getIdBase() + id;
-
-    this->tlmOut_out(
-      0,
-      _id,
-      _tlmTime,
-      _tlmBuff
-    );
-  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelU32Format(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-    this->tlmWrite(
-      CHANNELID_CHANNELU32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelF32Format(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelStringFormat(
-      const Fw::StringBase& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serializeTo(
-      _tlmBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRINGFORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelEnum(
-      const E& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUM,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelArrayFreq(
-      const A& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELARRAYFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelStructFreq(
-      const S& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRUCTFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelU32Limits(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelF32Limits(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelF64(
-      F64 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF64,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelU32OnChange(
-      U32 arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelU32OnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelU32OnChange) {
-      return;
+        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
     }
-    else {
-      this->m_last_ChannelU32OnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelU32OnChange = false;
-    this->m_last_ChannelU32OnChange = arg;
-  }
-
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32ONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
 }
 
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelEnumOnChange(
-      const E& arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelEnumOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelEnumOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelEnumOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelEnumOnChange = false;
-    this->m_last_ChannelEnumOnChange = arg;
-  }
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUMONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
+    }
 }
 
-void ActiveTelemetryComponentBase ::
-  tlmWrite_ChannelBoolOnChange(
-      bool arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelBoolOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelBoolOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelBoolOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelBoolOnChange = false;
-    this->m_last_ChannelBoolOnChange = arg;
-  }
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat =
+            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
+                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
+    }
+}
 
-    this->tlmWrite(
-      CHANNELID_CHANNELBOOLONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelU32OnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelU32OnChange) {
+            return;
+        } else {
+            this->m_last_ChannelU32OnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelU32OnChange = false;
+        this->m_last_ChannelU32OnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelEnumOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelEnumOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelEnumOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelEnumOnChange = false;
+        this->m_last_ChannelEnumOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void ActiveTelemetryComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelBoolOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelBoolOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelBoolOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelBoolOnChange = false;
+        this->m_last_ChannelBoolOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time ActiveTelemetryComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time ActiveTelemetryComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3444,868 +2070,505 @@ Fw::Time ActiveTelemetryComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void ActiveTelemetryComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void ActiveTelemetryComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void ActiveTelemetryComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == ACTIVETELEMETRY_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == ACTIVETELEMETRY_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void ActiveTelemetryComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                 FwIndexType portNum,
+                                                 FwOpcodeType opCode,
+                                                 U32 cmdSeq,
+                                                 Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           AliasPrim1 u32,
+                                                           AliasPrim2 f32,
+                                                           AliasBool b,
+                                                           const Fw::StringBase& str2,
+                                                           const AliasEnum& e,
+                                                           const AliasArray& a,
+                                                           const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String ActiveTelemetryComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                             FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void ActiveTelemetryComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void ActiveTelemetryComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 ActiveTelemetryComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 ActiveTelemetryComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 ActiveTelemetryComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 ActiveTelemetryComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String ActiveTelemetryComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void ActiveTelemetryComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 ActiveTelemetryComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 ActiveTelemetryComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                      FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String ActiveTelemetryComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String ActiveTelemetryComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 ActiveTelemetryComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveTelemetryComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str2,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 ActiveTelemetryComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 ActiveTelemetryComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void ActiveTelemetryComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void ActiveTelemetryComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4314,48 +2577,22 @@ void ActiveTelemetryComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void ActiveTelemetryComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
-void ActiveTelemetryComponentBase ::
-  tlmOut_out(
-      FwIndexType portNum,
-      FwChanIdType id,
-      Fw::Time& timeTag,
-      Fw::TlmBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void ActiveTelemetryComponentBase ::tlmOut_out(FwIndexType portNum,
+                                               FwChanIdType id,
+                                               Fw::Time& timeTag,
+                                               Fw::TlmBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_tlmOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_tlmOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    val
-  );
+    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -88,9 +88,8 @@ namespace M {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -13,1322 +13,2192 @@
 
 namespace M {
 
-namespace {
-enum MsgTypeEnum {
-    ACTIVETEST_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    PRODUCTRECVIN_DPRESPONSE,
-    ALIASTYPEDASYNC_ALIASTYPED,
-    NOARGSASYNC_NOARGS,
-    TYPEDASYNC_TYPED,
-    TYPEDASYNCASSERT_TYPED,
-    TYPEDASYNCBLOCKPRIORITY_TYPED,
-    TYPEDASYNCDROPPRIORITY_TYPED,
-    CMD_CMD_ASYNC,
-    CMD_CMD_PRIORITY,
-    CMD_CMD_PARAMS_PRIORITY,
-    CMD_CMD_DROP,
-    CMD_CMD_PARAMS_PRIORITY_DROP,
-    INT_IF_INTERNALARRAY,
-    INT_IF_INTERNALENUM,
-    INT_IF_INTERNALPRIMITIVE,
-    INT_IF_INTERNALPRIORITYDROP,
-    INT_IF_INTERNALSTRING,
-    INT_IF_INTERNALSTRUCT,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
-    BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
-    BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
-    BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
-    BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
-    BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
-    BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-    // Size of internalArray argument list
-    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
-    // Size of internalEnum argument list
-    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
-    // Size of internalPrimitive argument list
-    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
-    // Size of internalString argument list
-    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
-                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
-    // Size of internalStruct argument list
-    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+  namespace {
+    enum MsgTypeEnum {
+      ACTIVETEST_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      PRODUCTRECVIN_DPRESPONSE,
+      ALIASTYPEDASYNC_ALIASTYPED,
+      NOARGSASYNC_NOARGS,
+      TYPEDASYNC_TYPED,
+      TYPEDASYNCASSERT_TYPED,
+      TYPEDASYNCBLOCKPRIORITY_TYPED,
+      TYPEDASYNCDROPPRIORITY_TYPED,
+      CMD_CMD_ASYNC,
+      CMD_CMD_PRIORITY,
+      CMD_CMD_PARAMS_PRIORITY,
+      CMD_CMD_DROP,
+      CMD_CMD_PARAMS_PRIORITY_DROP,
+      INT_IF_INTERNALARRAY,
+      INT_IF_INTERNALENUM,
+      INT_IF_INTERNALPRIMITIVE,
+      INT_IF_INTERNALPRIORITYDROP,
+      INT_IF_INTERNALSTRING,
+      INT_IF_INTERNALSTRUCT,
     };
 
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
-    }
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
+      BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
+      BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
+      BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
+      BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
+      BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
+      BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
+      // Size of internalArray argument list
+      BYTE internalArrayIntIfSize[
+        A::SERIALIZED_SIZE
+      ];
+      // Size of internalEnum argument list
+      BYTE internalEnumIntIfSize[
+        E::SERIALIZED_SIZE
+      ];
+      // Size of internalPrimitive argument list
+      BYTE internalPrimitiveIntIfSize[
+        sizeof(U32) +
+        sizeof(F32) +
+        sizeof(U8)
+      ];
+      // Size of internalString argument list
+      BYTE internalStringIntIfSize[
+        Fw::InternalInterfaceString::SERIALIZED_SIZE +
+        Fw::InternalInterfaceString::SERIALIZED_SIZE
+      ];
+      // Size of internalStruct argument list
+      BYTE internalStructIntIfSize[
+        S::SERIALIZED_SIZE
+      ];
+    };
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-// ----------------------------------------------------------------------
-// Types for data products
-// ----------------------------------------------------------------------
+      public:
 
-ActiveTestComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
 
-ActiveTestComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
 
-Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const M::ActiveTest_Data* array,
-    FwSizeType size) {
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Types for data products
+  // ----------------------------------------------------------------------
+
+  ActiveTestComponentBase::DpContainer ::
+    DpContainer(
+        FwDpIdType id,
+        const Fw::Buffer& buffer,
+        FwDpIdType baseId
+    ) :
+      Fw::DpContainer(id, buffer),
+      m_baseId(baseId)
+  {
+
+  }
+
+  ActiveTestComponentBase::DpContainer ::
+    DpContainer() :
+      Fw::DpContainer(),
+      m_baseId(0)
+  {
+
+  }
+
+  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
+    serializeRecord_DataArrayRecord(
+        const M::ActiveTest_Data* array,
+        FwSizeType size
+    )
+  {
     FW_ASSERT(array != nullptr);
     // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+    FwSizeType sizeDelta =
+      sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      sizeDelta += array[i].serializedSize();
     }
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
+      const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+      status = this->m_dataBuffer.serializeFrom(id);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = this->m_dataBuffer.serializeSize(size);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      for (FwSizeType i = 0; i < size; i++) {
+        status = this->m_dataBuffer.serializeFrom(array[i]);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+      }
+      this->m_dataSize += sizeDelta;
+    }
+    else {
+      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-}
+  }
 
-Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_DataRecord(const M::ActiveTest_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
+    serializeRecord_DataRecord(const M::ActiveTest_Data& elt)
+  {
+    const FwSizeType sizeDelta =
+      sizeof(FwDpIdType) +
+      elt.serializedSize();
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+      const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+      status = this->m_dataBuffer.serializeFrom(id);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = this->m_dataBuffer.serializeFrom(elt);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      this->m_dataSize += sizeDelta;
+    }
+    else {
+      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-}
+  }
 
-Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
+  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
+    serializeRecord_StringArrayRecord(
+        const Fw::StringBase** array,
+        FwSizeType size
+    )
+  {
     FW_ASSERT(array != nullptr);
     // Compute the size delta
     const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+    FwSizeType sizeDelta =
+      sizeof(FwDpIdType) +
+      sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+    }
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+      const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+      status = this->m_dataBuffer.serializeFrom(id);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = this->m_dataBuffer.serializeSize(size);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      for (FwSizeType i = 0; i < size; i++) {
+        const Fw::StringBase *const sbPtr = array[i];
         FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+        status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      }
+      this->m_dataSize += sizeDelta;
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    else {
+      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-}
+  }
 
-Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_StringRecord(const Fw::StringBase& elt) {
+  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
+    serializeRecord_StringRecord(const Fw::StringBase& elt)
+  {
     const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    const FwSizeType sizeDelta =
+      sizeof(FwDpIdType) +
+      elt.serializedTruncatedSize(stringSize);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+      const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+      status = this->m_dataBuffer.serializeFrom(id);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = elt.serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      this->m_dataSize += sizeDelta;
+    }
+    else {
+      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-}
+  }
 
-Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                          FwSizeType size) {
+  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
+    serializeRecord_U32ArrayRecord(
+        const U32* array,
+        FwSizeType size
+    )
+  {
     FW_ASSERT(array != nullptr);
     // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    const FwSizeType sizeDelta =
+      sizeof(FwDpIdType) +
+      sizeof(FwSizeStoreType) +
+      size * sizeof(U32);
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
+      const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+      status = this->m_dataBuffer.serializeFrom(id);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = this->m_dataBuffer.serializeSize(size);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      for (FwSizeType i = 0; i < size; i++) {
+        status = this->m_dataBuffer.serializeFrom(array[i]);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+      }
+      this->m_dataSize += sizeDelta;
+    }
+    else {
+      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-}
+  }
 
-Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
+    serializeRecord_U32Record(U32 elt)
+  {
+    const FwSizeType sizeDelta =
+      sizeof(FwDpIdType) +
+      sizeof(U32);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+      const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+      status = this->m_dataBuffer.serializeFrom(id);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = this->m_dataBuffer.serializeFrom(elt);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      this->m_dataSize += sizeDelta;
+    }
+    else {
+      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-}
+  }
 
-Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                         FwSizeType size) {
+  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
+    serializeRecord_U8ArrayRecord(
+        const U8* array,
+        FwSizeType size
+    )
+  {
     FW_ASSERT(array != nullptr);
     // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    const FwSizeType sizeDelta =
+      sizeof(FwDpIdType) +
+      sizeof(FwSizeStoreType) +
+      size * sizeof(U8);
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+      const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+      status = this->m_dataBuffer.serializeFrom(id);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = this->m_dataBuffer.serializeSize(size);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+      this->m_dataSize += sizeDelta;
+    }
+    else {
+      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+  void ActiveTestComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+      port++
+    ) {
+      this->m_cmdIn_InputPort[port].init();
+      this->m_cmdIn_InputPort[port].addCallComp(
+        this,
+        m_p_cmdIn_in
+      );
+      this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+      port++
+    ) {
+      this->m_productRecvIn_InputPort[port].init();
+      this->m_productRecvIn_InputPort[port].addCallComp(
+        this,
+        m_p_productRecvIn_in
+      );
+      this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+      port++
+    ) {
+      this->m_aliasTypedAsync_InputPort[port].init();
+      this->m_aliasTypedAsync_InputPort[port].addCallComp(
+        this,
+        m_p_aliasTypedAsync_in
+      );
+      this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+      port++
+    ) {
+      this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+      this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+        this,
+        m_p_noArgsAliasStringReturnSync_in
+      );
+      this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+      port++
+    ) {
+      this->m_noArgsAsync_InputPort[port].init();
+      this->m_noArgsAsync_InputPort[port].addCallComp(
+        this,
+        m_p_noArgsAsync_in
+      );
+      this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+      port++
+    ) {
+      this->m_noArgsGuarded_InputPort[port].init();
+      this->m_noArgsGuarded_InputPort[port].addCallComp(
+        this,
+        m_p_noArgsGuarded_in
+      );
+      this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+      port++
+    ) {
+      this->m_noArgsReturnGuarded_InputPort[port].init();
+      this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+        this,
+        m_p_noArgsReturnGuarded_in
+      );
+      this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+      port++
+    ) {
+      this->m_noArgsReturnSync_InputPort[port].init();
+      this->m_noArgsReturnSync_InputPort[port].addCallComp(
+        this,
+        m_p_noArgsReturnSync_in
+      );
+      this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+      port++
+    ) {
+      this->m_noArgsStringReturnSync_InputPort[port].init();
+      this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+        this,
+        m_p_noArgsStringReturnSync_in
+      );
+      this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+      port++
+    ) {
+      this->m_noArgsSync_InputPort[port].init();
+      this->m_noArgsSync_InputPort[port].addCallComp(
+        this,
+        m_p_noArgsSync_in
+      );
+      this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+      port++
+    ) {
+      this->m_typedAliasGuarded_InputPort[port].init();
+      this->m_typedAliasGuarded_InputPort[port].addCallComp(
+        this,
+        m_p_typedAliasGuarded_in
+      );
+      this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+      port++
+    ) {
+      this->m_typedAliasReturnSync_InputPort[port].init();
+      this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+        this,
+        m_p_typedAliasReturnSync_in
+      );
+      this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+      port++
+    ) {
+      this->m_typedAliasStringReturnSync_InputPort[port].init();
+      this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+        this,
+        m_p_typedAliasStringReturnSync_in
+      );
+      this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+      port++
+    ) {
+      this->m_typedAsync_InputPort[port].init();
+      this->m_typedAsync_InputPort[port].addCallComp(
+        this,
+        m_p_typedAsync_in
+      );
+      this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+      port++
+    ) {
+      this->m_typedAsyncAssert_InputPort[port].init();
+      this->m_typedAsyncAssert_InputPort[port].addCallComp(
+        this,
+        m_p_typedAsyncAssert_in
+      );
+      this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+      port++
+    ) {
+      this->m_typedAsyncBlockPriority_InputPort[port].init();
+      this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+        this,
+        m_p_typedAsyncBlockPriority_in
+      );
+      this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+      port++
+    ) {
+      this->m_typedAsyncDropPriority_InputPort[port].init();
+      this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+        this,
+        m_p_typedAsyncDropPriority_in
+      );
+      this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+      port++
+    ) {
+      this->m_typedGuarded_InputPort[port].init();
+      this->m_typedGuarded_InputPort[port].addCallComp(
+        this,
+        m_p_typedGuarded_in
+      );
+      this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+      port++
+    ) {
+      this->m_typedReturnGuarded_InputPort[port].init();
+      this->m_typedReturnGuarded_InputPort[port].addCallComp(
+        this,
+        m_p_typedReturnGuarded_in
+      );
+      this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+      port++
+    ) {
+      this->m_typedReturnSync_InputPort[port].init();
+      this->m_typedReturnSync_InputPort[port].addCallComp(
+        this,
+        m_p_typedReturnSync_in
+      );
+      this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+      port++
+    ) {
+      this->m_typedSync_InputPort[port].init();
+      this->m_typedSync_InputPort[port].addCallComp(
+        this,
+        m_p_typedSync_in
+      );
+      this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+      port++
+    ) {
+      this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+      port++
+    ) {
+      this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+      port++
+    ) {
+      this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+      port++
+    ) {
+      this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+      port++
+    ) {
+      this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+      port++
+    ) {
+      this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+      port++
+    ) {
+      this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
     // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+      port++
+    ) {
+      this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+      port++
+    ) {
+      this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+      port++
+    ) {
+      this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+      port++
+    ) {
+      this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+      port++
+    ) {
+      this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+      port++
+    ) {
+      this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+      port++
+    ) {
+      this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+      port++
+    ) {
+      this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+      port++
+    ) {
+      this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+      port++
+    ) {
+      this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+      port++
+    ) {
+      this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Getters for special input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Getters for special input ports
+  // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* ActiveTestComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+  Fw::InputCmdPort* ActiveTestComponentBase ::
+    get_cmdIn_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_cmdIn_InputPort[portNum];
-}
+  }
 
-Fw::InputDpResponsePort* ActiveTestComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Fw::InputDpResponsePort* ActiveTestComponentBase ::
+    get_productRecvIn_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_productRecvIn_InputPort[portNum];
-}
+  }
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Getters for typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Getters for typed input ports
+  // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* ActiveTestComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputAliasTypedPort* ActiveTestComponentBase ::
+    get_aliasTypedAsync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_aliasTypedAsync_InputPort[portNum];
-}
+  }
 
-Ports::InputNoArgsAliasStringReturnPort* ActiveTestComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputNoArgsAliasStringReturnPort* ActiveTestComponentBase ::
+    get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
-}
+  }
 
-Ports::InputNoArgsPort* ActiveTestComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
+    get_noArgsAsync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_noArgsAsync_InputPort[portNum];
-}
+  }
 
-Ports::InputNoArgsPort* ActiveTestComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
+    get_noArgsGuarded_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_noArgsGuarded_InputPort[portNum];
-}
+  }
 
-Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
+    get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_noArgsReturnGuarded_InputPort[portNum];
-}
+  }
 
-Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
+    get_noArgsReturnSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_noArgsReturnSync_InputPort[portNum];
-}
+  }
 
-Ports::InputNoArgsStringReturnPort* ActiveTestComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputNoArgsStringReturnPort* ActiveTestComponentBase ::
+    get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_noArgsStringReturnSync_InputPort[portNum];
-}
+  }
 
-Ports::InputNoArgsPort* ActiveTestComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
+    get_noArgsSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_noArgsSync_InputPort[portNum];
-}
+  }
 
-Ports::InputAliasTypedPort* ActiveTestComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputAliasTypedPort* ActiveTestComponentBase ::
+    get_typedAliasGuarded_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedAliasGuarded_InputPort[portNum];
-}
+  }
 
-Ports::InputAliasTypedReturnPort* ActiveTestComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputAliasTypedReturnPort* ActiveTestComponentBase ::
+    get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedAliasReturnSync_InputPort[portNum];
-}
+  }
 
-Ports::InputAliasTypedReturnStringPort* ActiveTestComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputAliasTypedReturnStringPort* ActiveTestComponentBase ::
+    get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedAliasStringReturnSync_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedPort* ActiveTestComponentBase ::
+    get_typedAsync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedAsync_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedPort* ActiveTestComponentBase ::
+    get_typedAsyncAssert_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedAsyncAssert_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedPort* ActiveTestComponentBase ::
+    get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedAsyncBlockPriority_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedPort* ActiveTestComponentBase ::
+    get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedAsyncDropPriority_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedPort* ActiveTestComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedPort* ActiveTestComponentBase ::
+    get_typedGuarded_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedGuarded_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedReturnPort* ActiveTestComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
+    get_typedReturnGuarded_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedReturnGuarded_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedReturnPort* ActiveTestComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
+    get_typedReturnSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedReturnSync_InputPort[portNum];
-}
+  }
 
-Ports::InputTypedPort* ActiveTestComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+  Ports::InputTypedPort* ActiveTestComponentBase ::
+    get_typedSync_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_typedSync_InputPort[portNum];
-}
+  }
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Connect input ports to special output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Connect input ports to special output ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_cmdRegOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputCmdRegPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_cmdResponseOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputCmdResponsePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_eventOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputLogPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_eventOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_prmGetOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputPrmGetPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_prmSetOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputPrmSetPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_productRequestOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputDpRequestPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_productSendOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputDpSendPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_productSendOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_textEventOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputLogTextPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_textEventOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
 #endif
 
-void ActiveTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_timeGetOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputTimePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_tlmOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputTlmPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_tlmOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Connect typed input ports to typed output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Connect typed input ports to typed output ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_noArgsOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputNoArgsPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_noArgsReturnOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputNoArgsReturnPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_noArgsStringReturnOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputNoArgsStringReturnPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_typedAliasOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputAliasTypedPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                  Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_typedAliasReturnOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputAliasTypedReturnPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_typedAliasReturnStringOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_typedAliasReturnStringOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputAliasTypedReturnStringPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_typedOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputTypedPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_typedOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_typedReturnOut_OutputPort(
+        FwIndexType portNum,
+        Ports::InputTypedReturnPort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
-}
+  }
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_PORT_SERIALIZATION
 
-// ----------------------------------------------------------------------
-// Connect serial input ports to special output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Connect serial input ports to special output ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_cmdRegOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_cmdResponseOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_eventOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_prmSetOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_productRequestOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_productSendOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void ActiveTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_textEventOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
 #endif
 
-void ActiveTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_timeGetOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_tlmOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_PORT_SERIALIZATION
 
-// ----------------------------------------------------------------------
-// Connect serial input ports to typed output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Connect serial input ports to typed output ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_noArgsOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_typedAliasOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
-void ActiveTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    set_typedOut_OutputPort(
+        FwIndexType portNum,
+        Fw::InputSerializePort* port
+    )
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Command registration
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Command registration
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::regCommands() {
+  void ActiveTestComponentBase ::
+    regCommands()
+  {
     FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_SYNC
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_GUARDED
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_ASYNC
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_PRIORITY
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_DROP
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMU32_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMU32_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMF64_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMF64_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRING_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMENUM_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMARRAY_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
-}
+    this->cmdRegOut_out(
+      0,
+      this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Parameter loading
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Parameter loading
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::loadParameters() {
+  void ActiveTestComponentBase ::
+    loadParameters()
+  {
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
     FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
@@ -1339,16 +2209,20 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMU32;
 
     // Get serialized parameter ParamU32
-    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamU32_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
-        }
+      _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+      if (_stat != Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+      }
     }
 
     this->m_paramLock.unlock();
@@ -1356,16 +2230,20 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMF64;
 
     // Get serialized parameter ParamF64
-    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamF64_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
-        }
+      _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+      if (_stat != Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+      }
     }
 
     this->m_paramLock.unlock();
@@ -1373,21 +2251,26 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMSTRING;
 
     // Get serialized parameter ParamString
-    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamString_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
+      _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+      if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+      }
+    }
+    else {
+      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamString = Fw::String("default");
+      this->m_ParamString = Fw::String("default");
     }
 
     this->m_paramLock.unlock();
@@ -1395,16 +2278,20 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMENUM;
 
     // Get serialized parameter ParamEnum
-    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamEnum_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
-        }
+      _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+      if (_stat != Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+      }
     }
 
     this->m_paramLock.unlock();
@@ -1412,21 +2299,26 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMARRAY;
 
     // Get serialized parameter ParamArray
-    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamArray_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
+      _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+      if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+      }
+    }
+    else {
+      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamArray = A({1, 2, 3});
+      this->m_ParamArray = A({1, 2, 3});
     }
 
     this->m_paramLock.unlock();
@@ -1434,16 +2326,20 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMSTRUCT;
 
     // Get serialized parameter ParamStruct
-    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamStruct_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
-        }
+      _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+      if (_stat != Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+      }
     }
 
     this->m_paramLock.unlock();
@@ -1451,16 +2347,24 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMI32EXT;
 
     // Get serialized parameter ParamI32Ext
-    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMI32EXT,
+      this->m_param_ParamI32Ext_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
@@ -1468,16 +2372,24 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMF64EXT;
 
     // Get serialized parameter ParamF64Ext
-    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMF64EXT,
+      this->m_param_ParamF64Ext_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
@@ -1485,32 +2397,45 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
     // Get serialized parameter ParamStringExt
-    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamStringExt_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->deserializeParam(
+        _baseId,
+        PARAMID_PARAMSTRINGEXT,
+        this->m_param_ParamStringExt_valid,
+        _paramBuffer
+      );
+      if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+      }
+    }
+    else {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-        Fw::String _val = Fw::String("external default");
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        }
+      Fw::String _val = Fw::String("external default");
+      _paramBuffer.resetSer();
+      _stat = _paramBuffer.serializeFrom(_val);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->deserializeParam(
+        _baseId,
+        PARAMID_PARAMSTRINGEXT,
+        this->m_param_ParamStringExt_valid,
+        _paramBuffer
+      );
+      if (_stat != Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+      }
     }
 
     this->m_paramLock.unlock();
@@ -1518,16 +2443,24 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMENUMEXT;
 
     // Get serialized parameter ParamEnumExt
-    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMENUMEXT,
+      this->m_param_ParamEnumExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
@@ -1535,32 +2468,45 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMARRAYEXT;
 
     // Get serialized parameter ParamArrayExt
-    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->deserializeParam(
+        _baseId,
+        PARAMID_PARAMARRAYEXT,
+        this->m_param_ParamArrayExt_valid,
+        _paramBuffer
+      );
+      if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+      }
+    }
+    else {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-        A _val = A({1, 2, 3});
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        }
+      A _val = A({1, 2, 3});
+      _paramBuffer.resetSer();
+      _stat = _paramBuffer.serializeFrom(_val);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->deserializeParam(
+        _baseId,
+        PARAMID_PARAMARRAYEXT,
+        this->m_param_ParamArrayExt_valid,
+        _paramBuffer
+      );
+      if (_stat != Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+      }
     }
 
     this->m_paramLock.unlock();
@@ -1568,541 +2514,882 @@ void ActiveTestComponentBase ::loadParameters() {
     _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
     // Get serialized parameter ParamStructExt
-    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+    this->m_param_ParamStructExt_valid = this->prmGetOut_out(
+      0,
+      _id,
+      _paramBuffer
+    );
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
-                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRUCTEXT,
+      this->m_param_ParamStructExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
 
     // Call notifier
     this->parametersLoaded();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-ActiveTestComponentBase ::ActiveTestComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {
+  ActiveTestComponentBase ::
+    ActiveTestComponentBase(const char* compName) :
+      Fw::ActiveComponentBase(compName)
+  {
     this->m_EventActivityLowThrottledThrottle = 0;
     this->m_EventFatalThrottledThrottle = 0;
     this->m_EventWarningLowThrottledThrottle = 0;
     this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
     this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
-}
+  }
 
-ActiveTestComponentBase ::~ActiveTestComponentBase() {}
+  ActiveTestComponentBase ::
+    ~ActiveTestComponentBase()
+  {
+
+  }
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Connection status queries for special output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Connection status queries for special output ports
+  // ----------------------------------------------------------------------
 
-bool ActiveTestComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_cmdRegOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_eventOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_eventOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_prmGetOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_prmSetOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_productRequestOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_productSendOut_OutputPort[portNum].isConnected();
-}
+  }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool ActiveTestComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_textEventOut_OutputPort[portNum].isConnected();
-}
+  }
 
 #endif
 
-bool ActiveTestComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_timeGetOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_tlmOut_OutputPort[portNum].isConnected();
-}
+  }
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Connection status queries for typed output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Connection status queries for typed output ports
+  // ----------------------------------------------------------------------
 
-bool ActiveTestComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_noArgsOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_typedAliasOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_typedOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_typedOut_OutputPort[portNum].isConnected();
-}
+  }
 
-bool ActiveTestComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  bool ActiveTestComponentBase ::
+    isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return this->m_typedReturnOut_OutputPort[portNum].isConnected();
-}
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Port handler base-class functions for special input ports
-//
-// Call these functions directly to bypass the corresponding ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Port handler base-class functions for special input ports
+  //
+  // Call these functions directly to bypass the corresponding ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                 FwOpcodeType opCode,
-                                                 U32 cmdSeq,
-                                                 Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    cmdIn_handlerBase(
+        FwIndexType portNum,
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
+
     const U32 idBase = this->getIdBase();
     FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
     // Select base class function based on opcode
     switch (opCode - idBase) {
-        case OPCODE_CMD_SYNC: {
-            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_SYNC: {
+        this->CMD_SYNC_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_SYNC_PRIMITIVE: {
-            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_SYNC_PRIMITIVE: {
+        this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_SYNC_STRING: {
-            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_SYNC_STRING: {
+        this->CMD_SYNC_STRING_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_SYNC_ENUM: {
-            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_SYNC_ENUM: {
+        this->CMD_SYNC_ENUM_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_SYNC_ARRAY: {
-            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_SYNC_ARRAY: {
+        this->CMD_SYNC_ARRAY_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_SYNC_STRUCT: {
-            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_SYNC_STRUCT: {
+        this->CMD_SYNC_STRUCT_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_GUARDED: {
-            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_GUARDED: {
+        this->CMD_GUARDED_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_GUARDED_PRIMITIVE: {
-            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_GUARDED_PRIMITIVE: {
+        this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_GUARDED_STRING: {
-            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_GUARDED_STRING: {
+        this->CMD_GUARDED_STRING_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_GUARDED_ENUM: {
-            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_GUARDED_ENUM: {
+        this->CMD_GUARDED_ENUM_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_GUARDED_ARRAY: {
-            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_GUARDED_ARRAY: {
+        this->CMD_GUARDED_ARRAY_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_GUARDED_STRUCT: {
-            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_GUARDED_STRUCT: {
+        this->CMD_GUARDED_STRUCT_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_ASYNC: {
-            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_ASYNC: {
+        this->CMD_ASYNC_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_PRIORITY: {
-            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_PRIORITY: {
+        this->CMD_PRIORITY_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_PARAMS_PRIORITY: {
-            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_PARAMS_PRIORITY: {
+        this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_DROP: {
-            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_DROP: {
+        this->CMD_DROP_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+      case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+        this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+          opCode,
+          cmdSeq,
+          args
+        );
+        break;
+      }
 
-        case OPCODE_PARAMU32_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMU32_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMU32_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMU32_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMF64_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMF64_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMF64_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMF64_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRING_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMSTRING_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRING_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamString();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMSTRING_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamString();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMENUM_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMENUM_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMENUM_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMENUM_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMARRAY_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMARRAY_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMARRAY_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMARRAY_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRUCT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMSTRUCT_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRUCT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMSTRUCT_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMI32EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMI32EXT_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMI32EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMI32EXT_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMF64EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMF64EXT_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMF64EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMF64EXT_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRINGEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMSTRINGEXT_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRINGEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMSTRINGEXT_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMENUMEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMENUMEXT_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMENUMEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMENUMEXT_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMARRAYEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMARRAYEXT_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMARRAYEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMARRAYEXT_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRUCTEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+      case OPCODE_PARAMSTRUCTEXT_SET: {
+        Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
 
-        case OPCODE_PARAMSTRUCTEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+      case OPCODE_PARAMSTRUCTEXT_SAVE: {
+        Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+        this->cmdResponse_out(
+          opCode,
+          cmdSeq,
+          _cstat
+        );
+        break;
+      }
+      default:
+        // Unknown opcode: ignore it
+        break;
     }
-}
+  }
 
-void ActiveTestComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                         FwDpIdType id,
-                                                         const Fw::Buffer& buffer,
-                                                         const Fw::Success& status) {
+  void ActiveTestComponentBase ::
+    productRecvIn_handlerBase(
+        FwIndexType portNum,
+        FwDpIdType id,
+        const Fw::Buffer& buffer,
+        const Fw::Success& status
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call pre-message hook
-    productRecvIn_preMsgHook(portNum, id, buffer, status);
+    productRecvIn_preMsgHook(
+      portNum,
+      id,
+      buffer,
+      status
+    );
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    _status = msg.serializeFrom(
+      static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument id
     _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument buffer
     _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument status
     _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Port handler base-class functions for typed input ports
-//
-// Call these functions directly to bypass the corresponding ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Port handler base-class functions for typed input ports
+  //
+  // Call these functions directly to bypass the corresponding ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                           AliasPrim1 u32,
-                                                           AliasPrim2 f32,
-                                                           AliasBool b,
-                                                           const Fw::StringBase& str2,
-                                                           const AliasEnum& e,
-                                                           const AliasArray& a,
-                                                           const AliasStruct& s) {
+  void ActiveTestComponentBase ::
+    aliasTypedAsync_handlerBase(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    aliasTypedAsync_preMsgHook(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    _status = msg.serializeFrom(
+      static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument str2
     _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-Fw::String ActiveTestComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+  Fw::String ActiveTestComponentBase ::
+    noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     Fw::String retVal;
 
@@ -2110,12 +3397,16 @@ Fw::String ActiveTestComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwI
     retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
     return retVal;
-}
+  }
 
-void ActiveTestComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+  void ActiveTestComponentBase ::
+    noArgsAsync_handlerBase(FwIndexType portNum)
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call pre-message hook
     noArgsAsync_preMsgHook(portNum);
@@ -2123,24 +3414,39 @@ void ActiveTestComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    _status = msg.serializeFrom(
+      static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+  void ActiveTestComponentBase ::
+    noArgsGuarded_handlerBase(FwIndexType portNum)
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Lock guard mutex before calling
     this->lock();
@@ -2150,12 +3456,16 @@ void ActiveTestComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
 
     // Unlock guard mutex
     this->unLock();
-}
+  }
 
-U32 ActiveTestComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+  U32 ActiveTestComponentBase ::
+    noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     U32 retVal;
 
@@ -2169,12 +3479,16 @@ U32 ActiveTestComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNu
     this->unLock();
 
     return retVal;
-}
+  }
 
-U32 ActiveTestComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+  U32 ActiveTestComponentBase ::
+    noArgsReturnSync_handlerBase(FwIndexType portNum)
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     U32 retVal;
 
@@ -2182,12 +3496,16 @@ U32 ActiveTestComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) 
     retVal = this->noArgsReturnSync_handler(portNum);
 
     return retVal;
-}
+  }
 
-Fw::String ActiveTestComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+  Fw::String ActiveTestComponentBase ::
+    noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     Fw::String retVal;
 
@@ -2195,357 +3513,615 @@ Fw::String ActiveTestComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexT
     retVal = this->noArgsStringReturnSync_handler(portNum);
 
     return retVal;
-}
+  }
 
-void ActiveTestComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+  void ActiveTestComponentBase ::
+    noArgsSync_handlerBase(FwIndexType portNum)
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call handler function
     this->noArgsSync_handler(portNum);
-}
+  }
 
-void ActiveTestComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
+  void ActiveTestComponentBase ::
+    typedAliasGuarded_handlerBase(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Lock guard mutex before calling
     this->lock();
 
     // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+    this->typedAliasGuarded_handler(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
 
     // Unlock guard mutex
     this->unLock();
-}
+  }
 
-AliasPrim2 ActiveTestComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
+  AliasPrim2 ActiveTestComponentBase ::
+    typedAliasReturnSync_handlerBase(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     AliasPrim2 retVal;
 
     // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+    retVal = this->typedAliasReturnSync_handler(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
 
     return retVal;
-}
+  }
 
-Fw::String ActiveTestComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AnotherAliasStruct& s) {
+  Fw::String ActiveTestComponentBase ::
+    typedAliasStringReturnSync_handlerBase(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AnotherAliasStruct& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     Fw::String retVal;
 
     // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+    retVal = this->typedAliasStringReturnSync_handler(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
 
     return retVal;
-}
+  }
 
-void ActiveTestComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsync_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    typedAsync_preMsgHook(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    _status = msg.serializeFrom(
+      static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsyncAssert_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    typedAsyncAssert_preMsgHook(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    _status = msg.serializeFrom(
+      static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsyncBlockPriority_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    typedAsyncBlockPriority_preMsgHook(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    _status = msg.serializeFrom(
+      static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsyncDropPriority_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    typedAsyncDropPriority_preMsgHook(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    _status = msg.serializeFrom(
+      static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
+  void ActiveTestComponentBase ::
+    typedGuarded_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Lock guard mutex before calling
     this->lock();
 
     // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+    this->typedGuarded_handler(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
 
     // Unlock guard mutex
     this->unLock();
-}
+  }
 
-F32 ActiveTestComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str2,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
+  F32 ActiveTestComponentBase ::
+    typedReturnGuarded_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     F32 retVal;
 
@@ -2553,424 +4129,713 @@ F32 ActiveTestComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum
     this->lock();
 
     // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+    retVal = this->typedReturnGuarded_handler(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
 
     // Unlock guard mutex
     this->unLock();
 
     return retVal;
-}
+  }
 
-F32 ActiveTestComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
+  F32 ActiveTestComponentBase ::
+    typedReturnSync_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     F32 retVal;
 
     // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+    retVal = this->typedReturnSync_handler(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
 
     return retVal;
-}
+  }
 
-void ActiveTestComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
+  void ActiveTestComponentBase ::
+    typedSync_handlerBase(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
-}
+    this->typedSync_handler(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Pre-message hooks for special async input ports
+  //
+  // Each of these functions is invoked just before processing a message
+  // on the corresponding port. By default, they do nothing. You can
+  // override them to provide specific pre-message behavior.
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
-                                                        FwDpIdType id,
-                                                        const Fw::Buffer& buffer,
-                                                        const Fw::Success& status) {
+  void ActiveTestComponentBase ::
+    productRecvIn_preMsgHook(
+        FwIndexType portNum,
+        FwDpIdType id,
+        const Fw::Buffer& buffer,
+        const Fw::Success& status
+    )
+  {
     // Default: no-op
-}
+  }
 
-// ----------------------------------------------------------------------
-// Pre-message hooks for typed async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Pre-message hooks for typed async input ports
+  //
+  // Each of these functions is invoked just before processing a message
+  // on the corresponding port. By default, they do nothing. You can
+  // override them to provide specific pre-message behavior.
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
+  void ActiveTestComponentBase ::
+    aliasTypedAsync_preMsgHook(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    )
+  {
     // Default: no-op
-}
+  }
 
-void ActiveTestComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+  void ActiveTestComponentBase ::
+    noArgsAsync_preMsgHook(FwIndexType portNum)
+  {
     // Default: no-op
-}
+  }
 
-void ActiveTestComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsync_preMsgHook(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Default: no-op
-}
+  }
 
-void ActiveTestComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsyncAssert_preMsgHook(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Default: no-op
-}
+  }
 
-void ActiveTestComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsyncBlockPriority_preMsgHook(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Default: no-op
-}
+  }
 
-void ActiveTestComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
+  void ActiveTestComponentBase ::
+    typedAsyncDropPriority_preMsgHook(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     // Default: no-op
-}
+  }
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Invocation functions for typed output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Invocation functions for typed output ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    noArgsOut_out(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      this->m_noArgsOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
     this->m_noArgsOut_OutputPort[portNum].invoke();
-}
+  }
 
-U32 ActiveTestComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  U32 ActiveTestComponentBase ::
+    noArgsReturnOut_out(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
     return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
-}
+  }
 
-Fw::String ActiveTestComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Fw::String ActiveTestComponentBase ::
+    noArgsStringReturnOut_out(FwIndexType portNum) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
     return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
-}
+  }
 
-void ActiveTestComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                 AliasPrim1 u32,
-                                                 AliasPrim2 f32,
-                                                 AliasBool b,
-                                                 const Fw::StringBase& str2,
-                                                 const AliasEnum& e,
-                                                 const AliasArray& a,
-                                                 const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    typedAliasOut_out(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
-}
+    FW_ASSERT(
+      this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_typedAliasOut_OutputPort[portNum].invoke(
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-AliasPrim2 ActiveTestComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  AliasPrim2 ActiveTestComponentBase ::
+    typedAliasReturnOut_out(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
-}
+    FW_ASSERT(
+      this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-Fw::String ActiveTestComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Fw::String ActiveTestComponentBase ::
+    typedAliasReturnStringOut_out(
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AnotherAliasStruct& s
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
-}
+    FW_ASSERT(
+      this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::typedOut_out(FwIndexType portNum,
-                                            U32 u32,
-                                            F32 f32,
-                                            bool b,
-                                            const Fw::StringBase& str1,
-                                            const E& e,
-                                            const A& a,
-                                            const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    typedOut_out(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
-}
+    FW_ASSERT(
+      this->m_typedOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_typedOut_OutputPort[portNum].invoke(
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
-F32 ActiveTestComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                 U32 u32,
-                                                 F32 f32,
-                                                 bool b,
-                                                 const Fw::StringBase& str2,
-                                                 const E& e,
-                                                 const A& a,
-                                                 const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  F32 ActiveTestComponentBase ::
+    typedReturnOut_out(
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
-}
+    FW_ASSERT(
+      this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Internal interface base-class functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Internal interface base-class functions
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
+  void ActiveTestComponentBase ::
+    internalArray_internalInterfaceInvoke(const A& a)
+  {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
+  void ActiveTestComponentBase ::
+    internalEnum_internalInterfaceInvoke(const E& e)
+  {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
+  void ActiveTestComponentBase ::
+    internalPrimitive_internalInterfaceInvoke(
+        U32 u32,
+        F32 f32,
+        bool b
+    )
+  {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
+  void ActiveTestComponentBase ::
+    internalPriorityDrop_internalInterfaceInvoke()
+  {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
-                                                                      const Fw::InternalInterfaceString& str2) {
+  void ActiveTestComponentBase ::
+    internalString_internalInterfaceInvoke(
+        const Fw::InternalInterfaceString& str1,
+        const Fw::InternalInterfaceString& str2
+    )
+  {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(str1);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
+  void ActiveTestComponentBase ::
+    internalStruct_internalInterfaceInvoke(const S& s)
+  {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Command response
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Command response
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+  void ActiveTestComponentBase ::
+    cmdResponse_out(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdResponse response
+    )
+  {
     FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
     this->cmdResponseOut_out(0, opCode, cmdSeq, response);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Command handler base-class functions
-//
-// Call these functions directly to bypass the command input port
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Command handler base-class functions
+  //
+  // Call these functions directly to bypass the command input port
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_SYNC_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
     this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
-}
+  }
 
-void ActiveTestComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -2980,45 +4845,76 @@ void ActiveTestComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType op
     U32 u32;
     _status = args.deserializeTo(u32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
     F32 f32;
     _status = args.deserializeTo(f32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
     bool b;
     _status = args.deserializeTo(b);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
-    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
-}
+    this->CMD_SYNC_PRIMITIVE_cmdHandler(
+      opCode, cmdSeq,
+      u32,
+      f32,
+      b
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_SYNC_STRING_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3028,36 +4924,61 @@ void ActiveTestComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCod
     Fw::CmdStringArg str1;
     _status = args.deserializeTo(str1);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
     Fw::CmdStringArg str2;
     _status = args.deserializeTo(str2);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
-    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
-}
+    this->CMD_SYNC_STRING_cmdHandler(
+      opCode, cmdSeq,
+      str1,
+      str2
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_SYNC_ENUM_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3067,27 +4988,46 @@ void ActiveTestComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode,
     E e;
     _status = args.deserializeTo(e);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
-    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
-}
+    this->CMD_SYNC_ENUM_cmdHandler(
+      opCode, cmdSeq,
+      e
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_SYNC_ARRAY_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3097,27 +5037,46 @@ void ActiveTestComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode
     A a;
     _status = args.deserializeTo(a);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
-    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
-}
+    this->CMD_SYNC_ARRAY_cmdHandler(
+      opCode, cmdSeq,
+      a
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_SYNC_STRUCT_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3127,35 +5086,59 @@ void ActiveTestComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCod
     S s;
     _status = args.deserializeTo(s);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
-    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
-}
+    this->CMD_SYNC_STRUCT_cmdHandler(
+      opCode, cmdSeq,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_GUARDED_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
@@ -3164,11 +5147,15 @@ void ActiveTestComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U
     this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
     this->unLock();
-}
+  }
 
-void ActiveTestComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                    U32 cmdSeq,
-                                                                    Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3178,51 +5165,80 @@ void ActiveTestComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType
     U32 u32;
     _status = args.deserializeTo(u32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
     F32 f32;
     _status = args.deserializeTo(f32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
     bool b;
     _status = args.deserializeTo(b);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
+    this->CMD_GUARDED_PRIMITIVE_cmdHandler(
+      opCode, cmdSeq,
+      u32,
+      f32,
+      b
+    );
 
     this->unLock();
-}
+  }
 
-void ActiveTestComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_GUARDED_STRING_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3232,42 +5248,65 @@ void ActiveTestComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType op
     Fw::CmdStringArg str1;
     _status = args.deserializeTo(str1);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
     Fw::CmdStringArg str2;
     _status = args.deserializeTo(str2);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+    this->CMD_GUARDED_STRING_cmdHandler(
+      opCode, cmdSeq,
+      str1,
+      str2
+    );
 
     this->unLock();
-}
+  }
 
-void ActiveTestComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                               U32 cmdSeq,
-                                                               Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_GUARDED_ENUM_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3277,33 +5316,50 @@ void ActiveTestComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCo
     E e;
     _status = args.deserializeTo(e);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
+    this->CMD_GUARDED_ENUM_cmdHandler(
+      opCode, cmdSeq,
+      e
+    );
 
     this->unLock();
-}
+  }
 
-void ActiveTestComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_GUARDED_ARRAY_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3313,33 +5369,50 @@ void ActiveTestComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opC
     A a;
     _status = args.deserializeTo(a);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
+    this->CMD_GUARDED_ARRAY_cmdHandler(
+      opCode, cmdSeq,
+      a
+    );
 
     this->unLock();
-}
+  }
 
-void ActiveTestComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_GUARDED_STRUCT_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -3349,33 +5422,52 @@ void ActiveTestComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType op
     S s;
     _status = args.deserializeTo(s);
     if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+        this->cmdResponseOut_out(
+          0,
+          opCode,
+          cmdSeq,
+          Fw::CmdResponse::FORMAT_ERROR
+        );
+      }
+      return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
+    this->CMD_GUARDED_STRUCT_cmdHandler(
+      opCode, cmdSeq,
+      s
+    );
 
     this->unLock();
-}
+  }
 
-void ActiveTestComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_ASYNC_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Call pre-message hook
-    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
+    this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -3384,33 +5476,57 @@ void ActiveTestComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_PRIORITY_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Call pre-message hook
-    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
+    this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -3419,35 +5535,57 @@ void ActiveTestComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, 
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_PARAMS_PRIORITY_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
+    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -3456,33 +5594,57 @@ void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType o
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_DROP_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Call pre-message hook
-    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
+    this->CMD_DROP_preMsgHook(opCode,cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -3491,40 +5653,62 @@ void ActiveTestComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
-                                                                       U32 cmdSeq,
-                                                                       Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
+    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -3533,980 +5717,1499 @@ void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeT
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    FW_ASSERT (
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Pre-message hooks for async commands
-//
-// Each of these functions is invoked just before processing the
-// corresponding command. By default they do nothing. You can
-// override them to provide specific pre-command behavior.
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Pre-message hooks for async commands
+  //
+  // Each of these functions is invoked just before processing the
+  // corresponding command. By default they do nothing. You can
+  // override them to provide specific pre-command behavior.
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+  void ActiveTestComponentBase ::
+    CMD_ASYNC_preMsgHook(
+        FwOpcodeType opCode,
+        U32 cmdSeq
+    )
+  {
     // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
-}
+    (void) opCode;
+    (void) cmdSeq;
+  }
 
-void ActiveTestComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+  void ActiveTestComponentBase ::
+    CMD_PRIORITY_preMsgHook(
+        FwOpcodeType opCode,
+        U32 cmdSeq
+    )
+  {
     // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
-}
+    (void) opCode;
+    (void) cmdSeq;
+  }
 
-void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+  void ActiveTestComponentBase ::
+    CMD_PARAMS_PRIORITY_preMsgHook(
+        FwOpcodeType opCode,
+        U32 cmdSeq
+    )
+  {
     // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
-}
+    (void) opCode;
+    (void) cmdSeq;
+  }
 
-void ActiveTestComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+  void ActiveTestComponentBase ::
+    CMD_DROP_preMsgHook(
+        FwOpcodeType opCode,
+        U32 cmdSeq
+    )
+  {
     // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
-}
+    (void) opCode;
+    (void) cmdSeq;
+  }
 
-void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+  void ActiveTestComponentBase ::
+    CMD_PARAMS_PRIORITY_DROP_preMsgHook(
+        FwOpcodeType opCode,
+        U32 cmdSeq
+    )
+  {
     // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
-}
+    (void) opCode;
+    (void) cmdSeq;
+  }
 
-// ----------------------------------------------------------------------
-// Event logging functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Event logging functions
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
+  void ActiveTestComponentBase ::
+    log_ACTIVITY_HI_EventActivityHigh() const
+  {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+      Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(0));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::ACTIVITY_HI,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity High occurred";
+      const char* _formatString =
+        "(%s) %s: Event Activity High occurred";
 #else
-        const char* _formatString = "%s: Event Activity High occurred";
+      const char* _formatString =
+        "%s: Event Activity High occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventActivityHigh ");
+        "EventActivityHigh "
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::ACTIVITY_HI,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-void ActiveTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
+  void ActiveTestComponentBase ::
+    log_ACTIVITY_LO_EventActivityLowThrottled(
+        U32 u32,
+        F32 f32,
+        bool b
+    )
+  {
     // Check throttle value
     if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventActivityLowThrottledThrottle++;
+      return;
+    }
+    else {
+      this->m_EventActivityLowThrottledThrottle++;
     }
 
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      Fw::LogBuffer _logBuff;
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(3));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(3));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the argument size
+      _status = _logBuff.serializeFrom(
+        static_cast<U8>(sizeof(U32))
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
-        _status = _logBuff.serializeFrom(u32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _logBuff.serializeFrom(u32);
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the argument size
+      _status = _logBuff.serializeFrom(
+        static_cast<U8>(sizeof(F32))
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
-        _status = _logBuff.serializeFrom(f32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _logBuff.serializeFrom(f32);
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the argument size
+      _status = _logBuff.serializeFrom(
+        static_cast<U8>(sizeof(U8))
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
-        _status = _logBuff.serializeFrom(b);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _logBuff.serializeFrom(b);
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::ACTIVITY_LO,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+      const char* _formatString =
+        "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #else
-        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+      const char* _formatString =
+        "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
+        "EventActivityLowThrottled ",
+        u32,
+        static_cast<F64>(f32),
+        b
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::ACTIVITY_LO,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-void ActiveTestComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1, const Fw::StringBase& str2) const {
+  void ActiveTestComponentBase ::
+    log_COMMAND_EventCommand(
+        const Fw::StringBase& str1,
+        const Fw::StringBase& str2
+    ) const
+  {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      Fw::LogBuffer _logBuff;
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(2));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(2));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
-        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
-                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = str1.serializeTo(
+        _logBuff,
+        FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = str2.serializeTo(
+        _logBuff,
+        FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::COMMAND,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
+      const char* _formatString =
+        "(%s) %s: Event Command occurred with arguments: %s, %s";
 #else
-        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
+      const char* _formatString =
+        "%s: Event Command occurred with arguments: %s, %s";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventCommand ", str1.toChar(), str2.toChar());
+        "EventCommand ",
+        str1.toChar(),
+        str2.toChar()
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::COMMAND,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-void ActiveTestComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
+  void ActiveTestComponentBase ::
+    log_DIAGNOSTIC_EventDiagnostic(const E& e) const
+  {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      Fw::LogBuffer _logBuff;
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(1));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the argument size
+      _status = _logBuff.serializeFrom(
+        static_cast<U8>(E::SERIALIZED_SIZE)
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
-        _status = _logBuff.serializeFrom(e);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _logBuff.serializeFrom(e);
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::DIAGNOSTIC,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
+      const char* _formatString =
+        "(%s) %s: Event Diagnostic occurred with argument: %s";
 #else
-        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
+      const char* _formatString =
+        "%s: Event Diagnostic occurred with argument: %s";
 #endif
 
-        Fw::String eStr;
-        e.toString(eStr);
+      Fw::String eStr;
+      e.toString(eStr);
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventDiagnostic ", eStr.toChar());
+        "EventDiagnostic ",
+        eStr.toChar()
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::DIAGNOSTIC,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-void ActiveTestComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
+  void ActiveTestComponentBase ::
+    log_FATAL_EventFatalThrottled(const A& a)
+  {
     // Check throttle value
     if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventFatalThrottledThrottle++;
+      return;
+    }
+    else {
+      this->m_EventFatalThrottledThrottle++;
     }
 
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      Fw::LogBuffer _logBuff;
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-        _status = _logBuff.serializeFrom(static_cast<U8>(4));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+      _status = _logBuff.serializeFrom(static_cast<U8>(4));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        _status = _logBuff.serializeFrom(static_cast<U32>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _logBuff.serializeFrom(static_cast<U32>(0));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the argument size
+      _status = _logBuff.serializeFrom(
+        static_cast<U8>(A::SERIALIZED_SIZE)
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
-        _status = _logBuff.serializeFrom(a);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _logBuff.serializeFrom(a);
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::FATAL,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
+      const char* _formatString =
+        "(%s) %s: Event Fatal occurred with argument: %s";
 #else
-        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
+      const char* _formatString =
+        "%s: Event Fatal occurred with argument: %s";
 #endif
 
-        Fw::String aStr;
-        a.toString(aStr);
+      Fw::String aStr;
+      a.toString(aStr);
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventFatalThrottled ", aStr.toChar());
+        "EventFatalThrottled ",
+        aStr.toChar()
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::FATAL,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-void ActiveTestComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
+  void ActiveTestComponentBase ::
+    log_WARNING_HI_EventWarningHigh(const S& s) const
+  {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      Fw::LogBuffer _logBuff;
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(1));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      // Serialize the argument size
+      _status = _logBuff.serializeFrom(
+        static_cast<U8>(S::SERIALIZED_SIZE)
+      );
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
-        _status = _logBuff.serializeFrom(s);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _logBuff.serializeFrom(s);
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::WARNING_HI,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
+      const char* _formatString =
+        "(%s) %s: Event Warning High occurred with argument: %s";
 #else
-        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
+      const char* _formatString =
+        "%s: Event Warning High occurred with argument: %s";
 #endif
 
-        Fw::String sStr;
-        s.toString(sStr);
+      Fw::String sStr;
+      s.toString(sStr);
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventWarningHigh ", sStr.toChar());
+        "EventWarningHigh ",
+        sStr.toChar()
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::WARNING_HI,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
+  void ActiveTestComponentBase ::
+    log_WARNING_LO_EventWarningLowThrottled()
+  {
     // Check throttle value
     if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventWarningLowThrottledThrottle++;
+      return;
+    }
+    else {
+      this->m_EventWarningLowThrottledThrottle++;
     }
 
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+      Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(0));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::WARNING_LO,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+      const char* _formatString =
+        "(%s) %s: Event Warning Low occurred";
 #else
-        const char* _formatString = "%s: Event Warning Low occurred";
+      const char* _formatString =
+        "%s: Event Warning Low occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventWarningLowThrottled ");
+        "EventWarningLowThrottled "
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::WARNING_LO,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
+  void ActiveTestComponentBase ::
+    log_WARNING_LO_EventWarningLowThrottledInterval()
+  {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+      this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
 
     // Check throttle value & throttle timeout
     {
-        Os::ScopeLock scopedLock(this->m_eventLock);
+      Os::ScopeLock scopedLock(this->m_eventLock);
 
-        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-            // The counter has overflowed, check if time interval has passed
-            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
-                Fw::TimeInterval(10, 0)) {
-                // Reset the count
-                this->m_EventWarningLowThrottledIntervalThrottle = 0;
-            } else {
-                // Throttle the event
-                return;
-            }
+      if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+        // The counter has overflowed, check if time interval has passed
+        if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
+          // Reset the count
+          this->m_EventWarningLowThrottledIntervalThrottle = 0;
+        } else {
+          // Throttle the event
+          return;
         }
+      }
 
-        // Reset the throttle time if needed
-        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-            // This is the first event, reset the throttle time
-            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
-        }
+      // Reset the throttle time if needed
+      if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+        // This is the first event, reset the throttle time
+        this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+      }
 
-        // Increment the count
-        this->m_EventWarningLowThrottledIntervalThrottle++;
+      // Increment the count
+      this->m_EventWarningLowThrottledIntervalThrottle++;
     }
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+      Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+      // Serialize the number of arguments
+      _status = _logBuff.serializeFrom(static_cast<U8>(0));
+      FW_ASSERT(
+        _status == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_status)
+      );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+      this->eventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::WARNING_LO,
+        _logBuff
+      );
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+      const char* _formatString =
+        "(%s) %s: Event Warning Low occurred";
 #else
-        const char* _formatString = "%s: Event Warning Low occurred";
+      const char* _formatString =
+        "%s: Event Warning Low occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+      Fw::TextLogString _logString;
+      _logString.format(
+        _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+        this->m_objName.toChar(),
 #endif
-                          "EventWarningLowThrottledInterval ");
+        "EventWarningLowThrottledInterval "
+      );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+      this->textEventOut_out(
+        0,
+        _id,
+        _logTime,
+        Fw::LogSeverity::WARNING_LO,
+        _logString
+      );
     }
 #endif
-}
+  }
 
-// ----------------------------------------------------------------------
-// Event throttle reset functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Event throttle reset functions
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
+  void ActiveTestComponentBase ::
+    log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
+  {
     // Reset throttle counter
     this->m_EventActivityLowThrottledThrottle = 0;
-}
+  }
 
-void ActiveTestComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
+  void ActiveTestComponentBase ::
+    log_FATAL_EventFatalThrottled_ThrottleClear()
+  {
     // Reset throttle counter
     this->m_EventFatalThrottledThrottle = 0;
-}
+  }
 
-void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
+  void ActiveTestComponentBase ::
+    log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
+  {
     // Reset throttle counter
     this->m_EventWarningLowThrottledThrottle = 0;
-}
+  }
 
-void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
+  void ActiveTestComponentBase ::
+    log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
+  {
     {
-        Os::ScopeLock scopedLock(this->m_eventLock);
+      Os::ScopeLock scopedLock(this->m_eventLock);
 
-        // Reset throttle counter
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+      // Reset throttle counter
+      this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-        // Reset the throttle time
-        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+      // Reset the throttle time
+      this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
     }
-}
+  }
 
-// ----------------------------------------------------------------------
-// Telemetry serialized write
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Telemetry serialized write
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite(
+        FwChanIdType id,
+        Fw::TlmBuffer& _tlmBuff,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
-            this->timeGetOut_out(0, _tlmTime);
-        }
+      if (
+        this->isConnected_timeGetOut_OutputPort(0) &&
+        (_tlmTime ==  Fw::ZERO_TIME)
+      ) {
+        this->timeGetOut_out(0, _tlmTime);
+      }
 
-        FwChanIdType _id;
-        _id = this->getIdBase() + id;
+      FwChanIdType _id;
+      _id = this->getIdBase() + id;
 
-        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
+      this->tlmOut_out(
+        0,
+        _id,
+        _tlmTime,
+        _tlmBuff
+      );
     }
-}
+  }
 
-// ----------------------------------------------------------------------
-// Telemetry write functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Telemetry write functions
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelU32Format(
+        U32 arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELU32FORMAT,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelF32Format(
+        F32 arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELF32FORMAT,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelStringFormat(
+        const Fw::StringBase& arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat =
-            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
-                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = arg.serializeTo(
+        _tlmBuff,
+        FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+      );
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELSTRINGFORMAT,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelEnum(
+        const E& arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELENUM,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelArrayFreq(
+        const A& arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELARRAYFREQ,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelStructFreq(
+        const S& arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELSTRUCTFREQ,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelU32Limits(
+        U32 arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELU32LIMITS,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelF32Limits(
+        F32 arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELF32LIMITS,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelF64(
+        F64 arg,
+        Fw::Time _tlmTime
+    ) const
+  {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELF64,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelU32OnChange(
+        U32 arg,
+        Fw::Time _tlmTime
+    )
+  {
     // Check to see if it is the first time
     if (not this->m_first_update_ChannelU32OnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelU32OnChange) {
-            return;
-        } else {
-            this->m_last_ChannelU32OnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelU32OnChange = false;
+      // Check to see if value has changed. If not, don't write it.
+      if (arg == this->m_last_ChannelU32OnChange) {
+        return;
+      }
+      else {
         this->m_last_ChannelU32OnChange = arg;
+      }
+    }
+    else {
+      this->m_first_update_ChannelU32OnChange = false;
+      this->m_last_ChannelU32OnChange = arg;
     }
 
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELU32ONCHANGE,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelEnumOnChange(
+        const E& arg,
+        Fw::Time _tlmTime
+    )
+  {
     // Check to see if it is the first time
     if (not this->m_first_update_ChannelEnumOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelEnumOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelEnumOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelEnumOnChange = false;
+      // Check to see if value has changed. If not, don't write it.
+      if (arg == this->m_last_ChannelEnumOnChange) {
+        return;
+      }
+      else {
         this->m_last_ChannelEnumOnChange = arg;
+      }
+    }
+    else {
+      this->m_first_update_ChannelEnumOnChange = false;
+      this->m_last_ChannelEnumOnChange = arg;
     }
 
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELENUMONCHANGE,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-void ActiveTestComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelBoolOnChange(
+        bool arg,
+        Fw::Time _tlmTime
+    )
+  {
     // Check to see if it is the first time
     if (not this->m_first_update_ChannelBoolOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelBoolOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelBoolOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelBoolOnChange = false;
+      // Check to see if value has changed. If not, don't write it.
+      if (arg == this->m_last_ChannelBoolOnChange) {
+        return;
+      }
+      else {
         this->m_last_ChannelBoolOnChange = arg;
+      }
+    }
+    else {
+      this->m_first_update_ChannelBoolOnChange = false;
+      this->m_last_ChannelBoolOnChange = arg;
     }
 
     if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
 
-        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+      this->tlmWrite(
+        CHANNELID_CHANNELBOOLONCHANGE,
+        _tlmBuff,
+        _tlmTime
+      );
     }
-}
+  }
 
-// ----------------------------------------------------------------------
-// Parameter hook functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Parameter hook functions
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::parameterUpdated(FwPrmIdType id) {
+  void ActiveTestComponentBase ::
+    parameterUpdated(FwPrmIdType id)
+  {
     // Do nothing by default
-}
+  }
 
-void ActiveTestComponentBase ::parametersLoaded() {
+  void ActiveTestComponentBase ::
+    parametersLoaded()
+  {
     // Do nothing by default
-}
+  }
 
-// ----------------------------------------------------------------------
-// Parameter get functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Parameter get functions
+  // ----------------------------------------------------------------------
 
-U32 ActiveTestComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
+  U32 ActiveTestComponentBase ::
+    paramGet_ParamU32(Fw::ParamValid& valid)
+  {
     U32 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamU32_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamU32;
+      _local = this->m_ParamU32;
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-F64 ActiveTestComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
+  F64 ActiveTestComponentBase ::
+    paramGet_ParamF64(Fw::ParamValid& valid)
+  {
     F64 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamF64_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamF64;
+      _local = this->m_ParamF64;
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-Fw::ParamString ActiveTestComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
+  Fw::ParamString ActiveTestComponentBase ::
+    paramGet_ParamString(Fw::ParamValid& valid)
+  {
     Fw::ParamString _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamString_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamString;
+      _local = this->m_ParamString;
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-E ActiveTestComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
+  E ActiveTestComponentBase ::
+    paramGet_ParamEnum(Fw::ParamValid& valid)
+  {
     E _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamEnum_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamEnum;
+      _local = this->m_ParamEnum;
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-A ActiveTestComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
+  A ActiveTestComponentBase ::
+    paramGet_ParamArray(Fw::ParamValid& valid)
+  {
     A _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamArray_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamArray;
+      _local = this->m_ParamArray;
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-S ActiveTestComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
+  S ActiveTestComponentBase ::
+    paramGet_ParamStruct(Fw::ParamValid& valid)
+  {
     S _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamStruct_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamStruct;
+      _local = this->m_ParamStruct;
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-I32 ActiveTestComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
+  I32 ActiveTestComponentBase ::
+    paramGet_ParamI32Ext(Fw::ParamValid& valid)
+  {
     I32 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamI32Ext_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+      Fw::ParamBuffer _paramBuffer;
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()),
+        PARAMID_PARAMI32EXT,
+        _paramBuffer
+      );
+      if(_stat == Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(_local);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      } else {
+        valid = Fw::ParamValid::INVALID;
+      }
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-F64 ActiveTestComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
+  F64 ActiveTestComponentBase ::
+    paramGet_ParamF64Ext(Fw::ParamValid& valid)
+  {
     F64 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamF64Ext_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+      Fw::ParamBuffer _paramBuffer;
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()),
+        PARAMID_PARAMF64EXT,
+        _paramBuffer
+      );
+      if(_stat == Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(_local);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      } else {
+        valid = Fw::ParamValid::INVALID;
+      }
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-Fw::ParamString ActiveTestComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
+  Fw::ParamString ActiveTestComponentBase ::
+    paramGet_ParamStringExt(Fw::ParamValid& valid)
+  {
     Fw::ParamString _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamStringExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+      Fw::ParamBuffer _paramBuffer;
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()),
+        PARAMID_PARAMSTRINGEXT,
+        _paramBuffer
+      );
+      if(_stat == Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(_local);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      } else {
+        valid = Fw::ParamValid::INVALID;
+      }
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-E ActiveTestComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
+  E ActiveTestComponentBase ::
+    paramGet_ParamEnumExt(Fw::ParamValid& valid)
+  {
     E _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamEnumExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+      Fw::ParamBuffer _paramBuffer;
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()),
+        PARAMID_PARAMENUMEXT,
+        _paramBuffer
+      );
+      if(_stat == Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(_local);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      } else {
+        valid = Fw::ParamValid::INVALID;
+      }
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-A ActiveTestComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
+  A ActiveTestComponentBase ::
+    paramGet_ParamArrayExt(Fw::ParamValid& valid)
+  {
     A _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamArrayExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+      Fw::ParamBuffer _paramBuffer;
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()),
+        PARAMID_PARAMARRAYEXT,
+        _paramBuffer
+      );
+      if(_stat == Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(_local);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      } else {
+        valid = Fw::ParamValid::INVALID;
+      }
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-S ActiveTestComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
+  S ActiveTestComponentBase ::
+    paramGet_ParamStructExt(Fw::ParamValid& valid)
+  {
     S _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamStructExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+      Fw::ParamBuffer _paramBuffer;
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()),
+        PARAMID_PARAMSTRUCTEXT,
+        _paramBuffer
+      );
+      if(_stat == Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(_local);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+      } else {
+        valid = Fw::ParamValid::INVALID;
+      }
     }
     this->m_paramLock.unlock();
     return _local;
-}
+  }
 
-// ----------------------------------------------------------------------
-// External parameter delegate initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // External parameter delegate initialization
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
+  void ActiveTestComponentBase ::
+    registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
+  {
     FW_ASSERT(paramExternalDelegatePtr != nullptr);
     this->paramDelegatePtr = paramExternalDelegatePtr;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Functions for managing data products
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Functions for managing data products
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+  void ActiveTestComponentBase ::
+    dpSend(
+        DpContainer& container,
+        Fw::Time timeTag
+    )
+  {
     // Update the time tag
     if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
+      // Get the time from the time port
+      timeTag = this->getTime();
     }
     container.setTimeTag(timeTag);
     // Serialize the header into the packet
@@ -4515,1015 +7218,1654 @@ void ActiveTestComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) 
     const FwSizeType packetSize = container.getPacketSize();
     Fw::Buffer buffer = container.getBuffer();
     FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
+        static_cast<FwAssertArgType>(buffer.getSize()));
     buffer.setSize(static_cast<U32>(packetSize));
     // Invalidate the buffer in the container, so it can't be reused
     container.invalidateBuffer();
     // Send the buffer
     this->productSendOut_out(0, container.getId(), buffer);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Time
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Time
+  // ----------------------------------------------------------------------
 
-Fw::Time ActiveTestComponentBase ::getTime() const {
+  Fw::Time ActiveTestComponentBase ::
+    getTime() const
+  {
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+      Fw::Time _time;
+      this->timeGetOut_out(0, _time);
+      return _time;
     }
-}
+    else {
+      return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
+  }
 
-// ----------------------------------------------------------------------
-// Mutex operations for guarded ports
-//
-// You can override these operations to provide more sophisticated
-// synchronization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Mutex operations for guarded ports
+  //
+  // You can override these operations to provide more sophisticated
+  // synchronization
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::lock() {
+  void ActiveTestComponentBase ::
+    lock()
+  {
     this->m_guardedPortMutex.lock();
-}
+  }
 
-void ActiveTestComponentBase ::unLock() {
+  void ActiveTestComponentBase ::
+    unLock()
+  {
     this->m_guardedPortMutex.unLock();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus ActiveTestComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus ActiveTestComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::BLOCKING,
+      _priority
+    );
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == ACTIVETEST_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle async input port productRecvIn
-        case PRODUCTRECVIN_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle async input port productRecvIn
+      case PRODUCTRECVIN_DPRESPONSE: {
+        // Deserialize argument id
+        FwDpIdType id;
+        _deserStatus = _msg.deserializeTo(id);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument buffer
+        Fw::Buffer buffer;
+        _deserStatus = _msg.deserializeTo(buffer);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvIn_handler(portNum, id, buffer, status);
+        // Deserialize argument status
+        Fw::Success status;
+        _deserStatus = _msg.deserializeTo(status);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+        // Call handler function
+        this->productRecvIn_handler(
+          portNum,
+          id,
+          buffer,
+          status
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle async input port aliasTypedAsync
+      case ALIASTYPEDASYNC_ALIASTYPED: {
+        // Deserialize argument u32
+        AliasPrim1 u32;
+        _deserStatus = _msg.deserializeTo(u32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument f32
+        AliasPrim2 f32;
+        _deserStatus = _msg.deserializeTo(f32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument b
+        AliasBool b;
+        _deserStatus = _msg.deserializeTo(b);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument str2
+        char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+        Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+        _deserStatus = _msg.deserializeTo(str2);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument e
+        AliasEnum e;
+        _deserStatus = _msg.deserializeTo(e);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument a
+        AliasArray a;
+        _deserStatus = _msg.deserializeTo(a);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+        // Deserialize argument s
+        AliasStruct s;
+        _deserStatus = _msg.deserializeTo(s);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+        // Call handler function
+        this->aliasTypedAsync_handler(
+          portNum,
+          u32,
+          f32,
+          b,
+          str2,
+          e,
+          a,
+          s
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
+      // Handle async input port noArgsAsync
+      case NOARGSASYNC_NOARGS: {
+        // Call handler function
+        this->noArgsAsync_handler(portNum);
 
-            break;
-        }
+        break;
+      }
 
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle async input port typedAsync
+      case TYPEDASYNC_TYPED: {
+        // Deserialize argument u32
+        U32 u32;
+        _deserStatus = _msg.deserializeTo(u32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument f32
+        F32 f32;
+        _deserStatus = _msg.deserializeTo(f32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument b
+        bool b;
+        _deserStatus = _msg.deserializeTo(b);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument str1
+        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+        _deserStatus = _msg.deserializeTo(str1);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument e
+        E e;
+        _deserStatus = _msg.deserializeTo(e);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument a
+        A a;
+        _deserStatus = _msg.deserializeTo(a);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+        // Deserialize argument s
+        S s;
+        _deserStatus = _msg.deserializeTo(s);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+        // Call handler function
+        this->typedAsync_handler(
+          portNum,
+          u32,
+          f32,
+          b,
+          str1,
+          e,
+          a,
+          s
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle async input port typedAsyncAssert
+      case TYPEDASYNCASSERT_TYPED: {
+        // Deserialize argument u32
+        U32 u32;
+        _deserStatus = _msg.deserializeTo(u32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument f32
+        F32 f32;
+        _deserStatus = _msg.deserializeTo(f32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument b
+        bool b;
+        _deserStatus = _msg.deserializeTo(b);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument str1
+        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+        _deserStatus = _msg.deserializeTo(str1);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument e
+        E e;
+        _deserStatus = _msg.deserializeTo(e);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument a
+        A a;
+        _deserStatus = _msg.deserializeTo(a);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+        // Deserialize argument s
+        S s;
+        _deserStatus = _msg.deserializeTo(s);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+        // Call handler function
+        this->typedAsyncAssert_handler(
+          portNum,
+          u32,
+          f32,
+          b,
+          str1,
+          e,
+          a,
+          s
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle async input port typedAsyncBlockPriority
+      case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+        // Deserialize argument u32
+        U32 u32;
+        _deserStatus = _msg.deserializeTo(u32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument f32
+        F32 f32;
+        _deserStatus = _msg.deserializeTo(f32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument b
+        bool b;
+        _deserStatus = _msg.deserializeTo(b);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument str1
+        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+        _deserStatus = _msg.deserializeTo(str1);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument e
+        E e;
+        _deserStatus = _msg.deserializeTo(e);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument a
+        A a;
+        _deserStatus = _msg.deserializeTo(a);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+        // Deserialize argument s
+        S s;
+        _deserStatus = _msg.deserializeTo(s);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+        // Call handler function
+        this->typedAsyncBlockPriority_handler(
+          portNum,
+          u32,
+          f32,
+          b,
+          str1,
+          e,
+          a,
+          s
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle async input port typedAsyncDropPriority
+      case TYPEDASYNCDROPPRIORITY_TYPED: {
+        // Deserialize argument u32
+        U32 u32;
+        _deserStatus = _msg.deserializeTo(u32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument f32
+        F32 f32;
+        _deserStatus = _msg.deserializeTo(f32);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument b
+        bool b;
+        _deserStatus = _msg.deserializeTo(b);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument str1
+        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+        _deserStatus = _msg.deserializeTo(str1);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument e
+        E e;
+        _deserStatus = _msg.deserializeTo(e);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize argument a
+        A a;
+        _deserStatus = _msg.deserializeTo(a);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+        // Deserialize argument s
+        S s;
+        _deserStatus = _msg.deserializeTo(s);
+        FW_ASSERT(
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+        // Call handler function
+        this->typedAsyncDropPriority_handler(
+          portNum,
+          u32,
+          f32,
+          b,
+          str1,
+          e,
+          a,
+          s
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle command CMD_ASYNC
-        case CMD_CMD_ASYNC: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle command CMD_ASYNC
+      case CMD_CMD_ASYNC: {
+        // Deserialize opcode
+        FwOpcodeType _opCode = 0;
+        _deserStatus = _msg.deserializeTo(_opCode);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize command sequence
+        U32 _cmdSeq = 0;
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize command argument buffer
+        Fw::CmdArgBuffer args;
+        _deserStatus = _msg.deserializeTo(args);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Reset buffer
-            args.resetDeser();
+        // Reset buffer
+        args.resetDeser();
 
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
+        // Make sure there was no data left over.
+        // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
+        if (args.getDeserializeSizeLeft() != 0) {
+          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+          }
+          // Don't crash the task if bad arguments were passed from the ground
+          break;
+        }
 #endif
 
-            // Call handler function
-            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+        // Call handler function
+        this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
 
-            break;
-        }
+        break;
+      }
 
-        // Handle command CMD_PRIORITY
-        case CMD_CMD_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle command CMD_PRIORITY
+      case CMD_CMD_PRIORITY: {
+        // Deserialize opcode
+        FwOpcodeType _opCode = 0;
+        _deserStatus = _msg.deserializeTo(_opCode);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize command sequence
+        U32 _cmdSeq = 0;
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize command argument buffer
+        Fw::CmdArgBuffer args;
+        _deserStatus = _msg.deserializeTo(args);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Reset buffer
-            args.resetDeser();
+        // Reset buffer
+        args.resetDeser();
 
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
+        // Make sure there was no data left over.
+        // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
+        if (args.getDeserializeSizeLeft() != 0) {
+          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+          }
+          // Don't crash the task if bad arguments were passed from the ground
+          break;
+        }
 #endif
 
-            // Call handler function
-            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+        // Call handler function
+        this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
 
-            break;
+        break;
+      }
+
+      // Handle command CMD_PARAMS_PRIORITY
+      case CMD_CMD_PARAMS_PRIORITY: {
+        // Deserialize opcode
+        FwOpcodeType _opCode = 0;
+        _deserStatus = _msg.deserializeTo(_opCode);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+
+        // Deserialize command sequence
+        U32 _cmdSeq = 0;
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+
+        // Deserialize command argument buffer
+        Fw::CmdArgBuffer args;
+        _deserStatus = _msg.deserializeTo(args);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+
+        // Reset buffer
+        args.resetDeser();
+
+        // Deserialize argument u32
+        U32 u32;
+        _deserStatus = args.deserializeTo(u32);
+        if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponse_out(
+                _opCode,
+                _cmdSeq,
+                Fw::CmdResponse::FORMAT_ERROR
+            );
+          }
+          // Don't crash the task if bad arguments were passed from the ground
+          break;
         }
 
-        // Handle command CMD_PARAMS_PRIORITY
-        case CMD_CMD_PARAMS_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
+        // Make sure there was no data left over.
+        // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
+        if (args.getDeserializeSizeLeft() != 0) {
+          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+          }
+          // Don't crash the task if bad arguments were passed from the ground
+          break;
+        }
 #endif
 
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
+        // Call handler function
+        this->CMD_PARAMS_PRIORITY_cmdHandler(
+          _opCode, _cmdSeq,
+          u32
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle command CMD_DROP
-        case CMD_CMD_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Handle command CMD_DROP
+      case CMD_CMD_DROP: {
+        // Deserialize opcode
+        FwOpcodeType _opCode = 0;
+        _deserStatus = _msg.deserializeTo(_opCode);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize command sequence
+        U32 _cmdSeq = 0;
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+        // Deserialize command argument buffer
+        Fw::CmdArgBuffer args;
+        _deserStatus = _msg.deserializeTo(args);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Reset buffer
-            args.resetDeser();
+        // Reset buffer
+        args.resetDeser();
 
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
+        // Make sure there was no data left over.
+        // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
+        if (args.getDeserializeSizeLeft() != 0) {
+          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+          }
+          // Don't crash the task if bad arguments were passed from the ground
+          break;
+        }
 #endif
 
-            // Call handler function
-            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+        // Call handler function
+        this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
 
-            break;
+        break;
+      }
+
+      // Handle command CMD_PARAMS_PRIORITY_DROP
+      case CMD_CMD_PARAMS_PRIORITY_DROP: {
+        // Deserialize opcode
+        FwOpcodeType _opCode = 0;
+        _deserStatus = _msg.deserializeTo(_opCode);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+
+        // Deserialize command sequence
+        U32 _cmdSeq = 0;
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+
+        // Deserialize command argument buffer
+        Fw::CmdArgBuffer args;
+        _deserStatus = _msg.deserializeTo(args);
+        FW_ASSERT (
+          _deserStatus == Fw::FW_SERIALIZE_OK,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
+
+        // Reset buffer
+        args.resetDeser();
+
+        // Deserialize argument u32
+        U32 u32;
+        _deserStatus = args.deserializeTo(u32);
+        if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponse_out(
+                _opCode,
+                _cmdSeq,
+                Fw::CmdResponse::FORMAT_ERROR
+            );
+          }
+          // Don't crash the task if bad arguments were passed from the ground
+          break;
         }
 
-        // Handle command CMD_PARAMS_PRIORITY_DROP
-        case CMD_CMD_PARAMS_PRIORITY_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
+        // Make sure there was no data left over.
+        // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
+        if (args.getDeserializeSizeLeft() != 0) {
+          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+          }
+          // Don't crash the task if bad arguments were passed from the ground
+          break;
+        }
 #endif
 
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
+        // Call handler function
+        this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
+          _opCode, _cmdSeq,
+          u32
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle internal interface internalArray
-        case INT_IF_INTERNALARRAY: {
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
+      // Handle internal interface internalArray
+      case INT_IF_INTERNALARRAY: {
+        A a;
+        _deserStatus = _msg.deserializeTo(a);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+        // Make sure there was no data left over.
+        // That means the buffer size was incorrect.
+        FW_ASSERT(
+          _msg.getDeserializeSizeLeft() == 0,
+          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+        );
 
-            // Call handler function
-            this->internalArray_internalInterfaceHandler(a);
+        // Call handler function
+        this->internalArray_internalInterfaceHandler(
+          a
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle internal interface internalEnum
-        case INT_IF_INTERNALENUM: {
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
+      // Handle internal interface internalEnum
+      case INT_IF_INTERNALENUM: {
+        E e;
+        _deserStatus = _msg.deserializeTo(e);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+        // Make sure there was no data left over.
+        // That means the buffer size was incorrect.
+        FW_ASSERT(
+          _msg.getDeserializeSizeLeft() == 0,
+          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+        );
 
-            // Call handler function
-            this->internalEnum_internalInterfaceHandler(e);
+        // Call handler function
+        this->internalEnum_internalInterfaceHandler(
+          e
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle internal interface internalPrimitive
-        case INT_IF_INTERNALPRIMITIVE: {
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
+      // Handle internal interface internalPrimitive
+      case INT_IF_INTERNALPRIMITIVE: {
+        U32 u32;
+        _deserStatus = _msg.deserializeTo(u32);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
+        F32 f32;
+        _deserStatus = _msg.deserializeTo(f32);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
+        bool b;
+        _deserStatus = _msg.deserializeTo(b);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+        // Make sure there was no data left over.
+        // That means the buffer size was incorrect.
+        FW_ASSERT(
+          _msg.getDeserializeSizeLeft() == 0,
+          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+        );
 
-            // Call handler function
-            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
+        // Call handler function
+        this->internalPrimitive_internalInterfaceHandler(
+          u32,
+          f32,
+          b
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle internal interface internalPriorityDrop
-        case INT_IF_INTERNALPRIORITYDROP: {
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+      // Handle internal interface internalPriorityDrop
+      case INT_IF_INTERNALPRIORITYDROP: {
+        // Make sure there was no data left over.
+        // That means the buffer size was incorrect.
+        FW_ASSERT(
+          _msg.getDeserializeSizeLeft() == 0,
+          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+        );
 
-            // Call handler function
-            this->internalPriorityDrop_internalInterfaceHandler();
+        // Call handler function
+        this->internalPriorityDrop_internalInterfaceHandler();
 
-            break;
-        }
+        break;
+      }
 
-        // Handle internal interface internalString
-        case INT_IF_INTERNALSTRING: {
-            Fw::InternalInterfaceString str1;
-            _deserStatus = _msg.deserializeTo(str1);
+      // Handle internal interface internalString
+      case INT_IF_INTERNALSTRING: {
+        Fw::InternalInterfaceString str1;
+        _deserStatus = _msg.deserializeTo(str1);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            Fw::InternalInterfaceString str2;
-            _deserStatus = _msg.deserializeTo(str2);
+        Fw::InternalInterfaceString str2;
+        _deserStatus = _msg.deserializeTo(str2);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+        // Make sure there was no data left over.
+        // That means the buffer size was incorrect.
+        FW_ASSERT(
+          _msg.getDeserializeSizeLeft() == 0,
+          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+        );
 
-            // Call handler function
-            this->internalString_internalInterfaceHandler(str1, str2);
+        // Call handler function
+        this->internalString_internalInterfaceHandler(
+          str1,
+          str2
+        );
 
-            break;
-        }
+        break;
+      }
 
-        // Handle internal interface internalStruct
-        case INT_IF_INTERNALSTRUCT: {
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
+      // Handle internal interface internalStruct
+      case INT_IF_INTERNALSTRUCT: {
+        S s;
+        _deserStatus = _msg.deserializeTo(s);
 
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+        // Internal interface should always deserialize
+        FW_ASSERT(
+          Fw::FW_SERIALIZE_OK == _deserStatus,
+          static_cast<FwAssertArgType>(_deserStatus)
+        );
 
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+        // Make sure there was no data left over.
+        // That means the buffer size was incorrect.
+        FW_ASSERT(
+          _msg.getDeserializeSizeLeft() == 0,
+          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+        );
 
-            // Call handler function
-            this->internalStruct_internalInterfaceHandler(s);
+        // Call handler function
+        this->internalStruct_internalInterfaceHandler(
+          s
+        );
 
-            break;
-        }
+        break;
+      }
 
-        default:
-            return MSG_DISPATCH_ERROR;
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Calls for messages received on special input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Calls for messages received on special input ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                            FwIndexType portNum,
-                                            FwOpcodeType opCode,
-                                            U32 cmdSeq,
-                                            Fw::CmdArgBuffer& args) {
+  void ActiveTestComponentBase ::
+    m_p_cmdIn_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        Fw::CmdArgBuffer& args
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
-}
+    compPtr->cmdIn_handlerBase(
+      portNum,
+      opCode,
+      cmdSeq,
+      args
+    );
+  }
 
-void ActiveTestComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    FwDpIdType id,
-                                                    const Fw::Buffer& buffer,
-                                                    const Fw::Success& status) {
+  void ActiveTestComponentBase ::
+    m_p_productRecvIn_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        FwDpIdType id,
+        const Fw::Buffer& buffer,
+        const Fw::Success& status
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
-}
+    compPtr->productRecvIn_handlerBase(
+      portNum,
+      id,
+      buffer,
+      status
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Calls for messages received on typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Calls for messages received on typed input ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      AliasPrim1 u32,
-                                                      AliasPrim2 f32,
-                                                      AliasBool b,
-                                                      const Fw::StringBase& str2,
-                                                      const AliasEnum& e,
-                                                      const AliasArray& a,
-                                                      const AliasStruct& s) {
+  void ActiveTestComponentBase ::
+    m_p_aliasTypedAsync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
-}
+    compPtr->aliasTypedAsync_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-Fw::String ActiveTestComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum) {
+  Fw::String ActiveTestComponentBase ::
+    m_p_noArgsAliasStringReturnSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
-}
+  }
 
-void ActiveTestComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+  void ActiveTestComponentBase ::
+    m_p_noArgsAsync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsAsync_handlerBase(portNum);
-}
+  }
 
-void ActiveTestComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+  void ActiveTestComponentBase ::
+    m_p_noArgsGuarded_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsGuarded_handlerBase(portNum);
-}
+  }
 
-U32 ActiveTestComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+  U32 ActiveTestComponentBase ::
+    m_p_noArgsReturnGuarded_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsReturnGuarded_handlerBase(portNum);
-}
+  }
 
-U32 ActiveTestComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+  U32 ActiveTestComponentBase ::
+    m_p_noArgsReturnSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsReturnSync_handlerBase(portNum);
-}
+  }
 
-Fw::String ActiveTestComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum) {
+  Fw::String ActiveTestComponentBase ::
+    m_p_noArgsStringReturnSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsStringReturnSync_handlerBase(portNum);
-}
+  }
 
-void ActiveTestComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+  void ActiveTestComponentBase ::
+    m_p_noArgsSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsSync_handlerBase(portNum);
-}
+  }
 
-void ActiveTestComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
+  void ActiveTestComponentBase ::
+    m_p_typedAliasGuarded_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
-}
+    compPtr->typedAliasGuarded_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-AliasPrim2 ActiveTestComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
+  AliasPrim2 ActiveTestComponentBase ::
+    m_p_typedAliasReturnSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AliasStruct& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
-}
+    return compPtr->typedAliasReturnSync_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-Fw::String ActiveTestComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AnotherAliasStruct& s) {
+  Fw::String ActiveTestComponentBase ::
+    m_p_typedAliasStringReturnSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        AliasPrim1 u32,
+        AliasPrim2 f32,
+        AliasBool b,
+        const Fw::StringBase& str2,
+        const AliasEnum& e,
+        const AliasArray& a,
+        const AnotherAliasStruct& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
-}
+    return compPtr->typedAliasStringReturnSync_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                 FwIndexType portNum,
-                                                 U32 u32,
-                                                 F32 f32,
-                                                 bool b,
-                                                 const Fw::StringBase& str1,
-                                                 const E& e,
-                                                 const A& a,
-                                                 const S& s) {
+  void ActiveTestComponentBase ::
+    m_p_typedAsync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
-}
+    compPtr->typedAsync_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
+  void ActiveTestComponentBase ::
+    m_p_typedAsyncAssert_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
-}
+    compPtr->typedAsyncAssert_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
+  void ActiveTestComponentBase ::
+    m_p_typedAsyncBlockPriority_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
-}
+    compPtr->typedAsyncBlockPriority_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
+  void ActiveTestComponentBase ::
+    m_p_typedAsyncDropPriority_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
-}
+    compPtr->typedAsyncDropPriority_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
+  void ActiveTestComponentBase ::
+    m_p_typedGuarded_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
-}
+    compPtr->typedGuarded_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
-F32 ActiveTestComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str2,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
+  F32 ActiveTestComponentBase ::
+    m_p_typedReturnGuarded_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
-}
+    return compPtr->typedReturnGuarded_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-F32 ActiveTestComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str2,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
+  F32 ActiveTestComponentBase ::
+    m_p_typedReturnSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
-}
+    return compPtr->typedReturnSync_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str2,
+      e,
+      a,
+      s
+    );
+  }
 
-void ActiveTestComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                FwIndexType portNum,
-                                                U32 u32,
-                                                F32 f32,
-                                                bool b,
-                                                const Fw::StringBase& str1,
-                                                const E& e,
-                                                const A& a,
-                                                const S& s) {
+  void ActiveTestComponentBase ::
+    m_p_typedSync_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
-}
+    compPtr->typedSync_handlerBase(
+      portNum,
+      u32,
+      f32,
+      b,
+      str1,
+      e,
+      a,
+      s
+    );
+  }
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Invocation functions for special output ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Invocation functions for special output ports
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    cmdRegOut_out(
+        FwIndexType portNum,
+        FwOpcodeType opCode
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
-}
+    FW_ASSERT(
+      this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_cmdRegOut_OutputPort[portNum].invoke(
+      opCode
+    );
+  }
 
-void ActiveTestComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                  FwOpcodeType opCode,
-                                                  U32 cmdSeq,
-                                                  const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    cmdResponseOut_out(
+        FwIndexType portNum,
+        FwOpcodeType opCode,
+        U32 cmdSeq,
+        const Fw::CmdResponse& response
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
-}
+    FW_ASSERT(
+      this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(
+      opCode,
+      cmdSeq,
+      response
+    );
+  }
 
-void ActiveTestComponentBase ::eventOut_out(FwIndexType portNum,
-                                            FwEventIdType id,
-                                            Fw::Time& timeTag,
-                                            const Fw::LogSeverity& severity,
-                                            Fw::LogBuffer& args) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    eventOut_out(
+        FwIndexType portNum,
+        FwEventIdType id,
+        Fw::Time& timeTag,
+        const Fw::LogSeverity& severity,
+        Fw::LogBuffer& args
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
-}
+    FW_ASSERT(
+      this->m_eventOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_eventOut_OutputPort[portNum].invoke(
+      id,
+      timeTag,
+      severity,
+      args
+    );
+  }
 
-Fw::ParamValid ActiveTestComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                       FwPrmIdType id,
-                                                       Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  Fw::ParamValid ActiveTestComponentBase ::
+    prmGetOut_out(
+        FwIndexType portNum,
+        FwPrmIdType id,
+        Fw::ParamBuffer& val
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
-}
+    FW_ASSERT(
+      this->m_prmGetOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    return this->m_prmGetOut_OutputPort[portNum].invoke(
+      id,
+      val
+    );
+  }
 
-void ActiveTestComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    prmSetOut_out(
+        FwIndexType portNum,
+        FwPrmIdType id,
+        Fw::ParamBuffer& val
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
-}
+    FW_ASSERT(
+      this->m_prmSetOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_prmSetOut_OutputPort[portNum].invoke(
+      id,
+      val
+    );
+  }
 
-void ActiveTestComponentBase ::productRequestOut_out(FwIndexType portNum, FwDpIdType id, FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    productRequestOut_out(
+        FwIndexType portNum,
+        FwDpIdType id,
+        FwSizeType dataSize
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
-}
+    FW_ASSERT(
+      this->m_productRequestOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_productRequestOut_OutputPort[portNum].invoke(
+      id,
+      dataSize
+    );
+  }
 
-void ActiveTestComponentBase ::productSendOut_out(FwIndexType portNum, FwDpIdType id, const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    productSendOut_out(
+        FwIndexType portNum,
+        FwDpIdType id,
+        const Fw::Buffer& buffer
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
-}
+    FW_ASSERT(
+      this->m_productSendOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_productSendOut_OutputPort[portNum].invoke(
+      id,
+      buffer
+    );
+  }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void ActiveTestComponentBase ::textEventOut_out(FwIndexType portNum,
-                                                FwEventIdType id,
-                                                Fw::Time& timeTag,
-                                                const Fw::LogSeverity& severity,
-                                                Fw::TextLogString& text) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+  void ActiveTestComponentBase ::
+    textEventOut_out(
+        FwIndexType portNum,
+        FwEventIdType id,
+        Fw::Time& timeTag,
+        const Fw::LogSeverity& severity,
+        Fw::TextLogString& text
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
-}
-
-#endif
-
-void ActiveTestComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
-
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
-}
-
-void ActiveTestComponentBase ::tlmOut_out(FwIndexType portNum,
-                                          FwChanIdType id,
-                                          Fw::Time& timeTag,
-                                          Fw::TlmBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
-
-    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
-}
+    FW_ASSERT(
+      this->m_textEventOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_textEventOut_OutputPort[portNum].invoke(
+      id,
+      timeTag,
+      severity,
+      text
+    );
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Parameter set functions
-// ----------------------------------------------------------------------
+  void ActiveTestComponentBase ::
+    timeGetOut_out(
+        FwIndexType portNum,
+        Fw::Time& time
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
+    FW_ASSERT(
+      this->m_timeGetOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_timeGetOut_OutputPort[portNum].invoke(
+      time
+    );
+  }
+
+  void ActiveTestComponentBase ::
+    tlmOut_out(
+        FwIndexType portNum,
+        FwChanIdType id,
+        Fw::Time& timeTag,
+        Fw::TlmBuffer& val
+    ) const
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
+
+    FW_ASSERT(
+      this->m_tlmOut_OutputPort[portNum].isConnected(),
+      static_cast<FwAssertArgType>(portNum)
+    );
+    this->m_tlmOut_OutputPort[portNum].invoke(
+      id,
+      timeTag,
+      val
+    );
+  }
+
+#endif
+
+  // ----------------------------------------------------------------------
+  // Parameter set functions
+  // ----------------------------------------------------------------------
+
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamU32(Fw::SerialBufferBase& val)
+  {
     U32 _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -5535,13 +8877,15 @@ Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMU32);
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamF64(Fw::SerialBufferBase& val)
+  {
     F64 _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -5553,13 +8897,15 @@ Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMF64);
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamString(Fw::SerialBufferBase& val)
+  {
     Fw::ParamString _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -5571,13 +8917,15 @@ Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamString(Fw::SerialBufferB
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMSTRING);
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamEnum(Fw::SerialBufferBase& val)
+  {
     E _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -5589,13 +8937,15 @@ Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBas
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMENUM);
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamArray(Fw::SerialBufferBase& val)
+  {
     A _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -5607,13 +8957,15 @@ Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamArray(Fw::SerialBufferBa
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMARRAY);
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamStruct(Fw::SerialBufferBase& val)
+  {
     S _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -5625,508 +8977,641 @@ Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamStruct(Fw::SerialBufferB
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMSTRUCT);
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
+  {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMI32EXT,
+      Fw::ParamValid::VALID,
+      val
+    );
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
+      this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+      _response = Fw::CmdResponse::OK;
+    }
+    else {
+      this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+      _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMI32EXT);
+      this->parameterUpdated(PARAMID_PARAMI32EXT);
     }
     return _response;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
+  {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMF64EXT,
+      Fw::ParamValid::VALID,
+      val
+    );
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
+      this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+      _response = Fw::CmdResponse::OK;
+    }
+    else {
+      this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+      _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMF64EXT);
+      this->parameterUpdated(PARAMID_PARAMF64EXT);
     }
     return _response;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamStringExt(Fw::SerialBufferBase& val)
+  {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRINGEXT,
+      Fw::ParamValid::VALID,
+      val
+    );
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+      _response = Fw::CmdResponse::OK;
+    }
+    else {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+      _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+      this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
     }
     return _response;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
+  {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMENUMEXT,
+      Fw::ParamValid::VALID,
+      val
+    );
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
+      this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+      _response = Fw::CmdResponse::OK;
+    }
+    else {
+      this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+      _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMENUMEXT);
+      this->parameterUpdated(PARAMID_PARAMENUMEXT);
     }
     return _response;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
+  {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMARRAYEXT,
+      Fw::ParamValid::VALID,
+      val
+    );
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+      _response = Fw::CmdResponse::OK;
+    }
+    else {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+      _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+      this->parameterUpdated(PARAMID_PARAMARRAYEXT);
     }
     return _response;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSet_ParamStructExt(Fw::SerialBufferBase& val)
+  {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRUCTEXT,
+      Fw::ParamValid::VALID,
+      val
+    );
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
+      this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+      _response = Fw::CmdResponse::OK;
+    }
+    else {
+      this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+      _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+      this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
     }
     return _response;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Parameter save functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Parameter save functions
+  // ----------------------------------------------------------------------
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamU32() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamU32()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamU32);
+    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+      _stat = _paramBuffer.serializeFrom(m_ParamU32);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamF64() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamF64()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamF64);
+    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+      _stat = _paramBuffer.serializeFrom(m_ParamF64);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamString() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamString()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamString);
+    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+      _stat = _paramBuffer.serializeFrom(m_ParamString);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamEnum() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamEnum()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+      _stat = _paramBuffer.serializeFrom(m_ParamEnum);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamArray() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamArray()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamArray);
+    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+      _stat = _paramBuffer.serializeFrom(m_ParamArray);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamStruct() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamStruct()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+      _stat = _paramBuffer.serializeFrom(m_ParamStruct);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamI32Ext() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamI32Ext()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
+    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(idBase),
+        PARAMID_PARAMI32EXT,
+        _paramBuffer
+      );
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamF64Ext() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamF64Ext()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
+    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(idBase),
+        PARAMID_PARAMF64EXT,
+        _paramBuffer
+      );
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamStringExt() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamStringExt()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
-                                                       _paramBuffer);
+    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(idBase),
+        PARAMID_PARAMSTRINGEXT,
+        _paramBuffer
+      );
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamEnumExt() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamEnumExt()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
-                                                       _paramBuffer);
+    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(idBase),
+        PARAMID_PARAMENUMEXT,
+        _paramBuffer
+      );
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamArrayExt() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamArrayExt()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
-                                                       _paramBuffer);
+    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(idBase),
+        PARAMID_PARAMARRAYEXT,
+        _paramBuffer
+      );
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamStructExt() {
+  Fw::CmdResponse ActiveTestComponentBase ::
+    paramSave_ParamStructExt()
+  {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
+      return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
-                                                       _paramBuffer);
+    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
+      _stat = this->paramDelegatePtr->serializeParam(
+        static_cast<FwPrmIdType>(idBase),
+        PARAMID_PARAMSTRUCTEXT,
+        _paramBuffer
+      );
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
+      return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
+    this->prmSetOut_out(
+      0,
+      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
+      _paramBuffer
+    );
     // Return the command response
     return Fw::CmdResponse::OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Private data product handling functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Private data product handling functions
+  // ----------------------------------------------------------------------
 
-void ActiveTestComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+  void ActiveTestComponentBase ::
+    dpRequest(
+        ContainerId::T containerId,
+        FwSizeType dataSize
+    )
+  {
     const FwDpIdType globalId = this->getIdBase() + containerId;
     const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
     this->productRequestOut_out(0, globalId, size);
-}
+  }
 
-void ActiveTestComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                     FwDpIdType id,
-                                                     const Fw::Buffer& buffer,
-                                                     const Fw::Success& status) {
+  void ActiveTestComponentBase ::
+    productRecvIn_handler(
+        const FwIndexType portNum,
+        FwDpIdType id,
+        const Fw::Buffer& buffer,
+        const Fw::Success& status
+    )
+  {
     DpContainer container;
     if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
+      container = DpContainer(id, buffer, this->getIdBase());
     }
     // Convert global id to local id
     const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    FW_ASSERT(
+      id >= idBase,
+      static_cast<FwAssertArgType>(id),
+      static_cast<FwAssertArgType>(idBase)
+    );
     const FwDpIdType localId = id - idBase;
     // Switch on the local id
     switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
+      case ContainerId::Container1:
+        // Set the priority
+        container.setPriority(ContainerPriority::Container1);
+        // Call the handler
+        this->dpRecv_Container1_handler(container, status.e);
+        break;
+      case ContainerId::Container2:
+        // Set the priority
+        container.setPriority(ContainerPriority::Container2);
+        // Call the handler
+        this->dpRecv_Container2_handler(container, status.e);
+        break;
+      case ContainerId::Container3:
+        // Set the priority
+        container.setPriority(ContainerPriority::Container3);
+        // Call the handler
+        this->dpRecv_Container3_handler(container, status.e);
+        break;
+      case ContainerId::Container4:
+        // Set the priority
+        container.setPriority(ContainerPriority::Container4);
+        // Call the handler
+        this->dpRecv_Container4_handler(container, status.e);
+        break;
+      case ContainerId::Container5:
+        // Set the priority
+        container.setPriority(ContainerPriority::Container5);
+        // Call the handler
+        this->dpRecv_Container5_handler(container, status.e);
+        break;
+      default:
+        FW_ASSERT(0);
+        break;
     }
-}
+  }
 
-}  // namespace M
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -13,2199 +13,1322 @@
 
 namespace M {
 
-  namespace {
-    enum MsgTypeEnum {
-      ACTIVETEST_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      PRODUCTRECVIN_DPRESPONSE,
-      ALIASTYPEDASYNC_ALIASTYPED,
-      NOARGSASYNC_NOARGS,
-      TYPEDASYNC_TYPED,
-      TYPEDASYNCASSERT_TYPED,
-      TYPEDASYNCBLOCKPRIORITY_TYPED,
-      TYPEDASYNCDROPPRIORITY_TYPED,
-      CMD_CMD_ASYNC,
-      CMD_CMD_PRIORITY,
-      CMD_CMD_PARAMS_PRIORITY,
-      CMD_CMD_DROP,
-      CMD_CMD_PARAMS_PRIORITY_DROP,
-      INT_IF_INTERNALARRAY,
-      INT_IF_INTERNALENUM,
-      INT_IF_INTERNALPRIMITIVE,
-      INT_IF_INTERNALPRIORITYDROP,
-      INT_IF_INTERNALSTRING,
-      INT_IF_INTERNALSTRUCT,
+namespace {
+enum MsgTypeEnum {
+    ACTIVETEST_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    PRODUCTRECVIN_DPRESPONSE,
+    ALIASTYPEDASYNC_ALIASTYPED,
+    NOARGSASYNC_NOARGS,
+    TYPEDASYNC_TYPED,
+    TYPEDASYNCASSERT_TYPED,
+    TYPEDASYNCBLOCKPRIORITY_TYPED,
+    TYPEDASYNCDROPPRIORITY_TYPED,
+    CMD_CMD_ASYNC,
+    CMD_CMD_PRIORITY,
+    CMD_CMD_PARAMS_PRIORITY,
+    CMD_CMD_DROP,
+    CMD_CMD_PARAMS_PRIORITY_DROP,
+    INT_IF_INTERNALARRAY,
+    INT_IF_INTERNALENUM,
+    INT_IF_INTERNALPRIMITIVE,
+    INT_IF_INTERNALPRIORITYDROP,
+    INT_IF_INTERNALSTRING,
+    INT_IF_INTERNALSTRUCT,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
+    BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
+    BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
+    BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
+    BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
+    BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
+    // Size of internalArray argument list
+    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
+    // Size of internalEnum argument list
+    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
+    // Size of internalPrimitive argument list
+    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
+    // Size of internalString argument list
+    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
+                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
+    // Size of internalStruct argument list
+    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
     };
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
-      BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
-      BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
-      BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
-      BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
-      BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
-      BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-      // Size of internalArray argument list
-      BYTE internalArrayIntIfSize[
-        A::SERIALIZED_SIZE
-      ];
-      // Size of internalEnum argument list
-      BYTE internalEnumIntIfSize[
-        E::SERIALIZED_SIZE
-      ];
-      // Size of internalPrimitive argument list
-      BYTE internalPrimitiveIntIfSize[
-        sizeof(U32) +
-        sizeof(F32) +
-        sizeof(U8)
-      ];
-      // Size of internalString argument list
-      BYTE internalStringIntIfSize[
-        Fw::InternalInterfaceString::SERIALIZED_SIZE +
-        Fw::InternalInterfaceString::SERIALIZED_SIZE
-      ];
-      // Size of internalStruct argument list
-      BYTE internalStructIntIfSize[
-        S::SERIALIZED_SIZE
-      ];
-    };
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-      public:
+// ----------------------------------------------------------------------
+// Types for data products
+// ----------------------------------------------------------------------
 
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
+ActiveTestComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
+ActiveTestComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Types for data products
-  // ----------------------------------------------------------------------
-
-  ActiveTestComponentBase::DpContainer ::
-    DpContainer(
-        FwDpIdType id,
-        const Fw::Buffer& buffer,
-        FwDpIdType baseId
-    ) :
-      Fw::DpContainer(id, buffer),
-      m_baseId(baseId)
-  {
-
-  }
-
-  ActiveTestComponentBase::DpContainer ::
-    DpContainer() :
-      Fw::DpContainer(),
-      m_baseId(0)
-  {
-
-  }
-
-  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
-    serializeRecord_DataArrayRecord(
-        const M::ActiveTest_Data* array,
-        FwSizeType size
-    )
-  {
+Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const M::ActiveTest_Data* array,
+    FwSizeType size) {
     FW_ASSERT(array != nullptr);
     // Compute the size delta
-    FwSizeType sizeDelta =
-      sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      sizeDelta += array[i].serializedSize();
+        sizeDelta += array[i].serializedSize();
     }
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-      const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-      status = this->m_dataBuffer.serializeFrom(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      for (FwSizeType i = 0; i < size; i++) {
-        status = this->m_dataBuffer.serializeFrom(array[i]);
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      }
-      this->m_dataSize += sizeDelta;
-    }
-    else {
-      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-  }
+}
 
-  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
-    serializeRecord_DataRecord(const M::ActiveTest_Data& elt)
-  {
-    const FwSizeType sizeDelta =
-      sizeof(FwDpIdType) +
-      elt.serializedSize();
+Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_DataRecord(const M::ActiveTest_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-      const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-      status = this->m_dataBuffer.serializeFrom(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serializeFrom(elt);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      this->m_dataSize += sizeDelta;
-    }
-    else {
-      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-  }
+}
 
-  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
-    serializeRecord_StringArrayRecord(
-        const Fw::StringBase** array,
-        FwSizeType size
-    )
-  {
+Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
     FW_ASSERT(array != nullptr);
     // Compute the size delta
     const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta =
-      sizeof(FwDpIdType) +
-      sizeof(FwSizeStoreType);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-    }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-      const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-      status = this->m_dataBuffer.serializeFrom(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase *const sbPtr = array[i];
+        const Fw::StringBase* const sbPtr = array[i];
         FW_ASSERT(sbPtr != nullptr);
-        status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      }
-      this->m_dataSize += sizeDelta;
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    else {
-      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-  }
+}
 
-  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
-    serializeRecord_StringRecord(const Fw::StringBase& elt)
-  {
+Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_StringRecord(const Fw::StringBase& elt) {
     const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta =
-      sizeof(FwDpIdType) +
-      elt.serializedTruncatedSize(stringSize);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-      const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-      status = this->m_dataBuffer.serializeFrom(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = elt.serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      this->m_dataSize += sizeDelta;
-    }
-    else {
-      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
-  }
-
-  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
-    serializeRecord_U32ArrayRecord(
-        const U32* array,
-        FwSizeType size
-    )
-  {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta =
-      sizeof(FwDpIdType) +
-      sizeof(FwSizeStoreType) +
-      size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-      const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-      status = this->m_dataBuffer.serializeFrom(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      for (FwSizeType i = 0; i < size; i++) {
-        status = this->m_dataBuffer.serializeFrom(array[i]);
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      }
-      this->m_dataSize += sizeDelta;
-    }
-    else {
-      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
-  }
-
-  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
-    serializeRecord_U32Record(U32 elt)
-  {
-    const FwSizeType sizeDelta =
-      sizeof(FwDpIdType) +
-      sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-      const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-      status = this->m_dataBuffer.serializeFrom(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serializeFrom(elt);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      this->m_dataSize += sizeDelta;
-    }
-    else {
-      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-  }
+}
 
-  Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::
-    serializeRecord_U8ArrayRecord(
-        const U8* array,
-        FwSizeType size
-    )
-  {
+Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                          FwSizeType size) {
     FW_ASSERT(array != nullptr);
     // Compute the size delta
-    const FwSizeType sizeDelta =
-      sizeof(FwDpIdType) +
-      sizeof(FwSizeStoreType) +
-      size * sizeof(U8);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-      const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-      status = this->m_dataBuffer.serializeFrom(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      this->m_dataSize += sizeDelta;
-    }
-    else {
-      status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
     return status;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
+Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
 
-  void ActiveTestComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+Fw::SerializeStatus ActiveTestComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                         FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
+
+void ActiveTestComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port cmdIn
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-      port++
-    ) {
-      this->m_cmdIn_InputPort[port].init();
-      this->m_cmdIn_InputPort[port].addCallComp(
-        this,
-        m_p_cmdIn_in
-      );
-      this->m_cmdIn_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port productRecvIn
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-      port++
-    ) {
-      this->m_productRecvIn_InputPort[port].init();
-      this->m_productRecvIn_InputPort[port].addCallComp(
-        this,
-        m_p_productRecvIn_in
-      );
-      this->m_productRecvIn_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port aliasTypedAsync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-      port++
-    ) {
-      this->m_aliasTypedAsync_InputPort[port].init();
-      this->m_aliasTypedAsync_InputPort[port].addCallComp(
-        this,
-        m_p_aliasTypedAsync_in
-      );
-      this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsAliasStringReturnSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-      port++
-    ) {
-      this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-      this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-        this,
-        m_p_noArgsAliasStringReturnSync_in
-      );
-      this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsAsync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-      port++
-    ) {
-      this->m_noArgsAsync_InputPort[port].init();
-      this->m_noArgsAsync_InputPort[port].addCallComp(
-        this,
-        m_p_noArgsAsync_in
-      );
-      this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsGuarded
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-      port++
-    ) {
-      this->m_noArgsGuarded_InputPort[port].init();
-      this->m_noArgsGuarded_InputPort[port].addCallComp(
-        this,
-        m_p_noArgsGuarded_in
-      );
-      this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsReturnGuarded
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-      port++
-    ) {
-      this->m_noArgsReturnGuarded_InputPort[port].init();
-      this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-        this,
-        m_p_noArgsReturnGuarded_in
-      );
-      this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsReturnSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-      port++
-    ) {
-      this->m_noArgsReturnSync_InputPort[port].init();
-      this->m_noArgsReturnSync_InputPort[port].addCallComp(
-        this,
-        m_p_noArgsReturnSync_in
-      );
-      this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsStringReturnSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-      port++
-    ) {
-      this->m_noArgsStringReturnSync_InputPort[port].init();
-      this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-        this,
-        m_p_noArgsStringReturnSync_in
-      );
-      this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port noArgsSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-      port++
-    ) {
-      this->m_noArgsSync_InputPort[port].init();
-      this->m_noArgsSync_InputPort[port].addCallComp(
-        this,
-        m_p_noArgsSync_in
-      );
-      this->m_noArgsSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAliasGuarded
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-      port++
-    ) {
-      this->m_typedAliasGuarded_InputPort[port].init();
-      this->m_typedAliasGuarded_InputPort[port].addCallComp(
-        this,
-        m_p_typedAliasGuarded_in
-      );
-      this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAliasReturnSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-      port++
-    ) {
-      this->m_typedAliasReturnSync_InputPort[port].init();
-      this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-        this,
-        m_p_typedAliasReturnSync_in
-      );
-      this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAliasStringReturnSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-      port++
-    ) {
-      this->m_typedAliasStringReturnSync_InputPort[port].init();
-      this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-        this,
-        m_p_typedAliasStringReturnSync_in
-      );
-      this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-      port++
-    ) {
-      this->m_typedAsync_InputPort[port].init();
-      this->m_typedAsync_InputPort[port].addCallComp(
-        this,
-        m_p_typedAsync_in
-      );
-      this->m_typedAsync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsyncAssert
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-      port++
-    ) {
-      this->m_typedAsyncAssert_InputPort[port].init();
-      this->m_typedAsyncAssert_InputPort[port].addCallComp(
-        this,
-        m_p_typedAsyncAssert_in
-      );
-      this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsyncBlockPriority
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-      port++
-    ) {
-      this->m_typedAsyncBlockPriority_InputPort[port].init();
-      this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-        this,
-        m_p_typedAsyncBlockPriority_in
-      );
-      this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedAsyncDropPriority
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-      port++
-    ) {
-      this->m_typedAsyncDropPriority_InputPort[port].init();
-      this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-        this,
-        m_p_typedAsyncDropPriority_in
-      );
-      this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedGuarded
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-      port++
-    ) {
-      this->m_typedGuarded_InputPort[port].init();
-      this->m_typedGuarded_InputPort[port].addCallComp(
-        this,
-        m_p_typedGuarded_in
-      );
-      this->m_typedGuarded_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedReturnGuarded
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-      port++
-    ) {
-      this->m_typedReturnGuarded_InputPort[port].init();
-      this->m_typedReturnGuarded_InputPort[port].addCallComp(
-        this,
-        m_p_typedReturnGuarded_in
-      );
-      this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedReturnSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-      port++
-    ) {
-      this->m_typedReturnSync_InputPort[port].init();
-      this->m_typedReturnSync_InputPort[port].addCallComp(
-        this,
-        m_p_typedReturnSync_in
-      );
-      this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port typedSync
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-      port++
-    ) {
-      this->m_typedSync_InputPort[port].init();
-      this->m_typedSync_InputPort[port].addCallComp(
-        this,
-        m_p_typedSync_in
-      );
-      this->m_typedSync_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port cmdRegOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-      port++
-    ) {
-      this->m_cmdRegOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port cmdResponseOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-      port++
-    ) {
-      this->m_cmdResponseOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port eventOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-      port++
-    ) {
-      this->m_eventOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port prmGetOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-      port++
-    ) {
-      this->m_prmGetOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port prmSetOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-      port++
-    ) {
-      this->m_prmSetOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port productRequestOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-      port++
-    ) {
-      this->m_productRequestOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port productSendOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-      port++
-    ) {
-      this->m_productSendOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
     // Connect output port textEventOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-      port++
-    ) {
-      this->m_textEventOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port timeGetOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-      port++
-    ) {
-      this->m_timeGetOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port tlmOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-      port++
-    ) {
-      this->m_tlmOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port noArgsOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-      port++
-    ) {
-      this->m_noArgsOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port noArgsReturnOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-      port++
-    ) {
-      this->m_noArgsReturnOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port noArgsStringReturnOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-      port++
-    ) {
-      this->m_noArgsStringReturnOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedAliasOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-      port++
-    ) {
-      this->m_typedAliasOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedAliasReturnOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-      port++
-    ) {
-      this->m_typedAliasReturnOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedAliasReturnStringOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-      port++
-    ) {
-      this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-      port++
-    ) {
-      this->m_typedOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect output port typedReturnOut
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-      port++
-    ) {
-      this->m_typedReturnOut_OutputPort[port].init();
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Getters for special input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Getters for special input ports
+// ----------------------------------------------------------------------
 
-  Fw::InputCmdPort* ActiveTestComponentBase ::
-    get_cmdIn_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Fw::InputCmdPort* ActiveTestComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return &this->m_cmdIn_InputPort[portNum];
-  }
+}
 
-  Fw::InputDpResponsePort* ActiveTestComponentBase ::
-    get_productRecvIn_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Fw::InputDpResponsePort* ActiveTestComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_productRecvIn_InputPort[portNum];
-  }
+}
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Getters for typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Getters for typed input ports
+// ----------------------------------------------------------------------
 
-  Ports::InputAliasTypedPort* ActiveTestComponentBase ::
-    get_aliasTypedAsync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputAliasTypedPort* ActiveTestComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_aliasTypedAsync_InputPort[portNum];
-  }
+}
 
-  Ports::InputNoArgsAliasStringReturnPort* ActiveTestComponentBase ::
-    get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputNoArgsAliasStringReturnPort* ActiveTestComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
-  }
+}
 
-  Ports::InputNoArgsPort* ActiveTestComponentBase ::
-    get_noArgsAsync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputNoArgsPort* ActiveTestComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_noArgsAsync_InputPort[portNum];
-  }
+}
 
-  Ports::InputNoArgsPort* ActiveTestComponentBase ::
-    get_noArgsGuarded_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputNoArgsPort* ActiveTestComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_noArgsGuarded_InputPort[portNum];
-  }
+}
 
-  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
-    get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_noArgsReturnGuarded_InputPort[portNum];
-  }
+}
 
-  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
-    get_noArgsReturnSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_noArgsReturnSync_InputPort[portNum];
-  }
+}
 
-  Ports::InputNoArgsStringReturnPort* ActiveTestComponentBase ::
-    get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputNoArgsStringReturnPort* ActiveTestComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_noArgsStringReturnSync_InputPort[portNum];
-  }
+}
 
-  Ports::InputNoArgsPort* ActiveTestComponentBase ::
-    get_noArgsSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputNoArgsPort* ActiveTestComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_noArgsSync_InputPort[portNum];
-  }
+}
 
-  Ports::InputAliasTypedPort* ActiveTestComponentBase ::
-    get_typedAliasGuarded_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputAliasTypedPort* ActiveTestComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedAliasGuarded_InputPort[portNum];
-  }
+}
 
-  Ports::InputAliasTypedReturnPort* ActiveTestComponentBase ::
-    get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputAliasTypedReturnPort* ActiveTestComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedAliasReturnSync_InputPort[portNum];
-  }
+}
 
-  Ports::InputAliasTypedReturnStringPort* ActiveTestComponentBase ::
-    get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputAliasTypedReturnStringPort* ActiveTestComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedAliasStringReturnSync_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedPort* ActiveTestComponentBase ::
-    get_typedAsync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedAsync_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedPort* ActiveTestComponentBase ::
-    get_typedAsyncAssert_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedAsyncAssert_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedPort* ActiveTestComponentBase ::
-    get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedAsyncBlockPriority_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedPort* ActiveTestComponentBase ::
-    get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedPort* ActiveTestComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedAsyncDropPriority_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedPort* ActiveTestComponentBase ::
-    get_typedGuarded_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedPort* ActiveTestComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedGuarded_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
-    get_typedReturnGuarded_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedReturnPort* ActiveTestComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedReturnGuarded_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
-    get_typedReturnSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedReturnPort* ActiveTestComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedReturnSync_InputPort[portNum];
-  }
+}
 
-  Ports::InputTypedPort* ActiveTestComponentBase ::
-    get_typedSync_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Ports::InputTypedPort* ActiveTestComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return &this->m_typedSync_InputPort[portNum];
-  }
+}
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Connect input ports to special output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Connect input ports to special output ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    set_cmdRegOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputCmdRegPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_cmdResponseOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputCmdResponsePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_eventOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputLogPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     this->m_eventOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_prmGetOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputPrmGetPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_prmSetOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputPrmSetPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_productRequestOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputDpRequestPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_productSendOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputDpSendPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_productSendOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-  void ActiveTestComponentBase ::
-    set_textEventOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputLogTextPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_textEventOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
 #endif
 
-  void ActiveTestComponentBase ::
-    set_timeGetOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputTimePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_tlmOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputTlmPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     this->m_tlmOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Connect typed input ports to typed output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Connect typed input ports to typed output ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    set_noArgsOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputNoArgsPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_noArgsReturnOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputNoArgsReturnPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_noArgsStringReturnOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputNoArgsStringReturnPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_typedAliasOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputAliasTypedPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_typedAliasReturnOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputAliasTypedReturnPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                  Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_typedAliasReturnStringOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputAliasTypedReturnStringPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_typedAliasReturnStringOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_typedOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputTypedPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     this->m_typedOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_typedReturnOut_OutputPort(
-        FwIndexType portNum,
-        Ports::InputTypedReturnPort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
-  }
+}
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_PORT_SERIALIZATION
 
-  // ----------------------------------------------------------------------
-  // Connect serial input ports to special output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Connect serial input ports to special output ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    set_cmdRegOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_cmdResponseOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_eventOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_prmSetOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_productRequestOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_productSendOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-  void ActiveTestComponentBase ::
-    set_textEventOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
 #endif
 
-  void ActiveTestComponentBase ::
-    set_timeGetOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_tlmOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_PORT_SERIALIZATION
 
-  // ----------------------------------------------------------------------
-  // Connect serial input ports to typed output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Connect serial input ports to typed output ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    set_noArgsOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_typedAliasOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    set_typedOut_OutputPort(
-        FwIndexType portNum,
-        Fw::InputSerializePort* port
-    )
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-  }
+}
 
 #endif
 
-  // ----------------------------------------------------------------------
-  // Command registration
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Command registration
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    regCommands()
-  {
+void ActiveTestComponentBase ::regCommands() {
     FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_SYNC
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_SYNC_STRING
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_SYNC_ENUM
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_GUARDED
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_GUARDED_STRING
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_ASYNC
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_PRIORITY
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_DROP
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMU32_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMU32_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMF64_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMF64_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRING_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRING_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMENUM_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMENUM_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMARRAY_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMARRAY_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRUCT_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMI32EXT_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMF64EXT_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMENUMEXT_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
-    );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
 
-    this->cmdRegOut_out(
-      0,
-      this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
-    );
-  }
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
+}
 
-  // ----------------------------------------------------------------------
-  // Parameter loading
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Parameter loading
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    loadParameters()
-  {
+void ActiveTestComponentBase ::loadParameters() {
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
     FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
@@ -2216,20 +1339,16 @@ namespace M {
     _id = _baseId + PARAMID_PARAMU32;
 
     // Get serialized parameter ParamU32
-    this->m_param_ParamU32_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-      _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-      if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
-      }
+        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+        }
     }
 
     this->m_paramLock.unlock();
@@ -2237,20 +1356,16 @@ namespace M {
     _id = _baseId + PARAMID_PARAMF64;
 
     // Get serialized parameter ParamF64
-    this->m_param_ParamF64_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-      _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-      if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
-      }
+        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+        }
     }
 
     this->m_paramLock.unlock();
@@ -2258,26 +1373,21 @@ namespace M {
     _id = _baseId + PARAMID_PARAMSTRING;
 
     // Get serialized parameter ParamString
-    this->m_param_ParamString_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-      _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-      if (_stat != Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
         this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-      }
-    }
-    else {
-      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-      this->m_ParamString = Fw::String("default");
+        this->m_ParamString = Fw::String("default");
     }
 
     this->m_paramLock.unlock();
@@ -2285,20 +1395,16 @@ namespace M {
     _id = _baseId + PARAMID_PARAMENUM;
 
     // Get serialized parameter ParamEnum
-    this->m_param_ParamEnum_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-      _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-      if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
-      }
+        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+        }
     }
 
     this->m_paramLock.unlock();
@@ -2306,26 +1412,21 @@ namespace M {
     _id = _baseId + PARAMID_PARAMARRAY;
 
     // Get serialized parameter ParamArray
-    this->m_param_ParamArray_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-      _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-      if (_stat != Fw::FW_SERIALIZE_OK) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
         this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-      }
-    }
-    else {
-      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-      this->m_ParamArray = A({1, 2, 3});
+        this->m_ParamArray = A({1, 2, 3});
     }
 
     this->m_paramLock.unlock();
@@ -2333,20 +1434,16 @@ namespace M {
     _id = _baseId + PARAMID_PARAMSTRUCT;
 
     // Get serialized parameter ParamStruct
-    this->m_param_ParamStruct_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-      _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-      if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
-      }
+        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+        }
     }
 
     this->m_paramLock.unlock();
@@ -2354,24 +1451,16 @@ namespace M {
     _id = _baseId + PARAMID_PARAMI32EXT;
 
     // Get serialized parameter ParamI32Ext
-    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMI32EXT,
-      this->m_param_ParamI32Ext_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
@@ -2379,24 +1468,16 @@ namespace M {
     _id = _baseId + PARAMID_PARAMF64EXT;
 
     // Get serialized parameter ParamF64Ext
-    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMF64EXT,
-      this->m_param_ParamF64Ext_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
@@ -2404,45 +1485,32 @@ namespace M {
     _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
     // Get serialized parameter ParamStringExt
-    this->m_param_ParamStringExt_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->deserializeParam(
-        _baseId,
-        PARAMID_PARAMSTRINGEXT,
-        this->m_param_ParamStringExt_valid,
-        _paramBuffer
-      );
-      if (_stat != Fw::FW_SERIALIZE_OK) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
         this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-      }
-    }
-    else {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-      Fw::String _val = Fw::String("external default");
-      _paramBuffer.resetSer();
-      _stat = _paramBuffer.serializeFrom(_val);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->deserializeParam(
-        _baseId,
-        PARAMID_PARAMSTRINGEXT,
-        this->m_param_ParamStringExt_valid,
-        _paramBuffer
-      );
-      if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-      }
+        Fw::String _val = Fw::String("external default");
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        }
     }
 
     this->m_paramLock.unlock();
@@ -2450,24 +1518,16 @@ namespace M {
     _id = _baseId + PARAMID_PARAMENUMEXT;
 
     // Get serialized parameter ParamEnumExt
-    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMENUMEXT,
-      this->m_param_ParamEnumExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
@@ -2475,45 +1535,32 @@ namespace M {
     _id = _baseId + PARAMID_PARAMARRAYEXT;
 
     // Get serialized parameter ParamArrayExt
-    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter or use default value
     if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->deserializeParam(
-        _baseId,
-        PARAMID_PARAMARRAYEXT,
-        this->m_param_ParamArrayExt_valid,
-        _paramBuffer
-      );
-      if (_stat != Fw::FW_SERIALIZE_OK) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
         this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-      }
-    }
-    else {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
     }
     if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-      A _val = A({1, 2, 3});
-      _paramBuffer.resetSer();
-      _stat = _paramBuffer.serializeFrom(_val);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->deserializeParam(
-        _baseId,
-        PARAMID_PARAMARRAYEXT,
-        this->m_param_ParamArrayExt_valid,
-        _paramBuffer
-      );
-      if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-      }
+        A _val = A({1, 2, 3});
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        }
     }
 
     this->m_paramLock.unlock();
@@ -2521,882 +1568,541 @@ namespace M {
     _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
     // Get serialized parameter ParamStructExt
-    this->m_param_ParamStructExt_valid = this->prmGetOut_out(
-      0,
-      _id,
-      _paramBuffer
-    );
+    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
     this->m_paramLock.lock();
 
     // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRUCTEXT,
-      this->m_param_ParamStructExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
+                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
     }
 
     this->m_paramLock.unlock();
 
     // Call notifier
     this->parametersLoaded();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  ActiveTestComponentBase ::
-    ActiveTestComponentBase(const char* compName) :
-      Fw::ActiveComponentBase(compName)
-  {
+ActiveTestComponentBase ::ActiveTestComponentBase(const char* compName) : Fw::ActiveComponentBase(compName) {
     this->m_EventActivityLowThrottledThrottle = 0;
     this->m_EventFatalThrottledThrottle = 0;
     this->m_EventWarningLowThrottledThrottle = 0;
     this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
     this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
-  }
+}
 
-  ActiveTestComponentBase ::
-    ~ActiveTestComponentBase()
-  {
-
-  }
+ActiveTestComponentBase ::~ActiveTestComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Connection status queries for special output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Connection status queries for special output ports
+// ----------------------------------------------------------------------
 
-  bool ActiveTestComponentBase ::
-    isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_cmdRegOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_eventOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return this->m_eventOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_prmGetOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_prmSetOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_productRequestOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_productSendOut_OutputPort[portNum].isConnected();
-  }
+}
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-  bool ActiveTestComponentBase ::
-    isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_textEventOut_OutputPort[portNum].isConnected();
-  }
+}
 
 #endif
 
-  bool ActiveTestComponentBase ::
-    isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_timeGetOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return this->m_tlmOut_OutputPort[portNum].isConnected();
-  }
+}
 
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Connection status queries for typed output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Connection status queries for typed output ports
+// ----------------------------------------------------------------------
 
-  bool ActiveTestComponentBase ::
-    isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_noArgsOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_typedAliasOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_typedOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return this->m_typedOut_OutputPort[portNum].isConnected();
-  }
+}
 
-  bool ActiveTestComponentBase ::
-    isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+bool ActiveTestComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     return this->m_typedReturnOut_OutputPort[portNum].isConnected();
-  }
+}
 
 #endif
 
-  // ----------------------------------------------------------------------
-  // Port handler base-class functions for special input ports
-  //
-  // Call these functions directly to bypass the corresponding ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Port handler base-class functions for special input ports
+//
+// Call these functions directly to bypass the corresponding ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    cmdIn_handlerBase(
-        FwIndexType portNum,
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
-
+void ActiveTestComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                 FwOpcodeType opCode,
+                                                 U32 cmdSeq,
+                                                 Fw::CmdArgBuffer& args) {
     const U32 idBase = this->getIdBase();
     FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
     // Select base class function based on opcode
     switch (opCode - idBase) {
-      case OPCODE_CMD_SYNC: {
-        this->CMD_SYNC_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_SYNC: {
+            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_SYNC_PRIMITIVE: {
-        this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_SYNC_PRIMITIVE: {
+            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_SYNC_STRING: {
-        this->CMD_SYNC_STRING_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_SYNC_STRING: {
+            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_SYNC_ENUM: {
-        this->CMD_SYNC_ENUM_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_SYNC_ENUM: {
+            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_SYNC_ARRAY: {
-        this->CMD_SYNC_ARRAY_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_SYNC_ARRAY: {
+            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_SYNC_STRUCT: {
-        this->CMD_SYNC_STRUCT_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_SYNC_STRUCT: {
+            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_GUARDED: {
-        this->CMD_GUARDED_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_GUARDED: {
+            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_GUARDED_PRIMITIVE: {
-        this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_GUARDED_PRIMITIVE: {
+            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_GUARDED_STRING: {
-        this->CMD_GUARDED_STRING_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_GUARDED_STRING: {
+            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_GUARDED_ENUM: {
-        this->CMD_GUARDED_ENUM_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_GUARDED_ENUM: {
+            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_GUARDED_ARRAY: {
-        this->CMD_GUARDED_ARRAY_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_GUARDED_ARRAY: {
+            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_GUARDED_STRUCT: {
-        this->CMD_GUARDED_STRUCT_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_GUARDED_STRUCT: {
+            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_ASYNC: {
-        this->CMD_ASYNC_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_ASYNC: {
+            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_PRIORITY: {
-        this->CMD_PRIORITY_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_PRIORITY: {
+            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_PARAMS_PRIORITY: {
-        this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_PARAMS_PRIORITY: {
+            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_DROP: {
-        this->CMD_DROP_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_DROP: {
+            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-        this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-          opCode,
-          cmdSeq,
-          args
-        );
-        break;
-      }
+        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-      case OPCODE_PARAMU32_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMU32_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMU32_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMU32_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMF64_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMF64_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMF64_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMF64_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRING_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMSTRING_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRING_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamString();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMSTRING_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamString();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMENUM_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMENUM_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMENUM_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMENUM_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMARRAY_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMARRAY_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMARRAY_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMARRAY_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRUCT_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMSTRUCT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRUCT_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMSTRUCT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMI32EXT_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMI32EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMI32EXT_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMI32EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMF64EXT_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMF64EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMF64EXT_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMF64EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRINGEXT_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMSTRINGEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRINGEXT_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMSTRINGEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMENUMEXT_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMENUMEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMENUMEXT_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMENUMEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMARRAYEXT_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMARRAYEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMARRAYEXT_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMARRAYEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRUCTEXT_SET: {
-        Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
+        case OPCODE_PARAMSTRUCTEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-      case OPCODE_PARAMSTRUCTEXT_SAVE: {
-        Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-        this->cmdResponse_out(
-          opCode,
-          cmdSeq,
-          _cstat
-        );
-        break;
-      }
-      default:
-        // Unknown opcode: ignore it
-        break;
+        case OPCODE_PARAMSTRUCTEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    productRecvIn_handlerBase(
-        FwIndexType portNum,
-        FwDpIdType id,
-        const Fw::Buffer& buffer,
-        const Fw::Success& status
-    )
-  {
+void ActiveTestComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                         FwDpIdType id,
+                                                         const Fw::Buffer& buffer,
+                                                         const Fw::Success& status) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call pre-message hook
-    productRecvIn_preMsgHook(
-      portNum,
-      id,
-      buffer,
-      status
-    );
+    productRecvIn_preMsgHook(portNum, id, buffer, status);
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(
-      static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument id
     _status = msg.serializeFrom(id);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument buffer
     _status = msg.serializeFrom(buffer);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument status
     _status = msg.serializeFrom(status);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Port handler base-class functions for typed input ports
-  //
-  // Call these functions directly to bypass the corresponding ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Port handler base-class functions for typed input ports
+//
+// Call these functions directly to bypass the corresponding ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    aliasTypedAsync_handlerBase(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    )
-  {
+void ActiveTestComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                           AliasPrim1 u32,
+                                                           AliasPrim2 f32,
+                                                           AliasBool b,
+                                                           const Fw::StringBase& str2,
+                                                           const AliasEnum& e,
+                                                           const AliasArray& a,
+                                                           const AliasStruct& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call pre-message hook
-    aliasTypedAsync_preMsgHook(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(
-      static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument str2
     _status = msg.serializeFrom(str2);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  Fw::String ActiveTestComponentBase ::
-    noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-  {
+Fw::String ActiveTestComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     Fw::String retVal;
 
@@ -3404,16 +2110,12 @@ namespace M {
     retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
     return retVal;
-  }
+}
 
-  void ActiveTestComponentBase ::
-    noArgsAsync_handlerBase(FwIndexType portNum)
-  {
+void ActiveTestComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call pre-message hook
     noArgsAsync_preMsgHook(portNum);
@@ -3421,39 +2123,24 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(
-      static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    noArgsGuarded_handlerBase(FwIndexType portNum)
-  {
+void ActiveTestComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Lock guard mutex before calling
     this->lock();
@@ -3463,16 +2150,12 @@ namespace M {
 
     // Unlock guard mutex
     this->unLock();
-  }
+}
 
-  U32 ActiveTestComponentBase ::
-    noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-  {
+U32 ActiveTestComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     U32 retVal;
 
@@ -3486,16 +2169,12 @@ namespace M {
     this->unLock();
 
     return retVal;
-  }
+}
 
-  U32 ActiveTestComponentBase ::
-    noArgsReturnSync_handlerBase(FwIndexType portNum)
-  {
+U32 ActiveTestComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     U32 retVal;
 
@@ -3503,16 +2182,12 @@ namespace M {
     retVal = this->noArgsReturnSync_handler(portNum);
 
     return retVal;
-  }
+}
 
-  Fw::String ActiveTestComponentBase ::
-    noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-  {
+Fw::String ActiveTestComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     Fw::String retVal;
 
@@ -3520,615 +2195,357 @@ namespace M {
     retVal = this->noArgsStringReturnSync_handler(portNum);
 
     return retVal;
-  }
+}
 
-  void ActiveTestComponentBase ::
-    noArgsSync_handlerBase(FwIndexType portNum)
-  {
+void ActiveTestComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call handler function
     this->noArgsSync_handler(portNum);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedAliasGuarded_handlerBase(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    )
-  {
+void ActiveTestComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Lock guard mutex before calling
     this->lock();
 
     // Call handler function
-    this->typedAliasGuarded_handler(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
     // Unlock guard mutex
     this->unLock();
-  }
+}
 
-  AliasPrim2 ActiveTestComponentBase ::
-    typedAliasReturnSync_handlerBase(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    )
-  {
+AliasPrim2 ActiveTestComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     AliasPrim2 retVal;
 
     // Call handler function
-    retVal = this->typedAliasReturnSync_handler(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
     return retVal;
-  }
+}
 
-  Fw::String ActiveTestComponentBase ::
-    typedAliasStringReturnSync_handlerBase(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AnotherAliasStruct& s
-    )
-  {
+Fw::String ActiveTestComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AnotherAliasStruct& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     Fw::String retVal;
 
     // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
     return retVal;
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedAsync_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call pre-message hook
-    typedAsync_preMsgHook(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(
-      static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    typedAsyncAssert_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call pre-message hook
-    typedAsyncAssert_preMsgHook(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(
-      static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    typedAsyncBlockPriority_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(
-      static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    typedAsyncDropPriority_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serializeFrom(
-      static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize port number
     _status = msg.serializeFrom(portNum);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument u32
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument f32
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument b
     _status = msg.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument str1
     _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument e
     _status = msg.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument a
     _status = msg.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Serialize argument s
     _status = msg.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    typedGuarded_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     // Lock guard mutex before calling
     this->lock();
 
     // Call handler function
-    this->typedGuarded_handler(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
     // Unlock guard mutex
     this->unLock();
-  }
+}
 
-  F32 ActiveTestComponentBase ::
-    typedReturnGuarded_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str2,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+F32 ActiveTestComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str2,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     F32 retVal;
 
@@ -4136,713 +2553,424 @@ namespace M {
     this->lock();
 
     // Call handler function
-    retVal = this->typedReturnGuarded_handler(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
     // Unlock guard mutex
     this->unLock();
 
     return retVal;
-  }
+}
 
-  F32 ActiveTestComponentBase ::
-    typedReturnSync_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str2,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+F32 ActiveTestComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
     F32 retVal;
 
     // Call handler function
-    retVal = this->typedReturnSync_handler(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
     return retVal;
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedSync_handlerBase(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     // Call handler function
-    this->typedSync_handler(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+}
 
-  // ----------------------------------------------------------------------
-  // Pre-message hooks for special async input ports
-  //
-  // Each of these functions is invoked just before processing a message
-  // on the corresponding port. By default, they do nothing. You can
-  // override them to provide specific pre-message behavior.
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Pre-message hooks for special async input ports
+//
+// Each of these functions is invoked just before processing a message
+// on the corresponding port. By default, they do nothing. You can
+// override them to provide specific pre-message behavior.
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    productRecvIn_preMsgHook(
-        FwIndexType portNum,
-        FwDpIdType id,
-        const Fw::Buffer& buffer,
-        const Fw::Success& status
-    )
-  {
+void ActiveTestComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
+                                                        FwDpIdType id,
+                                                        const Fw::Buffer& buffer,
+                                                        const Fw::Success& status) {
     // Default: no-op
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Pre-message hooks for typed async input ports
-  //
-  // Each of these functions is invoked just before processing a message
-  // on the corresponding port. By default, they do nothing. You can
-  // override them to provide specific pre-message behavior.
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Pre-message hooks for typed async input ports
+//
+// Each of these functions is invoked just before processing a message
+// on the corresponding port. By default, they do nothing. You can
+// override them to provide specific pre-message behavior.
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    aliasTypedAsync_preMsgHook(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    )
-  {
+void ActiveTestComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
     // Default: no-op
-  }
+}
 
-  void ActiveTestComponentBase ::
-    noArgsAsync_preMsgHook(FwIndexType portNum)
-  {
+void ActiveTestComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
     // Default: no-op
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedAsync_preMsgHook(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
     // Default: no-op
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedAsyncAssert_preMsgHook(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
     // Default: no-op
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedAsyncBlockPriority_preMsgHook(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
     // Default: no-op
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedAsyncDropPriority_preMsgHook(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
     // Default: no-op
-  }
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Invocation functions for typed output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Invocation functions for typed output ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    noArgsOut_out(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_noArgsOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
     this->m_noArgsOut_OutputPort[portNum].invoke();
-  }
+}
 
-  U32 ActiveTestComponentBase ::
-    noArgsReturnOut_out(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+U32 ActiveTestComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
     return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
-  }
+}
 
-  Fw::String ActiveTestComponentBase ::
-    noArgsStringReturnOut_out(FwIndexType portNum) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Fw::String ActiveTestComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
     return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    typedAliasOut_out(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                 AliasPrim1 u32,
+                                                 AliasPrim2 f32,
+                                                 AliasBool b,
+                                                 const Fw::StringBase& str2,
+                                                 const AliasEnum& e,
+                                                 const AliasArray& a,
+                                                 const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_typedAliasOut_OutputPort[portNum].invoke(
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+}
 
-  AliasPrim2 ActiveTestComponentBase ::
-    typedAliasReturnOut_out(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+AliasPrim2 ActiveTestComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+}
 
-  Fw::String ActiveTestComponentBase ::
-    typedAliasReturnStringOut_out(
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AnotherAliasStruct& s
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Fw::String ActiveTestComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+}
 
-  void ActiveTestComponentBase ::
-    typedOut_out(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::typedOut_out(FwIndexType portNum,
+                                            U32 u32,
+                                            F32 f32,
+                                            bool b,
+                                            const Fw::StringBase& str1,
+                                            const E& e,
+                                            const A& a,
+                                            const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_typedOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_typedOut_OutputPort[portNum].invoke(
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+}
 
-  F32 ActiveTestComponentBase ::
-    typedReturnOut_out(
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str2,
-        const E& e,
-        const A& a,
-        const S& s
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+F32 ActiveTestComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                 U32 u32,
+                                                 F32 f32,
+                                                 bool b,
+                                                 const Fw::StringBase& str2,
+                                                 const E& e,
+                                                 const A& a,
+                                                 const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+}
 
 #endif
 
-  // ----------------------------------------------------------------------
-  // Internal interface base-class functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Internal interface base-class functions
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    internalArray_internalInterfaceInvoke(const A& a)
-  {
+void ActiveTestComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    internalEnum_internalInterfaceInvoke(const E& e)
-  {
+void ActiveTestComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    internalPrimitive_internalInterfaceInvoke(
-        U32 u32,
-        F32 f32,
-        bool b
-    )
-  {
+void ActiveTestComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    internalPriorityDrop_internalInterfaceInvoke()
-  {
+void ActiveTestComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    internalString_internalInterfaceInvoke(
-        const Fw::InternalInterfaceString& str1,
-        const Fw::InternalInterfaceString& str2
-    )
-  {
+void ActiveTestComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
+                                                                      const Fw::InternalInterfaceString& str2) {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(str1);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(str2);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    internalStruct_internalInterfaceInvoke(const S& s)
-  {
+void ActiveTestComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
     ComponentIpcSerializableBuffer msg;
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Command response
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Command response
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    cmdResponse_out(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdResponse response
-    )
-  {
+void ActiveTestComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
     FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
     this->cmdResponseOut_out(0, opCode, cmdSeq, response);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Command handler base-class functions
-  //
-  // Call these functions directly to bypass the command input port
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Command handler base-class functions
+//
+// Call these functions directly to bypass the command input port
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    CMD_SYNC_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
     this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -4852,76 +2980,45 @@ namespace M {
     U32 u32;
     _status = args.deserializeTo(u32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
     F32 f32;
     _status = args.deserializeTo(f32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
     bool b;
     _status = args.deserializeTo(b);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
-    this->CMD_SYNC_PRIMITIVE_cmdHandler(
-      opCode, cmdSeq,
-      u32,
-      f32,
-      b
-    );
-  }
+    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
+}
 
-  void ActiveTestComponentBase ::
-    CMD_SYNC_STRING_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -4931,61 +3028,36 @@ namespace M {
     Fw::CmdStringArg str1;
     _status = args.deserializeTo(str1);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
     Fw::CmdStringArg str2;
     _status = args.deserializeTo(str2);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
-    this->CMD_SYNC_STRING_cmdHandler(
-      opCode, cmdSeq,
-      str1,
-      str2
-    );
-  }
+    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+}
 
-  void ActiveTestComponentBase ::
-    CMD_SYNC_ENUM_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -4995,46 +3067,27 @@ namespace M {
     E e;
     _status = args.deserializeTo(e);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
-    this->CMD_SYNC_ENUM_cmdHandler(
-      opCode, cmdSeq,
-      e
-    );
-  }
+    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
+}
 
-  void ActiveTestComponentBase ::
-    CMD_SYNC_ARRAY_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -5044,46 +3097,27 @@ namespace M {
     A a;
     _status = args.deserializeTo(a);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
-    this->CMD_SYNC_ARRAY_cmdHandler(
-      opCode, cmdSeq,
-      a
-    );
-  }
+    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
+}
 
-  void ActiveTestComponentBase ::
-    CMD_SYNC_STRUCT_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -5093,59 +3127,35 @@ namespace M {
     S s;
     _status = args.deserializeTo(s);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
-    this->CMD_SYNC_STRUCT_cmdHandler(
-      opCode, cmdSeq,
-      s
-    );
-  }
+    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
+}
 
-  void ActiveTestComponentBase ::
-    CMD_GUARDED_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
@@ -5154,15 +3164,11 @@ namespace M {
     this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
     this->unLock();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                    U32 cmdSeq,
+                                                                    Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -5172,80 +3178,51 @@ namespace M {
     U32 u32;
     _status = args.deserializeTo(u32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
     F32 f32;
     _status = args.deserializeTo(f32);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
     bool b;
     _status = args.deserializeTo(b);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_PRIMITIVE_cmdHandler(
-      opCode, cmdSeq,
-      u32,
-      f32,
-      b
-    );
+    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 
     this->unLock();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    CMD_GUARDED_STRING_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -5255,65 +3232,42 @@ namespace M {
     Fw::CmdStringArg str1;
     _status = args.deserializeTo(str1);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
     Fw::CmdStringArg str2;
     _status = args.deserializeTo(str2);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_STRING_cmdHandler(
-      opCode, cmdSeq,
-      str1,
-      str2
-    );
+    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 
     this->unLock();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    CMD_GUARDED_ENUM_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                               U32 cmdSeq,
+                                                               Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -5323,50 +3277,33 @@ namespace M {
     E e;
     _status = args.deserializeTo(e);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_ENUM_cmdHandler(
-      opCode, cmdSeq,
-      e
-    );
+    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
 
     this->unLock();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    CMD_GUARDED_ARRAY_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -5376,50 +3313,33 @@ namespace M {
     A a;
     _status = args.deserializeTo(a);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_ARRAY_cmdHandler(
-      opCode, cmdSeq,
-      a
-    );
+    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
 
     this->unLock();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    CMD_GUARDED_STRUCT_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
     // Deserialize the arguments
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
@@ -5429,52 +3349,33 @@ namespace M {
     S s;
     _status = args.deserializeTo(s);
     if (_status != Fw::FW_SERIALIZE_OK) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 
 #if FW_CMD_CHECK_RESIDUAL
     // Make sure there was no data left over.
     // That means the argument buffer size was incorrect.
     if (args.getDeserializeSizeLeft() != 0) {
-      if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-        this->cmdResponseOut_out(
-          0,
-          opCode,
-          cmdSeq,
-          Fw::CmdResponse::FORMAT_ERROR
-        );
-      }
-      return;
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
 #endif
 
     this->lock();
 
-    this->CMD_GUARDED_STRUCT_cmdHandler(
-      opCode, cmdSeq,
-      s
-    );
+    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
 
     this->unLock();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    CMD_ASYNC_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
     // Call pre-message hook
-    this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
+    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -5483,57 +3384,33 @@ namespace M {
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    CMD_PRIORITY_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
     // Call pre-message hook
-    this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -5542,57 +3419,35 @@ namespace M {
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    CMD_PARAMS_PRIORITY_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
     // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -5601,57 +3456,33 @@ namespace M {
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    CMD_DROP_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
     // Call pre-message hook
-    this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -5660,62 +3491,40 @@ namespace M {
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void ActiveTestComponentBase ::
-    CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
+                                                                       U32 cmdSeq,
+                                                                       Fw::CmdArgBuffer& args) {
     // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
 
     // Defer deserializing arguments to the message dispatcher
     // to avoid deserializing and reserializing just for IPC
@@ -5724,1499 +3533,980 @@ namespace M {
 
     // Serialize for IPC
     _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
     _status = msg.serializeFrom(port);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(opCode);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = msg.serializeFrom(args);
-    FW_ASSERT (
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Pre-message hooks for async commands
-  //
-  // Each of these functions is invoked just before processing the
-  // corresponding command. By default they do nothing. You can
-  // override them to provide specific pre-command behavior.
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Pre-message hooks for async commands
+//
+// Each of these functions is invoked just before processing the
+// corresponding command. By default they do nothing. You can
+// override them to provide specific pre-command behavior.
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    CMD_ASYNC_preMsgHook(
-        FwOpcodeType opCode,
-        U32 cmdSeq
-    )
-  {
+void ActiveTestComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
     // Defaults to no-op; can be overridden
-    (void) opCode;
-    (void) cmdSeq;
-  }
+    (void)opCode;
+    (void)cmdSeq;
+}
 
-  void ActiveTestComponentBase ::
-    CMD_PRIORITY_preMsgHook(
-        FwOpcodeType opCode,
-        U32 cmdSeq
-    )
-  {
+void ActiveTestComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
     // Defaults to no-op; can be overridden
-    (void) opCode;
-    (void) cmdSeq;
-  }
+    (void)opCode;
+    (void)cmdSeq;
+}
 
-  void ActiveTestComponentBase ::
-    CMD_PARAMS_PRIORITY_preMsgHook(
-        FwOpcodeType opCode,
-        U32 cmdSeq
-    )
-  {
+void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
     // Defaults to no-op; can be overridden
-    (void) opCode;
-    (void) cmdSeq;
-  }
+    (void)opCode;
+    (void)cmdSeq;
+}
 
-  void ActiveTestComponentBase ::
-    CMD_DROP_preMsgHook(
-        FwOpcodeType opCode,
-        U32 cmdSeq
-    )
-  {
+void ActiveTestComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
     // Defaults to no-op; can be overridden
-    (void) opCode;
-    (void) cmdSeq;
-  }
+    (void)opCode;
+    (void)cmdSeq;
+}
 
-  void ActiveTestComponentBase ::
-    CMD_PARAMS_PRIORITY_DROP_preMsgHook(
-        FwOpcodeType opCode,
-        U32 cmdSeq
-    )
-  {
+void ActiveTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
     // Defaults to no-op; can be overridden
-    (void) opCode;
-    (void) cmdSeq;
-  }
+    (void)opCode;
+    (void)cmdSeq;
+}
 
-  // ----------------------------------------------------------------------
-  // Event logging functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Event logging functions
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    log_ACTIVITY_HI_EventActivityHigh() const
-  {
+void ActiveTestComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(0));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::ACTIVITY_HI,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Activity High occurred";
+        const char* _formatString = "(%s) %s: Event Activity High occurred";
 #else
-      const char* _formatString =
-        "%s: Event Activity High occurred";
+        const char* _formatString = "%s: Event Activity High occurred";
 #endif
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventActivityHigh "
-      );
+                          "EventActivityHigh ");
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::ACTIVITY_HI,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
     }
 #endif
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_ACTIVITY_LO_EventActivityLowThrottled(
-        U32 u32,
-        F32 f32,
-        bool b
-    )
-  {
+void ActiveTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
     // Check throttle value
     if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
-      return;
-    }
-    else {
-      this->m_EventActivityLowThrottledThrottle++;
+        return;
+    } else {
+        this->m_EventActivityLowThrottledThrottle++;
     }
 
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(3));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(3));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the argument size
-      _status = _logBuff.serializeFrom(
-        static_cast<U8>(sizeof(U32))
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
-      _status = _logBuff.serializeFrom(u32);
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = _logBuff.serializeFrom(u32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the argument size
-      _status = _logBuff.serializeFrom(
-        static_cast<U8>(sizeof(F32))
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
-      _status = _logBuff.serializeFrom(f32);
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = _logBuff.serializeFrom(f32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the argument size
-      _status = _logBuff.serializeFrom(
-        static_cast<U8>(sizeof(U8))
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
-      _status = _logBuff.serializeFrom(b);
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = _logBuff.serializeFrom(b);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::ACTIVITY_LO,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #else
-      const char* _formatString =
-        "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #endif
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventActivityLowThrottled ",
-        u32,
-        static_cast<F64>(f32),
-        b
-      );
+                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::ACTIVITY_LO,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
     }
 #endif
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_COMMAND_EventCommand(
-        const Fw::StringBase& str1,
-        const Fw::StringBase& str2
-    ) const
-  {
+void ActiveTestComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1, const Fw::StringBase& str2) const {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(2));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(2));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-      _status = str1.serializeTo(
-        _logBuff,
-        FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
+                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = str2.serializeTo(
-        _logBuff,
-        FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::COMMAND,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Command occurred with arguments: %s, %s";
+        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
 #else
-      const char* _formatString =
-        "%s: Event Command occurred with arguments: %s, %s";
+        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
 #endif
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventCommand ",
-        str1.toChar(),
-        str2.toChar()
-      );
+                          "EventCommand ", str1.toChar(), str2.toChar());
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::COMMAND,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
     }
 #endif
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_DIAGNOSTIC_EventDiagnostic(const E& e) const
-  {
+void ActiveTestComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(1));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the argument size
-      _status = _logBuff.serializeFrom(
-        static_cast<U8>(E::SERIALIZED_SIZE)
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
-      _status = _logBuff.serializeFrom(e);
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = _logBuff.serializeFrom(e);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::DIAGNOSTIC,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Diagnostic occurred with argument: %s";
+        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
 #else
-      const char* _formatString =
-        "%s: Event Diagnostic occurred with argument: %s";
+        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
 #endif
 
-      Fw::String eStr;
-      e.toString(eStr);
+        Fw::String eStr;
+        e.toString(eStr);
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventDiagnostic ",
-        eStr.toChar()
-      );
+                          "EventDiagnostic ", eStr.toChar());
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::DIAGNOSTIC,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
     }
 #endif
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_FATAL_EventFatalThrottled(const A& a)
-  {
+void ActiveTestComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
     // Check throttle value
     if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-      return;
-    }
-    else {
-      this->m_EventFatalThrottledThrottle++;
+        return;
+    } else {
+        this->m_EventFatalThrottledThrottle++;
     }
 
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-      _status = _logBuff.serializeFrom(static_cast<U8>(4));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+        _status = _logBuff.serializeFrom(static_cast<U8>(4));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = _logBuff.serializeFrom(static_cast<U32>(0));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = _logBuff.serializeFrom(static_cast<U32>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the argument size
-      _status = _logBuff.serializeFrom(
-        static_cast<U8>(A::SERIALIZED_SIZE)
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
-      _status = _logBuff.serializeFrom(a);
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = _logBuff.serializeFrom(a);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::FATAL,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Fatal occurred with argument: %s";
+        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
 #else
-      const char* _formatString =
-        "%s: Event Fatal occurred with argument: %s";
+        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
 #endif
 
-      Fw::String aStr;
-      a.toString(aStr);
+        Fw::String aStr;
+        a.toString(aStr);
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventFatalThrottled ",
-        aStr.toChar()
-      );
+                          "EventFatalThrottled ", aStr.toChar());
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::FATAL,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
     }
 #endif
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_WARNING_HI_EventWarningHigh(const S& s) const
-  {
+void ActiveTestComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(1));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
 #if FW_AMPCS_COMPATIBLE
-      // Serialize the argument size
-      _status = _logBuff.serializeFrom(
-        static_cast<U8>(S::SERIALIZED_SIZE)
-      );
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
-      _status = _logBuff.serializeFrom(s);
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        _status = _logBuff.serializeFrom(s);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::WARNING_HI,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Warning High occurred with argument: %s";
+        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
 #else
-      const char* _formatString =
-        "%s: Event Warning High occurred with argument: %s";
+        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
 #endif
 
-      Fw::String sStr;
-      s.toString(sStr);
+        Fw::String sStr;
+        s.toString(sStr);
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventWarningHigh ",
-        sStr.toChar()
-      );
+                          "EventWarningHigh ", sStr.toChar());
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::WARNING_HI,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
     }
 #endif
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_WARNING_LO_EventWarningLowThrottled()
-  {
+void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
     // Check throttle value
     if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-      return;
-    }
-    else {
-      this->m_EventWarningLowThrottledThrottle++;
+        return;
+    } else {
+        this->m_EventWarningLowThrottledThrottle++;
     }
 
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(0));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::WARNING_LO,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Warning Low occurred";
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
 #else
-      const char* _formatString =
-        "%s: Event Warning Low occurred";
+        const char* _formatString = "%s: Event Warning Low occurred";
 #endif
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventWarningLowThrottled "
-      );
+                          "EventWarningLowThrottled ");
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::WARNING_LO,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
     }
 #endif
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_WARNING_LO_EventWarningLowThrottledInterval()
-  {
+void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
     // Get the time
     Fw::Time _logTime;
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      this->timeGetOut_out(0, _logTime);
+        this->timeGetOut_out(0, _logTime);
     }
 
     const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
 
     // Check throttle value & throttle timeout
     {
-      Os::ScopeLock scopedLock(this->m_eventLock);
+        Os::ScopeLock scopedLock(this->m_eventLock);
 
-      if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-        // The counter has overflowed, check if time interval has passed
-        if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
-          // Reset the count
-          this->m_EventWarningLowThrottledIntervalThrottle = 0;
-        } else {
-          // Throttle the event
-          return;
+        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+            // The counter has overflowed, check if time interval has passed
+            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
+                Fw::TimeInterval(10, 0)) {
+                // Reset the count
+                this->m_EventWarningLowThrottledIntervalThrottle = 0;
+            } else {
+                // Throttle the event
+                return;
+            }
         }
-      }
 
-      // Reset the throttle time if needed
-      if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-        // This is the first event, reset the throttle time
-        this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
-      }
+        // Reset the throttle time if needed
+        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+            // This is the first event, reset the throttle time
+            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+        }
 
-      // Increment the count
-      this->m_EventWarningLowThrottledIntervalThrottle++;
+        // Increment the count
+        this->m_EventWarningLowThrottledIntervalThrottle++;
     }
 
     // Emit the event on the log port
     if (this->isConnected_eventOut_OutputPort(0)) {
-      Fw::LogBuffer _logBuff;
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-      Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-      // Serialize the number of arguments
-      _status = _logBuff.serializeFrom(static_cast<U8>(0));
-      FW_ASSERT(
-        _status == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_status)
-      );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-      this->eventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::WARNING_LO,
-        _logBuff
-      );
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
     }
 
     // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
     if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-      const char* _formatString =
-        "(%s) %s: Event Warning Low occurred";
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
 #else
-      const char* _formatString =
-        "%s: Event Warning Low occurred";
+        const char* _formatString = "%s: Event Warning Low occurred";
 #endif
 
-      Fw::TextLogString _logString;
-      _logString.format(
-        _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-        "EventWarningLowThrottledInterval "
-      );
+                          "EventWarningLowThrottledInterval ");
 
-      this->textEventOut_out(
-        0,
-        _id,
-        _logTime,
-        Fw::LogSeverity::WARNING_LO,
-        _logString
-      );
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
     }
 #endif
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Event throttle reset functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Event throttle reset functions
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
-  {
+void ActiveTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
     // Reset throttle counter
     this->m_EventActivityLowThrottledThrottle = 0;
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_FATAL_EventFatalThrottled_ThrottleClear()
-  {
+void ActiveTestComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
     // Reset throttle counter
     this->m_EventFatalThrottledThrottle = 0;
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
-  {
+void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
     // Reset throttle counter
     this->m_EventWarningLowThrottledThrottle = 0;
-  }
+}
 
-  void ActiveTestComponentBase ::
-    log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
-  {
+void ActiveTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
     {
-      Os::ScopeLock scopedLock(this->m_eventLock);
+        Os::ScopeLock scopedLock(this->m_eventLock);
 
-      // Reset throttle counter
-      this->m_EventWarningLowThrottledIntervalThrottle = 0;
+        // Reset throttle counter
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-      // Reset the throttle time
-      this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+        // Reset the throttle time
+        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
     }
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Telemetry serialized write
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Telemetry serialized write
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    tlmWrite(
-        FwChanIdType id,
-        Fw::TlmBuffer& _tlmBuff,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      if (
-        this->isConnected_timeGetOut_OutputPort(0) &&
-        (_tlmTime ==  Fw::ZERO_TIME)
-      ) {
-        this->timeGetOut_out(0, _tlmTime);
-      }
+        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
+            this->timeGetOut_out(0, _tlmTime);
+        }
 
-      FwChanIdType _id;
-      _id = this->getIdBase() + id;
+        FwChanIdType _id;
+        _id = this->getIdBase() + id;
 
-      this->tlmOut_out(
-        0,
-        _id,
-        _tlmTime,
-        _tlmBuff
-      );
+        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
     }
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Telemetry write functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Telemetry write functions
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelU32Format(
-        U32 arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELU32FORMAT,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelF32Format(
-        F32 arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELF32FORMAT,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelStringFormat(
-        const Fw::StringBase& arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = arg.serializeTo(
-        _tlmBuff,
-        FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-      );
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat =
+            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
+                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELSTRINGFORMAT,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelEnum(
-        const E& arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELENUM,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelArrayFreq(
-        const A& arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELARRAYFREQ,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelStructFreq(
-        const S& arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELSTRUCTFREQ,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelU32Limits(
-        U32 arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELU32LIMITS,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelF32Limits(
-        F32 arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELF32LIMITS,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelF64(
-        F64 arg,
-        Fw::Time _tlmTime
-    ) const
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELF64,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelU32OnChange(
-        U32 arg,
-        Fw::Time _tlmTime
-    )
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
     // Check to see if it is the first time
     if (not this->m_first_update_ChannelU32OnChange) {
-      // Check to see if value has changed. If not, don't write it.
-      if (arg == this->m_last_ChannelU32OnChange) {
-        return;
-      }
-      else {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelU32OnChange) {
+            return;
+        } else {
+            this->m_last_ChannelU32OnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelU32OnChange = false;
         this->m_last_ChannelU32OnChange = arg;
-      }
-    }
-    else {
-      this->m_first_update_ChannelU32OnChange = false;
-      this->m_last_ChannelU32OnChange = arg;
     }
 
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELU32ONCHANGE,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelEnumOnChange(
-        const E& arg,
-        Fw::Time _tlmTime
-    )
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
     // Check to see if it is the first time
     if (not this->m_first_update_ChannelEnumOnChange) {
-      // Check to see if value has changed. If not, don't write it.
-      if (arg == this->m_last_ChannelEnumOnChange) {
-        return;
-      }
-      else {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelEnumOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelEnumOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelEnumOnChange = false;
         this->m_last_ChannelEnumOnChange = arg;
-      }
-    }
-    else {
-      this->m_first_update_ChannelEnumOnChange = false;
-      this->m_last_ChannelEnumOnChange = arg;
     }
 
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELENUMONCHANGE,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  void ActiveTestComponentBase ::
-    tlmWrite_ChannelBoolOnChange(
-        bool arg,
-        Fw::Time _tlmTime
-    )
-  {
+void ActiveTestComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
     // Check to see if it is the first time
     if (not this->m_first_update_ChannelBoolOnChange) {
-      // Check to see if value has changed. If not, don't write it.
-      if (arg == this->m_last_ChannelBoolOnChange) {
-        return;
-      }
-      else {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelBoolOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelBoolOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelBoolOnChange = false;
         this->m_last_ChannelBoolOnChange = arg;
-      }
-    }
-    else {
-      this->m_first_update_ChannelBoolOnChange = false;
-      this->m_last_ChannelBoolOnChange = arg;
     }
 
     if (this->isConnected_tlmOut_OutputPort(0)) {
-      Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-      FW_ASSERT(
-        _stat == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_stat)
-      );
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-      this->tlmWrite(
-        CHANNELID_CHANNELBOOLONCHANGE,
-        _tlmBuff,
-        _tlmTime
-      );
+        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
     }
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Parameter hook functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Parameter hook functions
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    parameterUpdated(FwPrmIdType id)
-  {
+void ActiveTestComponentBase ::parameterUpdated(FwPrmIdType id) {
     // Do nothing by default
-  }
+}
 
-  void ActiveTestComponentBase ::
-    parametersLoaded()
-  {
+void ActiveTestComponentBase ::parametersLoaded() {
     // Do nothing by default
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Parameter get functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Parameter get functions
+// ----------------------------------------------------------------------
 
-  U32 ActiveTestComponentBase ::
-    paramGet_ParamU32(Fw::ParamValid& valid)
-  {
+U32 ActiveTestComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
     U32 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamU32_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      _local = this->m_ParamU32;
+        _local = this->m_ParamU32;
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  F64 ActiveTestComponentBase ::
-    paramGet_ParamF64(Fw::ParamValid& valid)
-  {
+F64 ActiveTestComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
     F64 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamF64_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      _local = this->m_ParamF64;
+        _local = this->m_ParamF64;
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  Fw::ParamString ActiveTestComponentBase ::
-    paramGet_ParamString(Fw::ParamValid& valid)
-  {
+Fw::ParamString ActiveTestComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
     Fw::ParamString _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamString_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      _local = this->m_ParamString;
+        _local = this->m_ParamString;
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  E ActiveTestComponentBase ::
-    paramGet_ParamEnum(Fw::ParamValid& valid)
-  {
+E ActiveTestComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
     E _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamEnum_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      _local = this->m_ParamEnum;
+        _local = this->m_ParamEnum;
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  A ActiveTestComponentBase ::
-    paramGet_ParamArray(Fw::ParamValid& valid)
-  {
+A ActiveTestComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
     A _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamArray_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      _local = this->m_ParamArray;
+        _local = this->m_ParamArray;
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  S ActiveTestComponentBase ::
-    paramGet_ParamStruct(Fw::ParamValid& valid)
-  {
+S ActiveTestComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
     S _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamStruct_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      _local = this->m_ParamStruct;
+        _local = this->m_ParamStruct;
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  I32 ActiveTestComponentBase ::
-    paramGet_ParamI32Ext(Fw::ParamValid& valid)
-  {
+I32 ActiveTestComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
     I32 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamI32Ext_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      Fw::ParamBuffer _paramBuffer;
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()),
-        PARAMID_PARAMI32EXT,
-        _paramBuffer
-      );
-      if(_stat == Fw::FW_SERIALIZE_OK) {
-        _stat = _paramBuffer.deserializeTo(_local);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      } else {
-        valid = Fw::ParamValid::INVALID;
-      }
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  F64 ActiveTestComponentBase ::
-    paramGet_ParamF64Ext(Fw::ParamValid& valid)
-  {
+F64 ActiveTestComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
     F64 _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamF64Ext_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      Fw::ParamBuffer _paramBuffer;
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()),
-        PARAMID_PARAMF64EXT,
-        _paramBuffer
-      );
-      if(_stat == Fw::FW_SERIALIZE_OK) {
-        _stat = _paramBuffer.deserializeTo(_local);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      } else {
-        valid = Fw::ParamValid::INVALID;
-      }
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  Fw::ParamString ActiveTestComponentBase ::
-    paramGet_ParamStringExt(Fw::ParamValid& valid)
-  {
+Fw::ParamString ActiveTestComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
     Fw::ParamString _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamStringExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      Fw::ParamBuffer _paramBuffer;
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()),
-        PARAMID_PARAMSTRINGEXT,
-        _paramBuffer
-      );
-      if(_stat == Fw::FW_SERIALIZE_OK) {
-        _stat = _paramBuffer.deserializeTo(_local);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      } else {
-        valid = Fw::ParamValid::INVALID;
-      }
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  E ActiveTestComponentBase ::
-    paramGet_ParamEnumExt(Fw::ParamValid& valid)
-  {
+E ActiveTestComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
     E _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamEnumExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      Fw::ParamBuffer _paramBuffer;
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()),
-        PARAMID_PARAMENUMEXT,
-        _paramBuffer
-      );
-      if(_stat == Fw::FW_SERIALIZE_OK) {
-        _stat = _paramBuffer.deserializeTo(_local);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      } else {
-        valid = Fw::ParamValid::INVALID;
-      }
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  A ActiveTestComponentBase ::
-    paramGet_ParamArrayExt(Fw::ParamValid& valid)
-  {
+A ActiveTestComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
     A _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamArrayExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      Fw::ParamBuffer _paramBuffer;
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()),
-        PARAMID_PARAMARRAYEXT,
-        _paramBuffer
-      );
-      if(_stat == Fw::FW_SERIALIZE_OK) {
-        _stat = _paramBuffer.deserializeTo(_local);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      } else {
-        valid = Fw::ParamValid::INVALID;
-      }
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  S ActiveTestComponentBase ::
-    paramGet_ParamStructExt(Fw::ParamValid& valid)
-  {
+S ActiveTestComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
     S _local{};
     this->m_paramLock.lock();
     valid = this->m_param_ParamStructExt_valid;
     if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-      Fw::ParamBuffer _paramBuffer;
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()),
-        PARAMID_PARAMSTRUCTEXT,
-        _paramBuffer
-      );
-      if(_stat == Fw::FW_SERIALIZE_OK) {
-        _stat = _paramBuffer.deserializeTo(_local);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-      } else {
-        valid = Fw::ParamValid::INVALID;
-      }
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
     this->m_paramLock.unlock();
     return _local;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // External parameter delegate initialization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// External parameter delegate initialization
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
-  {
+void ActiveTestComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
     FW_ASSERT(paramExternalDelegatePtr != nullptr);
     this->paramDelegatePtr = paramExternalDelegatePtr;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Functions for managing data products
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Functions for managing data products
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    dpSend(
-        DpContainer& container,
-        Fw::Time timeTag
-    )
-  {
+void ActiveTestComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
     // Update the time tag
     if (timeTag == Fw::ZERO_TIME) {
-      // Get the time from the time port
-      timeTag = this->getTime();
+        // Get the time from the time port
+        timeTag = this->getTime();
     }
     container.setTimeTag(timeTag);
     // Serialize the header into the packet
@@ -7225,1654 +4515,1015 @@ namespace M {
     const FwSizeType packetSize = container.getPacketSize();
     Fw::Buffer buffer = container.getBuffer();
     FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-        static_cast<FwAssertArgType>(buffer.getSize()));
+              static_cast<FwAssertArgType>(buffer.getSize()));
     buffer.setSize(static_cast<U32>(packetSize));
     // Invalidate the buffer in the container, so it can't be reused
     container.invalidateBuffer();
     // Send the buffer
     this->productSendOut_out(0, container.getId(), buffer);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Time
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Time
+// ----------------------------------------------------------------------
 
-  Fw::Time ActiveTestComponentBase ::
-    getTime() const
-  {
+Fw::Time ActiveTestComponentBase ::getTime() const {
     if (this->isConnected_timeGetOut_OutputPort(0)) {
-      Fw::Time _time;
-      this->timeGetOut_out(0, _time);
-      return _time;
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
     }
-    else {
-      return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Mutex operations for guarded ports
-  //
-  // You can override these operations to provide more sophisticated
-  // synchronization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Mutex operations for guarded ports
+//
+// You can override these operations to provide more sophisticated
+// synchronization
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    lock()
-  {
+void ActiveTestComponentBase ::lock() {
     this->m_guardedPortMutex.lock();
-  }
+}
 
-  void ActiveTestComponentBase ::
-    unLock()
-  {
+void ActiveTestComponentBase ::unLock() {
     this->m_guardedPortMutex.unLock();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus ActiveTestComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus ActiveTestComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::BLOCKING,
-      _priority
-    );
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == ACTIVETEST_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
-      // Handle async input port productRecvIn
-      case PRODUCTRECVIN_DPRESPONSE: {
-        // Deserialize argument id
-        FwDpIdType id;
-        _deserStatus = _msg.deserializeTo(id);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+        // Handle async input port productRecvIn
+        case PRODUCTRECVIN_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Deserialize argument buffer
-        Fw::Buffer buffer;
-        _deserStatus = _msg.deserializeTo(buffer);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Deserialize argument status
-        Fw::Success status;
-        _deserStatus = _msg.deserializeTo(status);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-        // Call handler function
-        this->productRecvIn_handler(
-          portNum,
-          id,
-          buffer,
-          status
-        );
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvIn_handler(portNum, id, buffer, status);
 
-        break;
-      }
-
-      // Handle async input port aliasTypedAsync
-      case ALIASTYPEDASYNC_ALIASTYPED: {
-        // Deserialize argument u32
-        AliasPrim1 u32;
-        _deserStatus = _msg.deserializeTo(u32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument f32
-        AliasPrim2 f32;
-        _deserStatus = _msg.deserializeTo(f32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument b
-        AliasBool b;
-        _deserStatus = _msg.deserializeTo(b);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument str2
-        char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-        Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-        _deserStatus = _msg.deserializeTo(str2);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument e
-        AliasEnum e;
-        _deserStatus = _msg.deserializeTo(e);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument a
-        AliasArray a;
-        _deserStatus = _msg.deserializeTo(a);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument s
-        AliasStruct s;
-        _deserStatus = _msg.deserializeTo(s);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-        // Call handler function
-        this->aliasTypedAsync_handler(
-          portNum,
-          u32,
-          f32,
-          b,
-          str2,
-          e,
-          a,
-          s
-        );
-
-        break;
-      }
-
-      // Handle async input port noArgsAsync
-      case NOARGSASYNC_NOARGS: {
-        // Call handler function
-        this->noArgsAsync_handler(portNum);
-
-        break;
-      }
-
-      // Handle async input port typedAsync
-      case TYPEDASYNC_TYPED: {
-        // Deserialize argument u32
-        U32 u32;
-        _deserStatus = _msg.deserializeTo(u32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument f32
-        F32 f32;
-        _deserStatus = _msg.deserializeTo(f32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument b
-        bool b;
-        _deserStatus = _msg.deserializeTo(b);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument str1
-        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserializeTo(str1);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument e
-        E e;
-        _deserStatus = _msg.deserializeTo(e);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument a
-        A a;
-        _deserStatus = _msg.deserializeTo(a);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument s
-        S s;
-        _deserStatus = _msg.deserializeTo(s);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-        // Call handler function
-        this->typedAsync_handler(
-          portNum,
-          u32,
-          f32,
-          b,
-          str1,
-          e,
-          a,
-          s
-        );
-
-        break;
-      }
-
-      // Handle async input port typedAsyncAssert
-      case TYPEDASYNCASSERT_TYPED: {
-        // Deserialize argument u32
-        U32 u32;
-        _deserStatus = _msg.deserializeTo(u32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument f32
-        F32 f32;
-        _deserStatus = _msg.deserializeTo(f32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument b
-        bool b;
-        _deserStatus = _msg.deserializeTo(b);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument str1
-        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserializeTo(str1);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument e
-        E e;
-        _deserStatus = _msg.deserializeTo(e);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument a
-        A a;
-        _deserStatus = _msg.deserializeTo(a);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument s
-        S s;
-        _deserStatus = _msg.deserializeTo(s);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-        // Call handler function
-        this->typedAsyncAssert_handler(
-          portNum,
-          u32,
-          f32,
-          b,
-          str1,
-          e,
-          a,
-          s
-        );
-
-        break;
-      }
-
-      // Handle async input port typedAsyncBlockPriority
-      case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-        // Deserialize argument u32
-        U32 u32;
-        _deserStatus = _msg.deserializeTo(u32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument f32
-        F32 f32;
-        _deserStatus = _msg.deserializeTo(f32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument b
-        bool b;
-        _deserStatus = _msg.deserializeTo(b);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument str1
-        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserializeTo(str1);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument e
-        E e;
-        _deserStatus = _msg.deserializeTo(e);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument a
-        A a;
-        _deserStatus = _msg.deserializeTo(a);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument s
-        S s;
-        _deserStatus = _msg.deserializeTo(s);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-        // Call handler function
-        this->typedAsyncBlockPriority_handler(
-          portNum,
-          u32,
-          f32,
-          b,
-          str1,
-          e,
-          a,
-          s
-        );
-
-        break;
-      }
-
-      // Handle async input port typedAsyncDropPriority
-      case TYPEDASYNCDROPPRIORITY_TYPED: {
-        // Deserialize argument u32
-        U32 u32;
-        _deserStatus = _msg.deserializeTo(u32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument f32
-        F32 f32;
-        _deserStatus = _msg.deserializeTo(f32);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument b
-        bool b;
-        _deserStatus = _msg.deserializeTo(b);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument str1
-        char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-        Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserializeTo(str1);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument e
-        E e;
-        _deserStatus = _msg.deserializeTo(e);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument a
-        A a;
-        _deserStatus = _msg.deserializeTo(a);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize argument s
-        S s;
-        _deserStatus = _msg.deserializeTo(s);
-        FW_ASSERT(
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-        // Call handler function
-        this->typedAsyncDropPriority_handler(
-          portNum,
-          u32,
-          f32,
-          b,
-          str1,
-          e,
-          a,
-          s
-        );
-
-        break;
-      }
-
-      // Handle command CMD_ASYNC
-      case CMD_CMD_ASYNC: {
-        // Deserialize opcode
-        FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserializeTo(_opCode);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command sequence
-        U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserializeTo(_cmdSeq);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command argument buffer
-        Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserializeTo(args);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Reset buffer
-        args.resetDeser();
-
-        // Make sure there was no data left over.
-        // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-        if (args.getDeserializeSizeLeft() != 0) {
-          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-          }
-          // Don't crash the task if bad arguments were passed from the ground
-          break;
+            break;
         }
+
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle command CMD_ASYNC
+        case CMD_CMD_ASYNC: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-        // Call handler function
-        this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
 
-        break;
-      }
-
-      // Handle command CMD_PRIORITY
-      case CMD_CMD_PRIORITY: {
-        // Deserialize opcode
-        FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserializeTo(_opCode);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command sequence
-        U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserializeTo(_cmdSeq);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command argument buffer
-        Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserializeTo(args);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Reset buffer
-        args.resetDeser();
-
-        // Make sure there was no data left over.
-        // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-        if (args.getDeserializeSizeLeft() != 0) {
-          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-          }
-          // Don't crash the task if bad arguments were passed from the ground
-          break;
+            break;
         }
+
+        // Handle command CMD_PRIORITY
+        case CMD_CMD_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-        // Call handler function
-        this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
 
-        break;
-      }
-
-      // Handle command CMD_PARAMS_PRIORITY
-      case CMD_CMD_PARAMS_PRIORITY: {
-        // Deserialize opcode
-        FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserializeTo(_opCode);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command sequence
-        U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserializeTo(_cmdSeq);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command argument buffer
-        Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserializeTo(args);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Reset buffer
-        args.resetDeser();
-
-        // Deserialize argument u32
-        U32 u32;
-        _deserStatus = args.deserializeTo(u32);
-        if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponse_out(
-                _opCode,
-                _cmdSeq,
-                Fw::CmdResponse::FORMAT_ERROR
-            );
-          }
-          // Don't crash the task if bad arguments were passed from the ground
-          break;
+            break;
         }
 
-        // Make sure there was no data left over.
-        // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY
+        case CMD_CMD_PARAMS_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-        if (args.getDeserializeSizeLeft() != 0) {
-          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-          }
-          // Don't crash the task if bad arguments were passed from the ground
-          break;
-        }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-        // Call handler function
-        this->CMD_PARAMS_PRIORITY_cmdHandler(
-          _opCode, _cmdSeq,
-          u32
-        );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
 
-        break;
-      }
-
-      // Handle command CMD_DROP
-      case CMD_CMD_DROP: {
-        // Deserialize opcode
-        FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserializeTo(_opCode);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command sequence
-        U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserializeTo(_cmdSeq);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command argument buffer
-        Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserializeTo(args);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Reset buffer
-        args.resetDeser();
-
-        // Make sure there was no data left over.
-        // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-        if (args.getDeserializeSizeLeft() != 0) {
-          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-          }
-          // Don't crash the task if bad arguments were passed from the ground
-          break;
+            break;
         }
+
+        // Handle command CMD_DROP
+        case CMD_CMD_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-        // Call handler function
-        this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
 
-        break;
-      }
-
-      // Handle command CMD_PARAMS_PRIORITY_DROP
-      case CMD_CMD_PARAMS_PRIORITY_DROP: {
-        // Deserialize opcode
-        FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserializeTo(_opCode);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command sequence
-        U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserializeTo(_cmdSeq);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Deserialize command argument buffer
-        Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserializeTo(args);
-        FW_ASSERT (
-          _deserStatus == Fw::FW_SERIALIZE_OK,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
-
-        // Reset buffer
-        args.resetDeser();
-
-        // Deserialize argument u32
-        U32 u32;
-        _deserStatus = args.deserializeTo(u32);
-        if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponse_out(
-                _opCode,
-                _cmdSeq,
-                Fw::CmdResponse::FORMAT_ERROR
-            );
-          }
-          // Don't crash the task if bad arguments were passed from the ground
-          break;
+            break;
         }
 
-        // Make sure there was no data left over.
-        // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_DROP
+        case CMD_CMD_PARAMS_PRIORITY_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-        if (args.getDeserializeSizeLeft() != 0) {
-          if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-          }
-          // Don't crash the task if bad arguments were passed from the ground
-          break;
-        }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-        // Call handler function
-        this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
-          _opCode, _cmdSeq,
-          u32
-        );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
 
-        break;
-      }
+            break;
+        }
 
-      // Handle internal interface internalArray
-      case INT_IF_INTERNALARRAY: {
-        A a;
-        _deserStatus = _msg.deserializeTo(a);
+        // Handle internal interface internalArray
+        case INT_IF_INTERNALARRAY: {
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Make sure there was no data left over.
-        // That means the buffer size was incorrect.
-        FW_ASSERT(
-          _msg.getDeserializeSizeLeft() == 0,
-          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-        );
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
 
-        // Call handler function
-        this->internalArray_internalInterfaceHandler(
-          a
-        );
+            // Call handler function
+            this->internalArray_internalInterfaceHandler(a);
 
-        break;
-      }
+            break;
+        }
 
-      // Handle internal interface internalEnum
-      case INT_IF_INTERNALENUM: {
-        E e;
-        _deserStatus = _msg.deserializeTo(e);
+        // Handle internal interface internalEnum
+        case INT_IF_INTERNALENUM: {
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Make sure there was no data left over.
-        // That means the buffer size was incorrect.
-        FW_ASSERT(
-          _msg.getDeserializeSizeLeft() == 0,
-          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-        );
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
 
-        // Call handler function
-        this->internalEnum_internalInterfaceHandler(
-          e
-        );
+            // Call handler function
+            this->internalEnum_internalInterfaceHandler(e);
 
-        break;
-      }
+            break;
+        }
 
-      // Handle internal interface internalPrimitive
-      case INT_IF_INTERNALPRIMITIVE: {
-        U32 u32;
-        _deserStatus = _msg.deserializeTo(u32);
+        // Handle internal interface internalPrimitive
+        case INT_IF_INTERNALPRIMITIVE: {
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        F32 f32;
-        _deserStatus = _msg.deserializeTo(f32);
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        bool b;
-        _deserStatus = _msg.deserializeTo(b);
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Make sure there was no data left over.
-        // That means the buffer size was incorrect.
-        FW_ASSERT(
-          _msg.getDeserializeSizeLeft() == 0,
-          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-        );
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
 
-        // Call handler function
-        this->internalPrimitive_internalInterfaceHandler(
-          u32,
-          f32,
-          b
-        );
+            // Call handler function
+            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
 
-        break;
-      }
+            break;
+        }
 
-      // Handle internal interface internalPriorityDrop
-      case INT_IF_INTERNALPRIORITYDROP: {
-        // Make sure there was no data left over.
-        // That means the buffer size was incorrect.
-        FW_ASSERT(
-          _msg.getDeserializeSizeLeft() == 0,
-          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-        );
+        // Handle internal interface internalPriorityDrop
+        case INT_IF_INTERNALPRIORITYDROP: {
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
 
-        // Call handler function
-        this->internalPriorityDrop_internalInterfaceHandler();
+            // Call handler function
+            this->internalPriorityDrop_internalInterfaceHandler();
 
-        break;
-      }
+            break;
+        }
 
-      // Handle internal interface internalString
-      case INT_IF_INTERNALSTRING: {
-        Fw::InternalInterfaceString str1;
-        _deserStatus = _msg.deserializeTo(str1);
+        // Handle internal interface internalString
+        case INT_IF_INTERNALSTRING: {
+            Fw::InternalInterfaceString str1;
+            _deserStatus = _msg.deserializeTo(str1);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        Fw::InternalInterfaceString str2;
-        _deserStatus = _msg.deserializeTo(str2);
+            Fw::InternalInterfaceString str2;
+            _deserStatus = _msg.deserializeTo(str2);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Make sure there was no data left over.
-        // That means the buffer size was incorrect.
-        FW_ASSERT(
-          _msg.getDeserializeSizeLeft() == 0,
-          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-        );
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
 
-        // Call handler function
-        this->internalString_internalInterfaceHandler(
-          str1,
-          str2
-        );
+            // Call handler function
+            this->internalString_internalInterfaceHandler(str1, str2);
 
-        break;
-      }
+            break;
+        }
 
-      // Handle internal interface internalStruct
-      case INT_IF_INTERNALSTRUCT: {
-        S s;
-        _deserStatus = _msg.deserializeTo(s);
+        // Handle internal interface internalStruct
+        case INT_IF_INTERNALSTRUCT: {
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
 
-        // Internal interface should always deserialize
-        FW_ASSERT(
-          Fw::FW_SERIALIZE_OK == _deserStatus,
-          static_cast<FwAssertArgType>(_deserStatus)
-        );
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
 
-        // Make sure there was no data left over.
-        // That means the buffer size was incorrect.
-        FW_ASSERT(
-          _msg.getDeserializeSizeLeft() == 0,
-          static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-        );
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
 
-        // Call handler function
-        this->internalStruct_internalInterfaceHandler(
-          s
-        );
+            // Call handler function
+            this->internalStruct_internalInterfaceHandler(s);
 
-        break;
-      }
+            break;
+        }
 
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Calls for messages received on special input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Calls for messages received on special input ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    m_p_cmdIn_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        Fw::CmdArgBuffer& args
-    )
-  {
+void ActiveTestComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                            FwIndexType portNum,
+                                            FwOpcodeType opCode,
+                                            U32 cmdSeq,
+                                            Fw::CmdArgBuffer& args) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(
-      portNum,
-      opCode,
-      cmdSeq,
-      args
-    );
-  }
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+}
 
-  void ActiveTestComponentBase ::
-    m_p_productRecvIn_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        FwDpIdType id,
-        const Fw::Buffer& buffer,
-        const Fw::Success& status
-    )
-  {
+void ActiveTestComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    FwDpIdType id,
+                                                    const Fw::Buffer& buffer,
+                                                    const Fw::Success& status) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(
-      portNum,
-      id,
-      buffer,
-      status
-    );
-  }
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+}
 
-  // ----------------------------------------------------------------------
-  // Calls for messages received on typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Calls for messages received on typed input ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    m_p_aliasTypedAsync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      AliasPrim1 u32,
+                                                      AliasPrim2 f32,
+                                                      AliasBool b,
+                                                      const Fw::StringBase& str2,
+                                                      const AliasEnum& e,
+                                                      const AliasArray& a,
+                                                      const AliasStruct& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+}
 
-  Fw::String ActiveTestComponentBase ::
-    m_p_noArgsAliasStringReturnSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-    )
-  {
+Fw::String ActiveTestComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    m_p_noArgsAsync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-    )
-  {
+void ActiveTestComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsAsync_handlerBase(portNum);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    m_p_noArgsGuarded_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-    )
-  {
+void ActiveTestComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsGuarded_handlerBase(portNum);
-  }
+}
 
-  U32 ActiveTestComponentBase ::
-    m_p_noArgsReturnGuarded_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-    )
-  {
+U32 ActiveTestComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsReturnGuarded_handlerBase(portNum);
-  }
+}
 
-  U32 ActiveTestComponentBase ::
-    m_p_noArgsReturnSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-    )
-  {
+U32 ActiveTestComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsReturnSync_handlerBase(portNum);
-  }
+}
 
-  Fw::String ActiveTestComponentBase ::
-    m_p_noArgsStringReturnSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-    )
-  {
+Fw::String ActiveTestComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsStringReturnSync_handlerBase(portNum);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    m_p_noArgsSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-    )
-  {
+void ActiveTestComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsSync_handlerBase(portNum);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    m_p_typedAliasGuarded_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+}
 
-  AliasPrim2 ActiveTestComponentBase ::
-    m_p_typedAliasReturnSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AliasStruct& s
-    )
-  {
+AliasPrim2 ActiveTestComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+}
 
-  Fw::String ActiveTestComponentBase ::
-    m_p_typedAliasStringReturnSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        AliasPrim1 u32,
-        AliasPrim2 f32,
-        AliasBool b,
-        const Fw::StringBase& str2,
-        const AliasEnum& e,
-        const AliasArray& a,
-        const AnotherAliasStruct& s
-    )
-  {
+Fw::String ActiveTestComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AnotherAliasStruct& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+}
 
-  void ActiveTestComponentBase ::
-    m_p_typedAsync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                 FwIndexType portNum,
+                                                 U32 u32,
+                                                 F32 f32,
+                                                 bool b,
+                                                 const Fw::StringBase& str1,
+                                                 const E& e,
+                                                 const A& a,
+                                                 const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+}
 
-  void ActiveTestComponentBase ::
-    m_p_typedAsyncAssert_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+}
 
-  void ActiveTestComponentBase ::
-    m_p_typedAsyncBlockPriority_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+}
 
-  void ActiveTestComponentBase ::
-    m_p_typedAsyncDropPriority_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+}
 
-  void ActiveTestComponentBase ::
-    m_p_typedGuarded_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+}
 
-  F32 ActiveTestComponentBase ::
-    m_p_typedReturnGuarded_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str2,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+F32 ActiveTestComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str2,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+}
 
-  F32 ActiveTestComponentBase ::
-    m_p_typedReturnSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str2,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+F32 ActiveTestComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str2,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str2,
-      e,
-      a,
-      s
-    );
-  }
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+}
 
-  void ActiveTestComponentBase ::
-    m_p_typedSync_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-    )
-  {
+void ActiveTestComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                FwIndexType portNum,
+                                                U32 u32,
+                                                F32 f32,
+                                                bool b,
+                                                const Fw::StringBase& str1,
+                                                const E& e,
+                                                const A& a,
+                                                const S& s) {
     FW_ASSERT(callComp);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(
-      portNum,
-      u32,
-      f32,
-      b,
-      str1,
-      e,
-      a,
-      s
-    );
-  }
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Invocation functions for special output ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Invocation functions for special output ports
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    cmdRegOut_out(
-        FwIndexType portNum,
-        FwOpcodeType opCode
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_cmdRegOut_OutputPort[portNum].invoke(
-      opCode
-    );
-  }
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+}
 
-  void ActiveTestComponentBase ::
-    cmdResponseOut_out(
-        FwIndexType portNum,
-        FwOpcodeType opCode,
-        U32 cmdSeq,
-        const Fw::CmdResponse& response
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                  FwOpcodeType opCode,
+                                                  U32 cmdSeq,
+                                                  const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(
-      opCode,
-      cmdSeq,
-      response
-    );
-  }
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+}
 
-  void ActiveTestComponentBase ::
-    eventOut_out(
-        FwIndexType portNum,
-        FwEventIdType id,
-        Fw::Time& timeTag,
-        const Fw::LogSeverity& severity,
-        Fw::LogBuffer& args
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::eventOut_out(FwIndexType portNum,
+                                            FwEventIdType id,
+                                            Fw::Time& timeTag,
+                                            const Fw::LogSeverity& severity,
+                                            Fw::LogBuffer& args) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_eventOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_eventOut_OutputPort[portNum].invoke(
-      id,
-      timeTag,
-      severity,
-      args
-    );
-  }
+    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
+}
 
-  Fw::ParamValid ActiveTestComponentBase ::
-    prmGetOut_out(
-        FwIndexType portNum,
-        FwPrmIdType id,
-        Fw::ParamBuffer& val
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Fw::ParamValid ActiveTestComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                       FwPrmIdType id,
+                                                       Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_prmGetOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    return this->m_prmGetOut_OutputPort[portNum].invoke(
-      id,
-      val
-    );
-  }
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+}
 
-  void ActiveTestComponentBase ::
-    prmSetOut_out(
-        FwIndexType portNum,
-        FwPrmIdType id,
-        Fw::ParamBuffer& val
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_prmSetOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_prmSetOut_OutputPort[portNum].invoke(
-      id,
-      val
-    );
-  }
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+}
 
-  void ActiveTestComponentBase ::
-    productRequestOut_out(
-        FwIndexType portNum,
-        FwDpIdType id,
-        FwSizeType dataSize
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::productRequestOut_out(FwIndexType portNum, FwDpIdType id, FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_productRequestOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_productRequestOut_OutputPort[portNum].invoke(
-      id,
-      dataSize
-    );
-  }
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+}
 
-  void ActiveTestComponentBase ::
-    productSendOut_out(
-        FwIndexType portNum,
-        FwDpIdType id,
-        const Fw::Buffer& buffer
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::productSendOut_out(FwIndexType portNum, FwDpIdType id, const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_productSendOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_productSendOut_OutputPort[portNum].invoke(
-      id,
-      buffer
-    );
-  }
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+}
 
 #if FW_ENABLE_TEXT_LOGGING
 
-  void ActiveTestComponentBase ::
-    textEventOut_out(
-        FwIndexType portNum,
-        FwEventIdType id,
-        Fw::Time& timeTag,
-        const Fw::LogSeverity& severity,
-        Fw::TextLogString& text
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::textEventOut_out(FwIndexType portNum,
+                                                FwEventIdType id,
+                                                Fw::Time& timeTag,
+                                                const Fw::LogSeverity& severity,
+                                                Fw::TextLogString& text) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_textEventOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_textEventOut_OutputPort[portNum].invoke(
-      id,
-      timeTag,
-      severity,
-      text
-    );
-  }
+    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
+}
 
 #endif
 
-  void ActiveTestComponentBase ::
-    timeGetOut_out(
-        FwIndexType portNum,
-        Fw::Time& time
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_timeGetOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_timeGetOut_OutputPort[portNum].invoke(
-      time
-    );
-  }
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+}
 
-  void ActiveTestComponentBase ::
-    tlmOut_out(
-        FwIndexType portNum,
-        FwChanIdType id,
-        Fw::Time& timeTag,
-        Fw::TlmBuffer& val
-    ) const
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+void ActiveTestComponentBase ::tlmOut_out(FwIndexType portNum,
+                                          FwChanIdType id,
+                                          Fw::Time& timeTag,
+                                          Fw::TlmBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-    FW_ASSERT(
-      this->m_tlmOut_OutputPort[portNum].isConnected(),
-      static_cast<FwAssertArgType>(portNum)
-    );
-    this->m_tlmOut_OutputPort[portNum].invoke(
-      id,
-      timeTag,
-      val
-    );
-  }
+    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
+}
 
 #endif
 
-  // ----------------------------------------------------------------------
-  // Parameter set functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Parameter set functions
+// ----------------------------------------------------------------------
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamU32(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
     U32 _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -8884,15 +5535,13 @@ namespace M {
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMU32);
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamF64(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
     F64 _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -8904,15 +5553,13 @@ namespace M {
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMF64);
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamString(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
     Fw::ParamString _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -8924,15 +5571,13 @@ namespace M {
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMSTRING);
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamEnum(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
     E _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -8944,15 +5589,13 @@ namespace M {
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMENUM);
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamArray(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
     A _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -8964,15 +5607,13 @@ namespace M {
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMARRAY);
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamStruct(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
     S _localVal{};
     const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
 
     // Assign value only if successfully deserialized
@@ -8984,641 +5625,508 @@ namespace M {
     // Call notifier
     this->parameterUpdated(PARAMID_PARAMSTRUCT);
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMI32EXT,
-      Fw::ParamValid::VALID,
-      val
-    );
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-      _response = Fw::CmdResponse::OK;
-    }
-    else {
-      this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-      _response = Fw::CmdResponse::VALIDATION_ERROR;
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-      this->parameterUpdated(PARAMID_PARAMI32EXT);
+        this->parameterUpdated(PARAMID_PARAMI32EXT);
     }
     return _response;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMF64EXT,
-      Fw::ParamValid::VALID,
-      val
-    );
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-      _response = Fw::CmdResponse::OK;
-    }
-    else {
-      this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-      _response = Fw::CmdResponse::VALIDATION_ERROR;
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-      this->parameterUpdated(PARAMID_PARAMF64EXT);
+        this->parameterUpdated(PARAMID_PARAMF64EXT);
     }
     return _response;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamStringExt(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRINGEXT,
-      Fw::ParamValid::VALID,
-      val
-    );
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-      _response = Fw::CmdResponse::OK;
-    }
-    else {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-      _response = Fw::CmdResponse::VALIDATION_ERROR;
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-      this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
     }
     return _response;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMENUMEXT,
-      Fw::ParamValid::VALID,
-      val
-    );
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-      _response = Fw::CmdResponse::OK;
-    }
-    else {
-      this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-      _response = Fw::CmdResponse::VALIDATION_ERROR;
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-      this->parameterUpdated(PARAMID_PARAMENUMEXT);
+        this->parameterUpdated(PARAMID_PARAMENUMEXT);
     }
     return _response;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMARRAYEXT,
-      Fw::ParamValid::VALID,
-      val
-    );
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-      _response = Fw::CmdResponse::OK;
-    }
-    else {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-      _response = Fw::CmdResponse::VALIDATION_ERROR;
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-      this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
     }
     return _response;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSet_ParamStructExt(Fw::SerialBufferBase& val)
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
     Fw::CmdResponse _response{};
 
     this->m_paramLock.lock();
     // Update the external parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRUCTEXT,
-      Fw::ParamValid::VALID,
-      val
-    );
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
     // Set response and update component state
     if (_stat == Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-      _response = Fw::CmdResponse::OK;
-    }
-    else {
-      this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-      _response = Fw::CmdResponse::VALIDATION_ERROR;
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
     }
     this->m_paramLock.unlock();
 
     // Call notifier
     if (_response == Fw::CmdResponse::OK) {
-      this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
     }
     return _response;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Parameter save functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Parameter save functions
+// ----------------------------------------------------------------------
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamU32()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamU32() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-      _stat = _paramBuffer.serializeFrom(m_ParamU32);
+    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamU32);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamF64()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamF64() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-      _stat = _paramBuffer.serializeFrom(m_ParamF64);
+    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamF64);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamString()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamString() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-      _stat = _paramBuffer.serializeFrom(m_ParamString);
+    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamString);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamEnum()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamEnum() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-      _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamArray()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamArray() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-      _stat = _paramBuffer.serializeFrom(m_ParamArray);
+    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamArray);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamStruct()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamStruct() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-      _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamI32Ext()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamI32Ext() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(idBase),
-        PARAMID_PARAMI32EXT,
-        _paramBuffer
-      );
+    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamF64Ext()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamF64Ext() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(idBase),
-        PARAMID_PARAMF64EXT,
-        _paramBuffer
-      );
+    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamStringExt()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamStringExt() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(idBase),
-        PARAMID_PARAMSTRINGEXT,
-        _paramBuffer
-      );
+    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
+                                                       _paramBuffer);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamEnumExt()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamEnumExt() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(idBase),
-        PARAMID_PARAMENUMEXT,
-        _paramBuffer
-      );
+    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
+                                                       _paramBuffer);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamArrayExt()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamArrayExt() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(idBase),
-        PARAMID_PARAMARRAYEXT,
-        _paramBuffer
-      );
+    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
+                                                       _paramBuffer);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  Fw::CmdResponse ActiveTestComponentBase ::
-    paramSave_ParamStructExt()
-  {
+Fw::CmdResponse ActiveTestComponentBase ::paramSave_ParamStructExt() {
     if (!this->isConnected_prmSetOut_OutputPort(0)) {
-      return Fw::CmdResponse::EXECUTION_ERROR;
+        return Fw::CmdResponse::EXECUTION_ERROR;
     }
     Fw::ParamBuffer _paramBuffer;
     const FwIdType idBase = this->getIdBase();
     Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
     // Serialize the parameter
     this->m_paramLock.lock();
-    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-      FW_ASSERT(this->paramDelegatePtr != nullptr);
-      _stat = this->paramDelegatePtr->serializeParam(
-        static_cast<FwPrmIdType>(idBase),
-        PARAMID_PARAMSTRUCTEXT,
-        _paramBuffer
-      );
+    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
+                                                       _paramBuffer);
     }
     this->m_paramLock.unlock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      return Fw::CmdResponse::VALIDATION_ERROR;
+        return Fw::CmdResponse::VALIDATION_ERROR;
     }
     // Save the parameter
-    this->prmSetOut_out(
-      0,
-      static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
-      _paramBuffer
-    );
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
     // Return the command response
     return Fw::CmdResponse::OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Private data product handling functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Private data product handling functions
+// ----------------------------------------------------------------------
 
-  void ActiveTestComponentBase ::
-    dpRequest(
-        ContainerId::T containerId,
-        FwSizeType dataSize
-    )
-  {
+void ActiveTestComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
     const FwDpIdType globalId = this->getIdBase() + containerId;
     const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
     this->productRequestOut_out(0, globalId, size);
-  }
+}
 
-  void ActiveTestComponentBase ::
-    productRecvIn_handler(
-        const FwIndexType portNum,
-        FwDpIdType id,
-        const Fw::Buffer& buffer,
-        const Fw::Success& status
-    )
-  {
+void ActiveTestComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                     FwDpIdType id,
+                                                     const Fw::Buffer& buffer,
+                                                     const Fw::Success& status) {
     DpContainer container;
     if (status == Fw::Success::SUCCESS) {
-      container = DpContainer(id, buffer, this->getIdBase());
+        container = DpContainer(id, buffer, this->getIdBase());
     }
     // Convert global id to local id
     const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(
-      id >= idBase,
-      static_cast<FwAssertArgType>(id),
-      static_cast<FwAssertArgType>(idBase)
-    );
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
     const FwDpIdType localId = id - idBase;
     // Switch on the local id
     switch (localId) {
-      case ContainerId::Container1:
-        // Set the priority
-        container.setPriority(ContainerPriority::Container1);
-        // Call the handler
-        this->dpRecv_Container1_handler(container, status.e);
-        break;
-      case ContainerId::Container2:
-        // Set the priority
-        container.setPriority(ContainerPriority::Container2);
-        // Call the handler
-        this->dpRecv_Container2_handler(container, status.e);
-        break;
-      case ContainerId::Container3:
-        // Set the priority
-        container.setPriority(ContainerPriority::Container3);
-        // Call the handler
-        this->dpRecv_Container3_handler(container, status.e);
-        break;
-      case ContainerId::Container4:
-        // Set the priority
-        container.setPriority(ContainerPriority::Container4);
-        // Call the handler
-        this->dpRecv_Container4_handler(container, status.e);
-        break;
-      case ContainerId::Container5:
-        // Set the priority
-        container.setPriority(ContainerPriority::Container5);
-        // Call the handler
-        this->dpRecv_Container5_handler(container, status.e);
-        break;
-      default:
-        FW_ASSERT(0);
-        break;
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
     }
-  }
-
 }
+
+}  // namespace M

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
@@ -17,116 +17,144 @@
 
 namespace Ports {
 
-//! Serialization buffer for NoArgs port
-//! A typed port with no arguments
-class NoArgsPortBuffer : public Fw::LinearBufferBase {
-  public:
-    // ----------------------------------------------------------------------
-    // Public constants for NoArgsPortBuffer
-    // ----------------------------------------------------------------------
+  //! Serialization buffer for NoArgs port
+  //! A typed port with no arguments
+  class NoArgsPortBuffer :
+    public Fw::LinearBufferBase
+  {
 
-    //! The buffer capacity. This is the sum of the static serialized
-    //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY = 0;
-};
+    public:
+
+      // ----------------------------------------------------------------------
+      // Public constants for NoArgsPortBuffer
+      // ----------------------------------------------------------------------
+
+      //! The buffer capacity. This is the sum of the static serialized
+      //! sizes of the port arguments.
+      static constexpr FwSizeType CAPACITY =
+        0;
+
+  };
 
 #if !FW_DIRECT_PORT_CALLS
 
-//! Input NoArgs port
-//! A typed port with no arguments
-class InputNoArgsPort : public Fw::InputPortBase {
-  public:
-    // ----------------------------------------------------------------------
-    // Public types for InputNoArgsPort
-    // ----------------------------------------------------------------------
+  //! Input NoArgs port
+  //! A typed port with no arguments
+  class InputNoArgsPort :
+    public Fw::InputPortBase
+  {
 
-    //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum);
+    public:
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public constructors for InputNoArgsPort
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Public types for InputNoArgsPort
+      // ----------------------------------------------------------------------
 
-    //! Constructor
-    InputNoArgsPort();
+      //! The port callback function type
+      typedef void (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum
+      );
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public member functions for InputNoArgsPort
-    // ----------------------------------------------------------------------
+    public:
 
-    //! Initialization function
-    void init();
+      // ----------------------------------------------------------------------
+      // Public constructors for InputNoArgsPort
+      // ----------------------------------------------------------------------
 
-    //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
-    );
+      //! Constructor
+      InputNoArgsPort();
 
-    //! Invoke a port interface
-    void invoke();
+    public:
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member functions for InputNoArgsPort
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Public member functions for InputNoArgsPort
+      // ----------------------------------------------------------------------
+
+      //! Initialization function
+      void init();
+
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
+
+      //! Invoke a port interface
+      void invoke();
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Private member functions for InputNoArgsPort
+      // ----------------------------------------------------------------------
 
 #if FW_PORT_SERIALIZATION == 1
 
-    //! Invoke the port with serialized arguments
-    //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
-    );
+      //! Invoke the port with serialized arguments
+      //! \return The serialize status
+      Fw::SerializeStatus invokeSerial(
+          Fw::LinearBufferBase& _buffer //!< The serial buffer
+      );
 
 #endif
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member variables for InputNoArgsPort
-    // ----------------------------------------------------------------------
+    private:
 
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
-};
+      // ----------------------------------------------------------------------
+      // Private member variables for InputNoArgsPort
+      // ----------------------------------------------------------------------
 
-//! Output NoArgs port
-//! A typed port with no arguments
-class OutputNoArgsPort : public Fw::OutputPortBase {
-  public:
-    // ----------------------------------------------------------------------
-    // Public constructors for OutputNoArgsPort
-    // ----------------------------------------------------------------------
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
 
-    //! Constructor
-    OutputNoArgsPort();
+  };
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public member functions for OutputNoArgsPort
-    // ----------------------------------------------------------------------
+  //! Output NoArgs port
+  //! A typed port with no arguments
+  class OutputNoArgsPort :
+    public Fw::OutputPortBase
+  {
 
-    //! Initialization function
-    void init();
+    public:
 
-    //! Register an input port
-    void addCallPort(InputNoArgsPort* callPort  //!< The input port
-    );
+      // ----------------------------------------------------------------------
+      // Public constructors for OutputNoArgsPort
+      // ----------------------------------------------------------------------
 
-    //! Invoke a port connection
-    void invoke() const;
+      //! Constructor
+      OutputNoArgsPort();
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member variables for OutputNoArgsPort
-    // ----------------------------------------------------------------------
+    public:
 
-    //! The pointer to the input port
-    InputNoArgsPort* m_port;
-};
+      // ----------------------------------------------------------------------
+      // Public member functions for OutputNoArgsPort
+      // ----------------------------------------------------------------------
+
+      //! Initialization function
+      void init();
+
+      //! Register an input port
+      void addCallPort(
+          InputNoArgsPort* callPort //!< The input port
+      );
+
+      //! Invoke a port connection
+      void invoke() const;
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Private member variables for OutputNoArgsPort
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the input port
+      InputNoArgsPort* m_port;
+
+  };
 
 #endif
 
-}  // namespace Ports
+}
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
@@ -34,6 +34,17 @@ namespace Ports {
       static constexpr FwSizeType CAPACITY =
         0;
 
+    public:
+
+      // ----------------------------------------------------------------------
+      // Public member functions for NoArgsPortBuffer
+      // ----------------------------------------------------------------------
+
+      //! Constructor
+      NoArgsPortBuffer() : Fw::LinearBufferBase(nullptr, 0) {
+
+      }
+
   };
 
 #if !FW_DIRECT_PORT_CALLS

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
@@ -17,168 +17,116 @@
 
 namespace Ports {
 
-  //! Serialization buffer for NoArgs port
-  //! A typed port with no arguments
-  class NoArgsPortBuffer :
-    public Fw::LinearBufferBase
-  {
+//! Serialization buffer for NoArgs port
+//! A typed port with no arguments
+class NoArgsPortBuffer : public Fw::LinearBufferBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Public constants for NoArgsPortBuffer
+    // ----------------------------------------------------------------------
 
-    public:
-
-      // ----------------------------------------------------------------------
-      // Public constants for NoArgsPortBuffer
-      // ----------------------------------------------------------------------
-
-      //! The buffer capacity. This is the sum of the static serialized
-      //! sizes of the port arguments.
-      static constexpr FwSizeType CAPACITY =
-        0;
-
-    public:
-
-      // ----------------------------------------------------------------------
-      // Public member functions for NoArgsPortBuffer
-      // ----------------------------------------------------------------------
-
-      //! Get the capacity of the buffer
-      //! \return The capacity
-      Fw::Serializable::SizeType getCapacity() const override {
-        return CAPACITY;
-      }
-
-      //! Get the buffer address (non-const)
-      //! \return The buffer address
-      U8* getBuffAddr() override {
-        return nullptr;
-      }
-
-      //! Get the buffer address (const)
-      //! \return The buffer address
-      const U8* getBuffAddr() const override {
-        return nullptr;
-      }
-
-  };
+    //! The buffer capacity. This is the sum of the static serialized
+    //! sizes of the port arguments.
+    static constexpr FwSizeType CAPACITY = 0;
+};
 
 #if !FW_DIRECT_PORT_CALLS
 
-  //! Input NoArgs port
-  //! A typed port with no arguments
-  class InputNoArgsPort :
-    public Fw::InputPortBase
-  {
+//! Input NoArgs port
+//! A typed port with no arguments
+class InputNoArgsPort : public Fw::InputPortBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Public types for InputNoArgsPort
+    // ----------------------------------------------------------------------
 
-    public:
+    //! The port callback function type
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum);
 
-      // ----------------------------------------------------------------------
-      // Public types for InputNoArgsPort
-      // ----------------------------------------------------------------------
+  public:
+    // ----------------------------------------------------------------------
+    // Public constructors for InputNoArgsPort
+    // ----------------------------------------------------------------------
 
-      //! The port callback function type
-      typedef void (*CompFuncPtr)(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum
-      );
+    //! Constructor
+    InputNoArgsPort();
 
-    public:
+  public:
+    // ----------------------------------------------------------------------
+    // Public member functions for InputNoArgsPort
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Public constructors for InputNoArgsPort
-      // ----------------------------------------------------------------------
+    //! Initialization function
+    void init();
 
-      //! Constructor
-      InputNoArgsPort();
+    //! Register a component
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
+    );
 
-    public:
+    //! Invoke a port interface
+    void invoke();
 
-      // ----------------------------------------------------------------------
-      // Public member functions for InputNoArgsPort
-      // ----------------------------------------------------------------------
-
-      //! Initialization function
-      void init();
-
-      //! Register a component
-      void addCallComp(
-          Fw::PassiveComponentBase* callComp, //!< The containing component
-          CompFuncPtr funcPtr //!< The port callback function
-      );
-
-      //! Invoke a port interface
-      void invoke();
-
-    private:
-
-      // ----------------------------------------------------------------------
-      // Private member functions for InputNoArgsPort
-      // ----------------------------------------------------------------------
+  private:
+    // ----------------------------------------------------------------------
+    // Private member functions for InputNoArgsPort
+    // ----------------------------------------------------------------------
 
 #if FW_PORT_SERIALIZATION == 1
 
-      //! Invoke the port with serialized arguments
-      //! \return The serialize status
-      Fw::SerializeStatus invokeSerial(
-          Fw::LinearBufferBase& _buffer //!< The serial buffer
-      );
+    //! Invoke the port with serialized arguments
+    //! \return The serialize status
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    );
 
 #endif
 
-    private:
+  private:
+    // ----------------------------------------------------------------------
+    // Private member variables for InputNoArgsPort
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Private member variables for InputNoArgsPort
-      // ----------------------------------------------------------------------
+    //! The pointer to the port callback function
+    CompFuncPtr m_func;
+};
 
-      //! The pointer to the port callback function
-      CompFuncPtr m_func;
+//! Output NoArgs port
+//! A typed port with no arguments
+class OutputNoArgsPort : public Fw::OutputPortBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Public constructors for OutputNoArgsPort
+    // ----------------------------------------------------------------------
 
-  };
+    //! Constructor
+    OutputNoArgsPort();
 
-  //! Output NoArgs port
-  //! A typed port with no arguments
-  class OutputNoArgsPort :
-    public Fw::OutputPortBase
-  {
+  public:
+    // ----------------------------------------------------------------------
+    // Public member functions for OutputNoArgsPort
+    // ----------------------------------------------------------------------
 
-    public:
+    //! Initialization function
+    void init();
 
-      // ----------------------------------------------------------------------
-      // Public constructors for OutputNoArgsPort
-      // ----------------------------------------------------------------------
+    //! Register an input port
+    void addCallPort(InputNoArgsPort* callPort  //!< The input port
+    );
 
-      //! Constructor
-      OutputNoArgsPort();
+    //! Invoke a port connection
+    void invoke() const;
 
-    public:
+  private:
+    // ----------------------------------------------------------------------
+    // Private member variables for OutputNoArgsPort
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Public member functions for OutputNoArgsPort
-      // ----------------------------------------------------------------------
-
-      //! Initialization function
-      void init();
-
-      //! Register an input port
-      void addCallPort(
-          InputNoArgsPort* callPort //!< The input port
-      );
-
-      //! Invoke a port connection
-      void invoke() const;
-
-    private:
-
-      // ----------------------------------------------------------------------
-      // Private member variables for OutputNoArgsPort
-      // ----------------------------------------------------------------------
-
-      //! The pointer to the input port
-      InputNoArgsPort* m_port;
-
-  };
+    //! The pointer to the input port
+    InputNoArgsPort* m_port;
+};
 
 #endif
 
-}
+}  // namespace Ports
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -12,94 +12,136 @@
 #include "QueuedAsyncProductPortsOnlyComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDASYNCPRODUCTPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -108,11 +150,15 @@ void QueuedAsyncProductPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEn
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputDpResponsePort* QueuedAsyncProductPortsOnlyComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* QueuedAsyncProductPortsOnlyComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -123,20 +169,32 @@ Fw::InputDpResponsePort* QueuedAsyncProductPortsOnlyComponentBase ::get_productR
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                                 Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                              Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -147,20 +205,32 @@ void QueuedAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(Fw
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                                 Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                              Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -169,10 +239,18 @@ void QueuedAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(Fw
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedAsyncProductPortsOnlyComponentBase ::QueuedAsyncProductPortsOnlyComponentBase(const char* compName)
-    : Fw::QueuedComponentBase(compName) {}
+QueuedAsyncProductPortsOnlyComponentBase ::
+  QueuedAsyncProductPortsOnlyComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
 
-QueuedAsyncProductPortsOnlyComponentBase ::~QueuedAsyncProductPortsOnlyComponentBase() {}
+}
+
+QueuedAsyncProductPortsOnlyComponentBase ::
+  ~QueuedAsyncProductPortsOnlyComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -180,18 +258,26 @@ QueuedAsyncProductPortsOnlyComponentBase ::~QueuedAsyncProductPortsOnlyComponent
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedAsyncProductPortsOnlyComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductPortsOnlyComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductPortsOnlyComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductPortsOnlyComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -202,44 +288,75 @@ bool QueuedAsyncProductPortsOnlyComponentBase ::isConnected_productSendOut_Outpu
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                          FwDpIdType id,
-                                                                          const Fw::Buffer& buffer,
-                                                                          const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    productRecvIn_preMsgHook(portNum, id, buffer, status);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  productRecvIn_preMsgHook(
+    portNum,
+    id,
+    buffer,
+    status
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument id
-    _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument id
+  _status = msg.serializeFrom(id);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msg.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument status
-    _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument status
+  _status = msg.serializeFrom(status);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -250,118 +367,166 @@ void QueuedAsyncProductPortsOnlyComponentBase ::productRecvIn_handlerBase(FwInde
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
-                                                                         FwDpIdType id,
-                                                                         const Fw::Buffer& buffer,
-                                                                         const Fw::Success& status) {
-    // Default: no-op
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  productRecvIn_preMsgHook(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port productRecvIn
+    case PRODUCTRECVIN_DPRESPONSE: {
+      // Deserialize argument id
+      FwDpIdType id;
+      _deserStatus = _msg.deserializeTo(id);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument buffer
+      Fw::Buffer buffer;
+      _deserStatus = _msg.deserializeTo(buffer);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument status
+      Fw::Success status;
+      _deserStatus = _msg.deserializeTo(status);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->productRecvIn_handler(
+        portNum,
+        id,
+        buffer,
+        status
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
-    }
-
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    switch (_msgType) {
-        // Handle async input port productRecvIn
-        case PRODUCTRECVIN_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvIn_handler(portNum, id, buffer, status);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
-    }
-
-    return MSG_DISPATCH_OK;
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     FwDpIdType id,
-                                                                     const Fw::Buffer& buffer,
-                                                                     const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductPortsOnlyComponentBase* compPtr =
-        static_cast<QueuedAsyncProductPortsOnlyComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductPortsOnlyComponentBase* compPtr = static_cast<QueuedAsyncProductPortsOnlyComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                                      FwDpIdType id,
-                                                                      const Fw::Buffer& buffer,
-                                                                      const Fw::Success& status) {
-    (void)portNum;
-    (void)id;
-    (void)buffer;
-    (void)status;
-    // No data products defined
+void QueuedAsyncProductPortsOnlyComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  (void) portNum;
+  (void) id;
+  (void) buffer;
+  (void) status;
+  // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -40,9 +40,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -12,143 +12,94 @@
 #include "QueuedAsyncProductPortsOnlyComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDASYNCPRODUCTPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedAsyncProductPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -157,15 +108,11 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputDpResponsePort* QueuedAsyncProductPortsOnlyComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* QueuedAsyncProductPortsOnlyComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -176,32 +123,20 @@ Fw::InputDpResponsePort* QueuedAsyncProductPortsOnlyComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                                 Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                              Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -212,32 +147,20 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductPortsOnlyComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                                 Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductPortsOnlyComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                              Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -246,18 +169,10 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedAsyncProductPortsOnlyComponentBase ::
-  QueuedAsyncProductPortsOnlyComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
+QueuedAsyncProductPortsOnlyComponentBase ::QueuedAsyncProductPortsOnlyComponentBase(const char* compName)
+    : Fw::QueuedComponentBase(compName) {}
 
-}
-
-QueuedAsyncProductPortsOnlyComponentBase ::
-  ~QueuedAsyncProductPortsOnlyComponentBase()
-{
-
-}
+QueuedAsyncProductPortsOnlyComponentBase ::~QueuedAsyncProductPortsOnlyComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -265,26 +180,18 @@ QueuedAsyncProductPortsOnlyComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedAsyncProductPortsOnlyComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductPortsOnlyComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductPortsOnlyComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductPortsOnlyComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -295,75 +202,44 @@ bool QueuedAsyncProductPortsOnlyComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductPortsOnlyComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                          FwDpIdType id,
+                                                                          const Fw::Buffer& buffer,
+                                                                          const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  productRecvIn_preMsgHook(
-    portNum,
-    id,
-    buffer,
-    status
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    productRecvIn_preMsgHook(portNum, id, buffer, status);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument id
-  _status = msg.serializeFrom(id);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument id
+    _status = msg.serializeFrom(id);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msg.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msg.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument status
-  _status = msg.serializeFrom(status);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument status
+    _status = msg.serializeFrom(status);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -374,166 +250,118 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
+void QueuedAsyncProductPortsOnlyComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
+                                                                         FwDpIdType id,
+                                                                         const Fw::Buffer& buffer,
+                                                                         const Fw::Success& status) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port productRecvIn
-    case PRODUCTRECVIN_DPRESPONSE: {
-      // Deserialize argument id
-      FwDpIdType id;
-      _deserStatus = _msg.deserializeTo(id);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument buffer
-      Fw::Buffer buffer;
-      _deserStatus = _msg.deserializeTo(buffer);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument status
-      Fw::Success status;
-      _deserStatus = _msg.deserializeTo(status);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->productRecvIn_handler(
-        portNum,
-        id,
-        buffer,
-        status
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  return MSG_DISPATCH_OK;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDASYNCPRODUCTPORTSONLY_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
+    }
+
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    switch (_msgType) {
+        // Handle async input port productRecvIn
+        case PRODUCTRECVIN_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvIn_handler(portNum, id, buffer, status);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
+    }
+
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductPortsOnlyComponentBase* compPtr = static_cast<QueuedAsyncProductPortsOnlyComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void QueuedAsyncProductPortsOnlyComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     FwDpIdType id,
+                                                                     const Fw::Buffer& buffer,
+                                                                     const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductPortsOnlyComponentBase* compPtr =
+        static_cast<QueuedAsyncProductPortsOnlyComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductPortsOnlyComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  (void) portNum;
-  (void) id;
-  (void) buffer;
-  (void) status;
-  // No data products defined
+void QueuedAsyncProductPortsOnlyComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                                      FwDpIdType id,
+                                                                      const Fw::Buffer& buffer,
+                                                                      const Fw::Success& status) {
+    (void)portNum;
+    (void)id;
+    (void)buffer;
+    (void)status;
+    // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedAsyncProductsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDASYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
     ALIASTYPEDASYNC_ALIASTYPED,
@@ -21,11 +21,11 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -33,1212 +33,772 @@ namespace {
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedAsyncProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+QueuedAsyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+QueuedAsyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-QueuedAsyncProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const QueuedAsyncProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const QueuedAsyncProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const QueuedAsyncProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const QueuedAsyncProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                   FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                  FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void QueuedAsyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1247,26 +807,17 @@ void QueuedAsyncProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedAsyncProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedAsyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedAsyncProductsComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* QueuedAsyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -1277,213 +828,141 @@ Fw::InputDpResponsePort* QueuedAsyncProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedAsyncProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedAsyncProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedAsyncProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedAsyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedAsyncProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedAsyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1494,148 +973,78 @@ Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                         Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedAsyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedAsyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1646,116 +1055,66 @@ void QueuedAsyncProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                             Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                     Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                           Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1766,134 +1125,72 @@ void QueuedAsyncProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                         Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedAsyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedAsyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1904,46 +1201,25 @@ void QueuedAsyncProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1952,18 +1228,10 @@ void QueuedAsyncProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedAsyncProductsComponentBase ::
-  QueuedAsyncProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+QueuedAsyncProductsComponentBase ::QueuedAsyncProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-QueuedAsyncProductsComponentBase ::
-  ~QueuedAsyncProductsComponentBase()
-{
-
-}
+QueuedAsyncProductsComponentBase ::~QueuedAsyncProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1971,118 +1239,76 @@ QueuedAsyncProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2093,92 +1319,59 @@ bool QueuedAsyncProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedAsyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2189,95 +1382,59 @@ bool QueuedAsyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedAsyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                          FwOpcodeType opCode,
+                                                          U32 cmdSeq,
+                                                          Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
-void QueuedAsyncProductsComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                  FwDpIdType id,
+                                                                  const Fw::Buffer& buffer,
+                                                                  const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  productRecvIn_preMsgHook(
-    portNum,
-    id,
-    buffer,
-    status
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    productRecvIn_preMsgHook(portNum, id, buffer, status);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument id
-  _status = msg.serializeFrom(id);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument id
+    _status = msg.serializeFrom(id);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msg.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msg.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument status
-  _status = msg.serializeFrom(status);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument status
+    _status = msg.serializeFrom(status);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -2286,941 +1443,561 @@ void QueuedAsyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedAsyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedAsyncProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedAsyncProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedAsyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedAsyncProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedAsyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedAsyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedAsyncProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedAsyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                               AliasPrim1 u32,
+                                                                               AliasPrim2 f32,
+                                                                               AliasBool b,
+                                                                               const Fw::StringBase& str2,
+                                                                               const AliasEnum& e,
+                                                                               const AliasArray& a,
+                                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedAsyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                     AliasPrim1 u32,
+                                                                                     AliasPrim2 f32,
+                                                                                     AliasBool b,
+                                                                                     const Fw::StringBase& str2,
+                                                                                     const AliasEnum& e,
+                                                                                     const AliasArray& a,
+                                                                                     const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedAsyncProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedAsyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedAsyncProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedAsyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3231,15 +2008,11 @@ void QueuedAsyncProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
+void QueuedAsyncProductsComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
+                                                                 FwDpIdType id,
+                                                                 const Fw::Buffer& buffer,
+                                                                 const Fw::Success& status) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -3250,85 +2023,63 @@ void QueuedAsyncProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedAsyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedAsyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedAsyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedAsyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedAsyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedAsyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3337,209 +2088,103 @@ void QueuedAsyncProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedAsyncProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedAsyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedAsyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedAsyncProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedAsyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedAsyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedAsyncProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedAsyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3548,47 +2193,39 @@ F32 QueuedAsyncProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void QueuedAsyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedAsyncProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedAsyncProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3598,923 +2235,539 @@ Fw::Time QueuedAsyncProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedAsyncProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedAsyncProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedAsyncProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == QUEUEDASYNCPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port productRecvIn
-    case PRODUCTRECVIN_DPRESPONSE: {
-      // Deserialize argument id
-      FwDpIdType id;
-      _deserStatus = _msg.deserializeTo(id);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument buffer
-      Fw::Buffer buffer;
-      _deserStatus = _msg.deserializeTo(buffer);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument status
-      Fw::Success status;
-      _deserStatus = _msg.deserializeTo(status);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->productRecvIn_handler(
-        portNum,
-        id,
-        buffer,
-        status
-      );
-
-      break;
+    if (_msgType == QUEUEDASYNCPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port productRecvIn
+        case PRODUCTRECVIN_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvIn_handler(portNum, id, buffer, status);
 
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            break;
+        }
 
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
-
-      break;
-    }
-
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedAsyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     FwOpcodeType opCode,
+                                                     U32 cmdSeq,
+                                                     Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void QueuedAsyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer,
+                                                             const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedAsyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedAsyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedAsyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedAsyncProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedAsyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedAsyncProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedAsyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedAsyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedAsyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedAsyncProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedAsyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum,
+                                                                          AliasPrim1 u32,
+                                                                          AliasPrim2 f32,
+                                                                          AliasBool b,
+                                                                          const Fw::StringBase& str2,
+                                                                          const AliasEnum& e,
+                                                                          const AliasArray& a,
+                                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedAsyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                FwIndexType portNum,
+                                                                                AliasPrim1 u32,
+                                                                                AliasPrim2 f32,
+                                                                                AliasBool b,
+                                                                                const Fw::StringBase& str2,
+                                                                                const AliasEnum& e,
+                                                                                const AliasArray& a,
+                                                                                const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                      FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedAsyncProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedAsyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedAsyncProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedAsyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str2,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedAsyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4523,68 +2776,32 @@ void QueuedAsyncProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  productRequestOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
+                                                              FwDpIdType id,
+                                                              FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productRequestOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productRequestOut_OutputPort[portNum].invoke(
-    id,
-    dataSize
-  );
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                           FwDpIdType id,
+                                                           const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedAsyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4593,71 +2810,58 @@ void QueuedAsyncProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::
-  dpRequest(
-      ContainerId::T containerId,
-      FwSizeType dataSize
-  )
-{
-  const FwDpIdType globalId = this->getIdBase() + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  this->productRequestOut_out(0, globalId, size);
+void QueuedAsyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+    const FwDpIdType globalId = this->getIdBase() + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedAsyncProductsComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  DpContainer container;
-  if (status == Fw::Success::SUCCESS) {
-    container = DpContainer(id, buffer, this->getIdBase());
-  }
-  // Convert global id to local id
-  const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(
-    id >= idBase,
-    static_cast<FwAssertArgType>(id),
-    static_cast<FwAssertArgType>(idBase)
-  );
-  const FwDpIdType localId = id - idBase;
-  // Switch on the local id
-  switch (localId) {
-    case ContainerId::Container1:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container1);
-      // Call the handler
-      this->dpRecv_Container1_handler(container, status.e);
-      break;
-    case ContainerId::Container2:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container2);
-      // Call the handler
-      this->dpRecv_Container2_handler(container, status.e);
-      break;
-    case ContainerId::Container3:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container3);
-      // Call the handler
-      this->dpRecv_Container3_handler(container, status.e);
-      break;
-    case ContainerId::Container4:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container4);
-      // Call the handler
-      this->dpRecv_Container4_handler(container, status.e);
-      break;
-    case ContainerId::Container5:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container5);
-      // Call the handler
-      this->dpRecv_Container5_handler(container, status.e);
-      break;
-    default:
-      FW_ASSERT(0);
-      break;
-  }
+void QueuedAsyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                              FwDpIdType id,
+                                                              const Fw::Buffer& buffer,
+                                                              const Fw::Success& status) {
+    DpContainer container;
+    if (status == Fw::Success::SUCCESS) {
+        container = DpContainer(id, buffer, this->getIdBase());
+    }
+    // Convert global id to local id
+    const FwDpIdType idBase = this->getIdBase();
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    const FwDpIdType localId = id - idBase;
+    // Switch on the local id
+    switch (localId) {
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
+    }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -52,9 +52,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedAsyncProductsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDASYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
     ALIASTYPEDASYNC_ALIASTYPED,
@@ -21,11 +21,11 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -33,772 +33,1205 @@ union BuffUnion {
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedAsyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+QueuedAsyncProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-QueuedAsyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const QueuedAsyncProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+QueuedAsyncProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const QueuedAsyncProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const QueuedAsyncProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const QueuedAsyncProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                   FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                  FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void QueuedAsyncProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -807,17 +1240,26 @@ void QueuedAsyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreT
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedAsyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedAsyncProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedAsyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* QueuedAsyncProductsComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -828,141 +1270,213 @@ Fw::InputDpResponsePort* QueuedAsyncProductsComponentBase ::get_productRecvIn_In
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedAsyncProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedAsyncProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedAsyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedAsyncProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedAsyncProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedAsyncProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedAsyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedAsyncProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedAsyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedAsyncProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedAsyncProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -973,78 +1487,148 @@ Ports::InputTypedPort* QueuedAsyncProductsComponentBase ::get_typedSync_InputPor
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                         Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1055,66 +1639,116 @@ void QueuedAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNu
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                             Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                     Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                           Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1125,72 +1759,134 @@ void QueuedAsyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexTyp
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                         Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedAsyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedAsyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1201,25 +1897,46 @@ void QueuedAsyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNu
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1228,10 +1945,18 @@ void QueuedAsyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType port
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedAsyncProductsComponentBase ::QueuedAsyncProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+QueuedAsyncProductsComponentBase ::
+  QueuedAsyncProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-QueuedAsyncProductsComponentBase ::~QueuedAsyncProductsComponentBase() {}
+}
+
+QueuedAsyncProductsComponentBase ::
+  ~QueuedAsyncProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1239,76 +1964,118 @@ QueuedAsyncProductsComponentBase ::~QueuedAsyncProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedAsyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedAsyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedAsyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1319,59 +2086,92 @@ bool QueuedAsyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexTyp
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedAsyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedAsyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedAsyncProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1382,59 +2182,95 @@ bool QueuedAsyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(Fw
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                          FwOpcodeType opCode,
-                                                          U32 cmdSeq,
-                                                          Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedAsyncProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void QueuedAsyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                  FwDpIdType id,
-                                                                  const Fw::Buffer& buffer,
-                                                                  const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    productRecvIn_preMsgHook(portNum, id, buffer, status);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  productRecvIn_preMsgHook(
+    portNum,
+    id,
+    buffer,
+    status
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument id
-    _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument id
+  _status = msg.serializeFrom(id);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msg.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument status
-    _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument status
+  _status = msg.serializeFrom(status);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1443,561 +2279,941 @@ void QueuedAsyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType po
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedAsyncProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedAsyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedAsyncProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedAsyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedAsyncProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedAsyncProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedAsyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                               AliasPrim1 u32,
-                                                                               AliasPrim2 f32,
-                                                                               AliasBool b,
-                                                                               const Fw::StringBase& str2,
-                                                                               const AliasEnum& e,
-                                                                               const AliasArray& a,
-                                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedAsyncProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                     AliasPrim1 u32,
-                                                                                     AliasPrim2 f32,
-                                                                                     AliasBool b,
-                                                                                     const Fw::StringBase& str2,
-                                                                                     const AliasEnum& e,
-                                                                                     const AliasArray& a,
-                                                                                     const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedAsyncProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedAsyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedAsyncProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedAsyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedAsyncProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedAsyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2008,11 +3224,15 @@ void QueuedAsyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNu
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
-                                                                 FwDpIdType id,
-                                                                 const Fw::Buffer& buffer,
-                                                                 const Fw::Success& status) {
-    // Default: no-op
+void QueuedAsyncProductsComponentBase ::
+  productRecvIn_preMsgHook(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -2023,63 +3243,85 @@ void QueuedAsyncProductsComponentBase ::productRecvIn_preMsgHook(FwIndexType por
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    // Default: no-op
+void QueuedAsyncProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedAsyncProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Default: no-op
+void QueuedAsyncProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void QueuedAsyncProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Default: no-op
+void QueuedAsyncProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedAsyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Default: no-op
+void QueuedAsyncProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2088,103 +3330,209 @@ void QueuedAsyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwInde
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedAsyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedAsyncProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedAsyncProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedAsyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedAsyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedAsyncProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedAsyncProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedAsyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedAsyncProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2193,39 +3541,47 @@ F32 QueuedAsyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void QueuedAsyncProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedAsyncProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedAsyncProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2235,539 +3591,923 @@ Fw::Time QueuedAsyncProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedAsyncProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedAsyncProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedAsyncProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == QUEUEDASYNCPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == QUEUEDASYNCPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port productRecvIn
+    case PRODUCTRECVIN_DPRESPONSE: {
+      // Deserialize argument id
+      FwDpIdType id;
+      _deserStatus = _msg.deserializeTo(id);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument buffer
+      Fw::Buffer buffer;
+      _deserStatus = _msg.deserializeTo(buffer);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument status
+      Fw::Success status;
+      _deserStatus = _msg.deserializeTo(status);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->productRecvIn_handler(
+        portNum,
+        id,
+        buffer,
+        status
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port productRecvIn
-        case PRODUCTRECVIN_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvIn_handler(portNum, id, buffer, status);
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            break;
-        }
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
+
+      break;
+    }
+
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     FwOpcodeType opCode,
-                                                     U32 cmdSeq,
-                                                     Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedAsyncProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer,
-                                                             const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void QueuedAsyncProductsComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedAsyncProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedAsyncProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedAsyncProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedAsyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedAsyncProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedAsyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedAsyncProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedAsyncProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedAsyncProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedAsyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum,
-                                                                          AliasPrim1 u32,
-                                                                          AliasPrim2 f32,
-                                                                          AliasBool b,
-                                                                          const Fw::StringBase& str2,
-                                                                          const AliasEnum& e,
-                                                                          const AliasArray& a,
-                                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedAsyncProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedAsyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                FwIndexType portNum,
-                                                                                AliasPrim1 u32,
-                                                                                AliasPrim2 f32,
-                                                                                AliasBool b,
-                                                                                const Fw::StringBase& str2,
-                                                                                const AliasEnum& e,
-                                                                                const AliasArray& a,
-                                                                                const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedAsyncProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                      FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedAsyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedAsyncProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedAsyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str2,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedAsyncProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedAsyncProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2776,32 +4516,68 @@ void QueuedAsyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBas
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
-                                                              FwDpIdType id,
-                                                              FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  productRequestOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+  FW_ASSERT(
+    this->m_productRequestOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productRequestOut_OutputPort[portNum].invoke(
+    id,
+    dataSize
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                           FwDpIdType id,
-                                                           const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void QueuedAsyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedAsyncProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2810,58 +4586,71 @@ void QueuedAsyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedAsyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
-    const FwDpIdType globalId = this->getIdBase() + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    this->productRequestOut_out(0, globalId, size);
+void QueuedAsyncProductsComponentBase ::
+  dpRequest(
+      ContainerId::T containerId,
+      FwSizeType dataSize
+  )
+{
+  const FwDpIdType globalId = this->getIdBase() + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedAsyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                              FwDpIdType id,
-                                                              const Fw::Buffer& buffer,
-                                                              const Fw::Success& status) {
-    DpContainer container;
-    if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
-    }
-    // Convert global id to local id
-    const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
-    const FwDpIdType localId = id - idBase;
-    // Switch on the local id
-    switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
-    }
+void QueuedAsyncProductsComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  DpContainer container;
+  if (status == Fw::Success::SUCCESS) {
+    container = DpContainer(id, buffer, this->getIdBase());
+  }
+  // Convert global id to local id
+  const FwDpIdType idBase = this->getIdBase();
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
+  const FwDpIdType localId = id - idBase;
+  // Switch on the local id
+  switch (localId) {
+    case ContainerId::Container1:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container1);
+      // Call the handler
+      this->dpRecv_Container1_handler(container, status.e);
+      break;
+    case ContainerId::Container2:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container2);
+      // Call the handler
+      this->dpRecv_Container2_handler(container, status.e);
+      break;
+    case ContainerId::Container3:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container3);
+      // Call the handler
+      this->dpRecv_Container3_handler(container, status.e);
+      break;
+    case ContainerId::Container4:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container4);
+      // Call the handler
+      this->dpRecv_Container4_handler(container, status.e);
+      break;
+    case ContainerId::Container5:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container5);
+      // Call the handler
+      this->dpRecv_Container5_handler(container, status.e);
+      break;
+    default:
+      FW_ASSERT(0);
+      break;
+  }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedCommandsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDCOMMANDS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -25,933 +25,575 @@ namespace {
     CMD_CMD_PARAMS_PRIORITY,
     CMD_CMD_DROP,
     CMD_CMD_PARAMS_PRIORITY_DROP,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedCommandsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -960,15 +602,10 @@ void QueuedCommandsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedCommandsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedCommandsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -979,213 +616,140 @@ Fw::InputCmdPort* QueuedCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedCommandsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedCommandsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedCommandsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedCommandsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedCommandsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedCommandsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedCommandsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedCommandsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1196,120 +760,62 @@ Ports::InputTypedPort* QueuedCommandsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedCommandsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedCommandsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1320,116 +826,65 @@ void QueuedCommandsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                  Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                 Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1440,106 +895,55 @@ void QueuedCommandsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedCommandsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedCommandsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1550,46 +954,24 @@ void QueuedCommandsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1598,113 +980,51 @@ void QueuedCommandsComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedCommandsComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_ASYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedCommandsComponentBase ::
-  QueuedCommandsComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
+QueuedCommandsComponentBase ::QueuedCommandsComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
 
-}
-
-QueuedCommandsComponentBase ::
-  ~QueuedCommandsComponentBase()
-{
-
-}
+QueuedCommandsComponentBase ::~QueuedCommandsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1712,96 +1032,62 @@ QueuedCommandsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedCommandsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedCommandsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedCommandsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1812,92 +1098,59 @@ bool QueuedCommandsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedCommandsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedCommandsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1908,176 +1161,103 @@ bool QueuedCommandsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedCommandsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                     FwOpcodeType opCode,
+                                                     U32 cmdSeq,
+                                                     Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_CMD_SYNC: {
+            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_CMD_SYNC: {
-      this->CMD_SYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
+        case OPCODE_CMD_SYNC_PRIMITIVE: {
+            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRING: {
+            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ENUM: {
+            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ARRAY: {
+            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRUCT: {
+            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED: {
+            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_PRIMITIVE: {
+            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRING: {
+            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ENUM: {
+            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ARRAY: {
+            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRUCT: {
+            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_ASYNC: {
+            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PRIORITY: {
+            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY: {
+            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_DROP: {
+            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_CMD_SYNC_PRIMITIVE: {
-      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRING: {
-      this->CMD_SYNC_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ENUM: {
-      this->CMD_SYNC_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ARRAY: {
-      this->CMD_SYNC_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRUCT: {
-      this->CMD_SYNC_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED: {
-      this->CMD_GUARDED_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_PRIMITIVE: {
-      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRING: {
-      this->CMD_GUARDED_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ENUM: {
-      this->CMD_GUARDED_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ARRAY: {
-      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRUCT: {
-      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_ASYNC: {
-      this->CMD_ASYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PRIORITY: {
-      this->CMD_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY: {
-      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_DROP: {
-      this->CMD_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -2086,941 +1266,561 @@ void QueuedCommandsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedCommandsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedCommandsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedCommandsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedCommandsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedCommandsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedCommandsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedCommandsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedCommandsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedCommandsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedCommandsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedCommandsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                          AliasPrim1 u32,
+                                                                          AliasPrim2 f32,
+                                                                          AliasBool b,
+                                                                          const Fw::StringBase& str2,
+                                                                          const AliasEnum& e,
+                                                                          const AliasArray& a,
+                                                                          const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedCommandsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                AliasPrim1 u32,
+                                                                                AliasPrim2 f32,
+                                                                                AliasBool b,
+                                                                                const Fw::StringBase& str2,
+                                                                                const AliasEnum& e,
+                                                                                const AliasArray& a,
+                                                                                const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedCommandsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedCommandsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedCommandsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedCommandsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str2,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedCommandsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3031,85 +1831,63 @@ void QueuedCommandsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedCommandsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                              AliasPrim1 u32,
+                                                              AliasPrim2 f32,
+                                                              AliasBool b,
+                                                              const Fw::StringBase& str2,
+                                                              const AliasEnum& e,
+                                                              const AliasArray& a,
+                                                              const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedCommandsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedCommandsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedCommandsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedCommandsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedCommandsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3118,209 +1896,103 @@ void QueuedCommandsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedCommandsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedCommandsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedCommandsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedCommandsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                     AliasPrim1 u32,
+                                                     AliasPrim2 f32,
+                                                     AliasBool b,
+                                                     const Fw::StringBase& str2,
+                                                     const AliasEnum& e,
+                                                     const AliasArray& a,
+                                                     const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedCommandsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedCommandsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedCommandsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedCommandsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                U32 u32,
+                                                F32 f32,
+                                                bool b,
+                                                const Fw::StringBase& str1,
+                                                const E& e,
+                                                const A& a,
+                                                const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedCommandsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedCommandsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str2,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3329,15 +2001,9 @@ F32 QueuedCommandsComponentBase ::
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedCommandsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -3346,965 +2012,623 @@ void QueuedCommandsComponentBase ::
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  CMD_SYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedCommandsComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                     U32 cmdSeq,
+                                                                     Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_SYNC_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_SYNC_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_SYNC_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_SYNC_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_GUARDED_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedCommandsComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                        U32 cmdSeq,
+                                                                        Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_GUARDED_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                     U32 cmdSeq,
+                                                                     Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_GUARDED_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_GUARDED_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                    U32 cmdSeq,
+                                                                    Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_GUARDED_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                     U32 cmdSeq,
+                                                                     Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_ASYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
+void QueuedCommandsComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+void QueuedCommandsComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                               U32 cmdSeq,
+                                                               Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                      U32 cmdSeq,
+                                                                      Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+void QueuedCommandsComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
+                                                                           U32 cmdSeq,
+                                                                           Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -4315,76 +2639,48 @@ void QueuedCommandsComponentBase ::
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  CMD_ASYNC_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedCommandsComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedCommandsComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedCommandsComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedCommandsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedCommandsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -4394,1163 +2690,738 @@ Fw::Time QueuedCommandsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedCommandsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedCommandsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedCommandsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDCOMMANDS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      break;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDCOMMANDS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
-    }
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle command CMD_ASYNC
-    case CMD_CMD_ASYNC: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle command CMD_ASYNC
+        case CMD_CMD_ASYNC: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PRIORITY
-    case CMD_CMD_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_PRIORITY
+        case CMD_CMD_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY
-    case CMD_CMD_PARAMS_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY
+        case CMD_CMD_PARAMS_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
-    }
-
-    // Handle command CMD_DROP
-    case CMD_CMD_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_DROP
+        case CMD_CMD_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY_DROP
-    case CMD_CMD_PARAMS_PRIORITY_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_DROP
+        case CMD_CMD_PARAMS_PRIORITY_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedCommandsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                FwIndexType portNum,
+                                                FwOpcodeType opCode,
+                                                U32 cmdSeq,
+                                                Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedCommandsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedCommandsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedCommandsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedCommandsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedCommandsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedCommandsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedCommandsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedCommandsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedCommandsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedCommandsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedCommandsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedCommandsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedCommandsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                           FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedCommandsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedCommandsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedCommandsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedCommandsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str2,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedCommandsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedCommandsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) {
+    FW_ASSERT(callComp);
+    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -5559,68 +3430,31 @@ void QueuedCommandsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void QueuedCommandsComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-void QueuedCommandsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedCommandsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -55,9 +55,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedCommandsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDCOMMANDS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -25,575 +25,926 @@ enum MsgTypeEnum {
     CMD_CMD_PARAMS_PRIORITY,
     CMD_CMD_DROP,
     CMD_CMD_PARAMS_PRIORITY_DROP,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedCommandsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -602,10 +953,15 @@ void QueuedCommandsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType i
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedCommandsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedCommandsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -616,140 +972,213 @@ Fw::InputCmdPort* QueuedCommandsComponentBase ::get_cmdIn_InputPort(FwIndexType 
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedCommandsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedCommandsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedCommandsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedCommandsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedCommandsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedCommandsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedCommandsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedCommandsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedCommandsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedCommandsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedCommandsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedCommandsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -760,62 +1189,120 @@ Ports::InputTypedPort* QueuedCommandsComponentBase ::get_typedSync_InputPort(FwI
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -826,65 +1313,116 @@ void QueuedCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                  Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                 Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -895,55 +1433,106 @@ void QueuedCommandsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType por
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedCommandsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedCommandsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -954,24 +1543,46 @@ void QueuedCommandsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -980,51 +1591,113 @@ void QueuedCommandsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, 
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedCommandsComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_ASYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+  );
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedCommandsComponentBase ::QueuedCommandsComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
+QueuedCommandsComponentBase ::
+  QueuedCommandsComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
 
-QueuedCommandsComponentBase ::~QueuedCommandsComponentBase() {}
+}
+
+QueuedCommandsComponentBase ::
+  ~QueuedCommandsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1032,62 +1705,96 @@ QueuedCommandsComponentBase ::~QueuedCommandsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedCommandsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedCommandsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedCommandsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1098,59 +1805,92 @@ bool QueuedCommandsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType por
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedCommandsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedCommandsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedCommandsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1161,103 +1901,176 @@ bool QueuedCommandsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndex
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                     FwOpcodeType opCode,
-                                                     U32 cmdSeq,
-                                                     Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedCommandsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_CMD_SYNC: {
-            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_CMD_SYNC_PRIMITIVE: {
-            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRING: {
-            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ENUM: {
-            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ARRAY: {
-            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRUCT: {
-            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED: {
-            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_PRIMITIVE: {
-            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRING: {
-            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ENUM: {
-            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ARRAY: {
-            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRUCT: {
-            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_ASYNC: {
-            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PRIORITY: {
-            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY: {
-            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_DROP: {
-            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_CMD_SYNC: {
+      this->CMD_SYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
     }
+
+    case OPCODE_CMD_SYNC_PRIMITIVE: {
+      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRING: {
+      this->CMD_SYNC_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ENUM: {
+      this->CMD_SYNC_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ARRAY: {
+      this->CMD_SYNC_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRUCT: {
+      this->CMD_SYNC_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED: {
+      this->CMD_GUARDED_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_PRIMITIVE: {
+      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRING: {
+      this->CMD_GUARDED_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ENUM: {
+      this->CMD_GUARDED_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ARRAY: {
+      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRUCT: {
+      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_ASYNC: {
+      this->CMD_ASYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PRIORITY: {
+      this->CMD_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY: {
+      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_DROP: {
+      this->CMD_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1266,561 +2079,941 @@ void QueuedCommandsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedCommandsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedCommandsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedCommandsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedCommandsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedCommandsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedCommandsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedCommandsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedCommandsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedCommandsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedCommandsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedCommandsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedCommandsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedCommandsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                          AliasPrim1 u32,
-                                                                          AliasPrim2 f32,
-                                                                          AliasBool b,
-                                                                          const Fw::StringBase& str2,
-                                                                          const AliasEnum& e,
-                                                                          const AliasArray& a,
-                                                                          const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedCommandsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedCommandsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                AliasPrim1 u32,
-                                                                                AliasPrim2 f32,
-                                                                                AliasBool b,
-                                                                                const Fw::StringBase& str2,
-                                                                                const AliasEnum& e,
-                                                                                const AliasArray& a,
-                                                                                const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedCommandsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedCommandsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedCommandsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedCommandsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedCommandsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedCommandsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedCommandsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedCommandsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedCommandsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str2,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedCommandsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedCommandsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1831,63 +3024,85 @@ void QueuedCommandsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                              AliasPrim1 u32,
-                                                              AliasPrim2 f32,
-                                                              AliasBool b,
-                                                              const Fw::StringBase& str2,
-                                                              const AliasEnum& e,
-                                                              const AliasArray& a,
-                                                              const AliasStruct& s) {
-    // Default: no-op
+void QueuedCommandsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedCommandsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Default: no-op
+void QueuedCommandsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Default: no-op
+void QueuedCommandsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Default: no-op
+void QueuedCommandsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedCommandsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Default: no-op
+void QueuedCommandsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1896,103 +3111,209 @@ void QueuedCommandsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedCommandsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedCommandsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedCommandsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedCommandsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedCommandsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                     AliasPrim1 u32,
-                                                     AliasPrim2 f32,
-                                                     AliasBool b,
-                                                     const Fw::StringBase& str2,
-                                                     const AliasEnum& e,
-                                                     const AliasArray& a,
-                                                     const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedCommandsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedCommandsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedCommandsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedCommandsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                U32 u32,
-                                                F32 f32,
-                                                bool b,
-                                                const Fw::StringBase& str1,
-                                                const E& e,
-                                                const A& a,
-                                                const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedCommandsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str2,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedCommandsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2001,9 +3322,15 @@ F32 QueuedCommandsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedCommandsComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -2012,623 +3339,965 @@ void QueuedCommandsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdS
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void QueuedCommandsComponentBase ::
+  CMD_SYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void QueuedCommandsComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                     U32 cmdSeq,
-                                                                     Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
+  this->CMD_SYNC_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 }
 
-void QueuedCommandsComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_SYNC_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_SYNC_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 }
 
-void QueuedCommandsComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_SYNC_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_SYNC_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 }
 
-void QueuedCommandsComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_SYNC_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_SYNC_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 }
 
-void QueuedCommandsComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_SYNC_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_SYNC_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void QueuedCommandsComponentBase ::
+  CMD_GUARDED_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedCommandsComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                        U32 cmdSeq,
-                                                                        Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
-
-#if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-#endif
-
-    this->lock();
-
-    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
-
-    this->unLock();
-}
-
-void QueuedCommandsComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                     U32 cmdSeq,
-                                                                     Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Reset the buffer
-    args.resetDeser();
-
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedCommandsComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_GUARDED_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
+
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_GUARDED_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedCommandsComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                    U32 cmdSeq,
-                                                                    Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_GUARDED_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_GUARDED_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedCommandsComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                     U32 cmdSeq,
-                                                                     Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedCommandsComponentBase ::
+  CMD_GUARDED_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_GUARDED_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedCommandsComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
+void QueuedCommandsComponentBase ::
+  CMD_GUARDED_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Reset the buffer
+  args.resetDeser();
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedCommandsComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                               U32 cmdSeq,
-                                                               Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                      U32 cmdSeq,
-                                                                      Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedCommandsComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+#if FW_CMD_CHECK_RESIDUAL
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
+#endif
+
+  this->lock();
+
+  this->CMD_GUARDED_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
+
+  this->unLock();
 }
 
-void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
-                                                                           U32 cmdSeq,
-                                                                           Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
+void QueuedCommandsComponentBase ::
+  CMD_ASYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+void QueuedCommandsComponentBase ::
+  CMD_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedCommandsComponentBase ::
+  CMD_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2639,48 +4308,76 @@ void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpc
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedCommandsComponentBase ::
+  CMD_ASYNC_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedCommandsComponentBase ::
+  CMD_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedCommandsComponentBase ::
+  CMD_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedCommandsComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedCommandsComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedCommandsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedCommandsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2690,738 +4387,1163 @@ Fw::Time QueuedCommandsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedCommandsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedCommandsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedCommandsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDCOMMANDS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDCOMMANDS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle command CMD_ASYNC
-        case CMD_CMD_ASYNC: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PRIORITY
-        case CMD_CMD_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY
-        case CMD_CMD_PARAMS_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle command CMD_DROP
-        case CMD_CMD_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY_DROP
-        case CMD_CMD_PARAMS_PRIORITY_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle command CMD_ASYNC
+    case CMD_CMD_ASYNC: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PRIORITY
+    case CMD_CMD_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY
+    case CMD_CMD_PARAMS_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle command CMD_DROP
+    case CMD_CMD_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY_DROP
+    case CMD_CMD_PARAMS_PRIORITY_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                FwIndexType portNum,
-                                                FwOpcodeType opCode,
-                                                U32 cmdSeq,
-                                                Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedCommandsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedCommandsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedCommandsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedCommandsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedCommandsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedCommandsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedCommandsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedCommandsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedCommandsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedCommandsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedCommandsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedCommandsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedCommandsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedCommandsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedCommandsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedCommandsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                           FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedCommandsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedCommandsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedCommandsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedCommandsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str2,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedCommandsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedCommandsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) {
-    FW_ASSERT(callComp);
-    QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedCommandsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3430,31 +5552,68 @@ void QueuedCommandsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* ca
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedCommandsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void QueuedCommandsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-void QueuedCommandsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedCommandsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedEventsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDEVENTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedEventsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void QueuedEventsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType ins
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedEventsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedEventsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,139 +967,213 @@ Fw::InputCmdPort* QueuedEventsComponentBase ::get_cmdIn_InputPort(FwIndexType po
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedEventsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedEventsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedEventsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedEventsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedEventsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedEventsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedEventsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedEventsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedEventsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedEventsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedEventsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedEventsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedEventsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedEventsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedEventsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedEventsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedEventsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedEventsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedEventsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedEventsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedEventsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedEventsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedEventsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -754,62 +1184,120 @@ Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedSync_InputPort(FwInd
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -820,64 +1308,116 @@ void QueuedEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -888,55 +1428,106 @@ void QueuedEventsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portN
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -947,24 +1538,46 @@ void QueuedEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -973,16 +1586,23 @@ void QueuedEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedEventsComponentBase ::QueuedEventsComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {
-    this->m_EventActivityLowThrottledThrottle = 0;
-    this->m_EventFatalThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+QueuedEventsComponentBase ::
+  QueuedEventsComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
+  this->m_EventActivityLowThrottledThrottle = 0;
+  this->m_EventFatalThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-QueuedEventsComponentBase ::~QueuedEventsComponentBase() {}
+QueuedEventsComponentBase ::
+  ~QueuedEventsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -990,62 +1610,96 @@ QueuedEventsComponentBase ::~QueuedEventsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedEventsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedEventsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedEventsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1056,59 +1710,92 @@ bool QueuedEventsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portN
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedEventsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedEventsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1119,19 +1806,24 @@ bool QueuedEventsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexTy
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedEventsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1140,561 +1832,941 @@ void QueuedEventsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedEventsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedEventsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedEventsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedEventsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedEventsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedEventsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedEventsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedEventsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedEventsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedEventsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedEventsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedEventsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedEventsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedEventsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedEventsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedEventsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedEventsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedEventsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedEventsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedEventsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedEventsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedEventsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedEventsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedEventsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedEventsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedEventsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1705,63 +2777,85 @@ void QueuedEventsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    // Default: no-op
+void QueuedEventsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedEventsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedEventsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedEventsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Default: no-op
+void QueuedEventsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedEventsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void QueuedEventsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedEventsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void QueuedEventsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedEventsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void QueuedEventsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1770,103 +2864,209 @@ void QueuedEventsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType p
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedEventsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedEventsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedEventsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedEventsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedEventsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                   AliasPrim1 u32,
-                                                   AliasPrim2 f32,
-                                                   AliasBool b,
-                                                   const Fw::StringBase& str2,
-                                                   const AliasEnum& e,
-                                                   const AliasArray& a,
-                                                   const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedEventsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedEventsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedEventsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedEventsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedEventsComponentBase ::typedOut_out(FwIndexType portNum,
-                                              U32 u32,
-                                              F32 f32,
-                                              bool b,
-                                              const Fw::StringBase& str1,
-                                              const E& e,
-                                              const A& a,
-                                              const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedEventsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str2,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedEventsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -1875,474 +3075,723 @@ F32 QueuedEventsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
+void QueuedEventsComponentBase ::
+  log_ACTIVITY_HI_EventActivityHigh() const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
-    }
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logBuff
+    );
+  }
 
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity High occurred";
+    const char* _formatString =
+      "(%s) %s: Event Activity High occurred";
 #else
-        const char* _formatString = "%s: Event Activity High occurred";
+    const char* _formatString =
+      "%s: Event Activity High occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityHigh ");
+      "EventActivityHigh "
+    );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
-    }
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logString
+    );
+  }
 #endif
 }
 
-void QueuedEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
-    // Check throttle value
-    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+void QueuedEventsComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  // Check throttle value
+  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventActivityLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(u32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(F32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(f32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U8))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(b);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#else
+    const char* _formatString =
+      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventActivityLowThrottled ",
+      u32,
+      static_cast<F64>(f32),
+      b
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedEventsComponentBase ::
+  log_COMMAND_EventCommand(
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
+  ) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    _status = str1.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = str2.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+    const char* _formatString =
+      "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventCommand ",
+      str1.toChar(),
+      str2.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedEventsComponentBase ::
+  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(E::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(e);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+    Fw::String eStr;
+    e.toString(eStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventDiagnostic ",
+      eStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedEventsComponentBase ::
+  log_FATAL_EventFatalThrottled(const A& a)
+{
+  // Check throttle value
+  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventFatalThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(A::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(a);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Fatal occurred with argument: %s";
+#endif
+
+    Fw::String aStr;
+    a.toString(aStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventFatalThrottled ",
+      aStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedEventsComponentBase ::
+  log_WARNING_HI_EventWarningHigh(const S& s) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(S::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(s);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Warning High occurred with argument: %s";
+#endif
+
+    Fw::String sStr;
+    s.toString(sStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningHigh ",
+      sStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled()
+{
+  // Check throttle value
+  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventWarningLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
+#else
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningLowThrottled "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval()
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+  // Check throttle value & throttle timeout
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
+
+    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+      // The counter has overflowed, check if time interval has passed
+      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
+        // Reset the count
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+      } else {
+        // Throttle the event
         return;
-    } else {
-        this->m_EventActivityLowThrottledThrottle++;
+      }
     }
 
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+    // Reset the throttle time if needed
+    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+      // This is the first event, reset the throttle time
+      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
     }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+    // Increment the count
+    this->m_EventWarningLowThrottledIntervalThrottle++;
+  }
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(3));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
-        _status = _logBuff.serializeFrom(u32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(f32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(b);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
 #else
-        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
-    }
-#endif
-}
-
-void QueuedEventsComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
-                                                          const Fw::StringBase& str2) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(2));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
-                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventCommand ", str1.toChar(), str2.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
-    }
-#endif
-}
-
-void QueuedEventsComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(e);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-        Fw::String eStr;
-        e.toString(eStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventDiagnostic ", eStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
-    }
-#endif
-}
-
-void QueuedEventsComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
-    // Check throttle value
-    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventFatalThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-        _status = _logBuff.serializeFrom(static_cast<U8>(4));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = _logBuff.serializeFrom(static_cast<U32>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(a);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
-#endif
-
-        Fw::String aStr;
-        a.toString(aStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventFatalThrottled ", aStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
-    }
-#endif
-}
-
-void QueuedEventsComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(s);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
-#endif
-
-        Fw::String sStr;
-        s.toString(sStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningHigh ", sStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
-    }
-#endif
-}
-
-void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
-    // Check throttle value
-    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventWarningLowThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottled ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
-#endif
-}
-
-void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-    // Check throttle value & throttle timeout
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
-
-        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-            // The counter has overflowed, check if time interval has passed
-            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
-                Fw::TimeInterval(10, 0)) {
-                // Reset the count
-                this->m_EventWarningLowThrottledIntervalThrottle = 0;
-            } else {
-                // Throttle the event
-                return;
-            }
-        }
-
-        // Reset the throttle time if needed
-        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-            // This is the first event, reset the throttle time
-            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
-        }
-
-        // Increment the count
-        this->m_EventWarningLowThrottledIntervalThrottle++;
-    }
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottledInterval ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
+      "EventWarningLowThrottledInterval "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
 #endif
 }
 
@@ -2350,45 +3799,56 @@ void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventActivityLowThrottledThrottle = 0;
+void QueuedEventsComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventActivityLowThrottledThrottle = 0;
 }
 
-void QueuedEventsComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventFatalThrottledThrottle = 0;
+void QueuedEventsComponentBase ::
+  log_FATAL_EventFatalThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventFatalThrottledThrottle = 0;
 }
 
-void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventWarningLowThrottledThrottle = 0;
+void QueuedEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventWarningLowThrottledThrottle = 0;
 }
 
-void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
+void QueuedEventsComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
+{
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
 
-        // Reset throttle counter
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-        // Reset the throttle time
-        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-    }
+    // Reset the throttle time
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedEventsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedEventsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2398,526 +3858,892 @@ Fw::Time QueuedEventsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedEventsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedEventsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedEventsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDEVENTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDEVENTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                              FwIndexType portNum,
-                                              FwOpcodeType opCode,
-                                              U32 cmdSeq,
-                                              Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedEventsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedEventsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedEventsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedEventsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedEventsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedEventsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedEventsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedEventsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedEventsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedEventsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedEventsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedEventsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedEventsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedEventsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedEventsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedEventsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedEventsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedEventsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedEventsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedEventsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedEventsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedEventsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedEventsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedEventsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str2,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedEventsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedEventsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                  FwIndexType portNum,
-                                                  U32 u32,
-                                                  F32 f32,
-                                                  bool b,
-                                                  const Fw::StringBase& str1,
-                                                  const E& e,
-                                                  const A& a,
-                                                  const S& s) {
-    FW_ASSERT(callComp);
-    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedEventsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2926,39 +4752,80 @@ void QueuedEventsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* call
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::eventOut_out(FwIndexType portNum,
-                                              FwEventIdType id,
-                                              Fw::Time& timeTag,
-                                              const Fw::LogSeverity& severity,
-                                              Fw::LogBuffer& args) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  eventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::LogBuffer& args
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
+  FW_ASSERT(
+    this->m_eventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_eventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    args
+  );
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void QueuedEventsComponentBase ::textEventOut_out(FwIndexType portNum,
-                                                  FwEventIdType id,
-                                                  Fw::Time& timeTag,
-                                                  const Fw::LogSeverity& severity,
-                                                  Fw::TextLogString& text) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  textEventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::TextLogString& text
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
+  FW_ASSERT(
+    this->m_textEventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_textEventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    text
+  );
 }
 
 #endif
 
-void QueuedEventsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedEventsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedEventsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDEVENTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedEventsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void QueuedEventsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedEventsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedEventsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,139 @@ Fw::InputCmdPort* QueuedEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedEventsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedEventsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedEventsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedEventsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedEventsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedEventsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedEventsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedEventsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedEventsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedEventsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedEventsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedEventsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedEventsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedEventsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedEventsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedEventsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedEventsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +754,62 @@ Ports::InputTypedPort* QueuedEventsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedEventsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedEventsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +820,64 @@ void QueuedEventsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +888,55 @@ void QueuedEventsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedEventsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedEventsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +947,24 @@ void QueuedEventsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedEventsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,23 +973,16 @@ void QueuedEventsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedEventsComponentBase ::
-  QueuedEventsComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
-  this->m_EventActivityLowThrottledThrottle = 0;
-  this->m_EventFatalThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledIntervalThrottle = 0;
+QueuedEventsComponentBase ::QueuedEventsComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {
+    this->m_EventActivityLowThrottledThrottle = 0;
+    this->m_EventFatalThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-QueuedEventsComponentBase ::
-  ~QueuedEventsComponentBase()
-{
-
-}
+QueuedEventsComponentBase ::~QueuedEventsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1617,96 +990,62 @@ QueuedEventsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedEventsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedEventsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedEventsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1717,92 +1056,59 @@ bool QueuedEventsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedEventsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedEventsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedEventsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1813,24 +1119,19 @@ bool QueuedEventsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedEventsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1839,941 +1140,561 @@ void QueuedEventsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedEventsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedEventsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedEventsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedEventsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedEventsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedEventsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedEventsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedEventsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedEventsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedEventsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedEventsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedEventsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedEventsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedEventsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedEventsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedEventsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedEventsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedEventsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedEventsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedEventsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedEventsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedEventsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedEventsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedEventsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedEventsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedEventsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -2784,85 +1705,63 @@ void QueuedEventsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedEventsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedEventsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedEventsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedEventsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedEventsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Default: no-op
 }
 
-void QueuedEventsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedEventsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void QueuedEventsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedEventsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void QueuedEventsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedEventsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2871,209 +1770,103 @@ void QueuedEventsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedEventsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedEventsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedEventsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedEventsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedEventsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                   AliasPrim1 u32,
+                                                   AliasPrim2 f32,
+                                                   AliasBool b,
+                                                   const Fw::StringBase& str2,
+                                                   const AliasEnum& e,
+                                                   const AliasArray& a,
+                                                   const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedEventsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedEventsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedEventsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedEventsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedEventsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::typedOut_out(FwIndexType portNum,
+                                              U32 u32,
+                                              F32 f32,
+                                              bool b,
+                                              const Fw::StringBase& str1,
+                                              const E& e,
+                                              const A& a,
+                                              const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedEventsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedEventsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str2,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3082,723 +1875,474 @@ F32 QueuedEventsComponentBase ::
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  log_ACTIVITY_HI_EventActivityHigh() const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
+void QueuedEventsComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
 
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logBuff
-    );
-  }
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
+    }
 
-  // Emit the event on the text log port
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity High occurred";
+        const char* _formatString = "(%s) %s: Event Activity High occurred";
 #else
-    const char* _formatString =
-      "%s: Event Activity High occurred";
+        const char* _formatString = "%s: Event Activity High occurred";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventActivityHigh "
-    );
+                          "EventActivityHigh ");
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
+    }
 #endif
 }
 
-void QueuedEventsComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  // Check throttle value
-  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventActivityLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(3));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(F32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U8))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#else
-    const char* _formatString =
-      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventActivityLowThrottled ",
-      u32,
-      static_cast<F64>(f32),
-      b
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedEventsComponentBase ::
-  log_COMMAND_EventCommand(
-      const Fw::StringBase& str1,
-      const Fw::StringBase& str2
-  ) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(2));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    _status = str1.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = str2.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-    const char* _formatString =
-      "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventCommand ",
-      str1.toChar(),
-      str2.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedEventsComponentBase ::
-  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(E::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-    Fw::String eStr;
-    e.toString(eStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventDiagnostic ",
-      eStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedEventsComponentBase ::
-  log_FATAL_EventFatalThrottled(const A& a)
-{
-  // Check throttle value
-  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventFatalThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serializeFrom(static_cast<U8>(4));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = _logBuff.serializeFrom(static_cast<U32>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(A::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Fatal occurred with argument: %s";
-#endif
-
-    Fw::String aStr;
-    a.toString(aStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventFatalThrottled ",
-      aStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedEventsComponentBase ::
-  log_WARNING_HI_EventWarningHigh(const S& s) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(S::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Warning High occurred with argument: %s";
-#endif
-
-    Fw::String sStr;
-    s.toString(sStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningHigh ",
-      sStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled()
-{
-  // Check throttle value
-  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventWarningLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
-#else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningLowThrottled "
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval()
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-  // Check throttle value & throttle timeout
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
-    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-      // The counter has overflowed, check if time interval has passed
-      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
-        // Reset the count
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
-      } else {
-        // Throttle the event
+void QueuedEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
+    // Check throttle value
+    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
         return;
-      }
+    } else {
+        this->m_EventActivityLowThrottledThrottle++;
     }
 
-    // Reset the throttle time if needed
-    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-      // This is the first event, reset the throttle time
-      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
     }
 
-    // Increment the count
-    this->m_EventWarningLowThrottledIntervalThrottle++;
-  }
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(3));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(u32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Emit the event on the text log port
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(f32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(b);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
+        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
+        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventWarningLowThrottledInterval "
-    );
+                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
+    }
+#endif
+}
+
+void QueuedEventsComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
+                                                          const Fw::StringBase& str2) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(2));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
+                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventCommand ", str1.toChar(), str2.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
+    }
+#endif
+}
+
+void QueuedEventsComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(e);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+        Fw::String eStr;
+        e.toString(eStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventDiagnostic ", eStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
+    }
+#endif
+}
+
+void QueuedEventsComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
+    // Check throttle value
+    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventFatalThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+        _status = _logBuff.serializeFrom(static_cast<U8>(4));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = _logBuff.serializeFrom(static_cast<U32>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(a);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
+#endif
+
+        Fw::String aStr;
+        a.toString(aStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventFatalThrottled ", aStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
+    }
+#endif
+}
+
+void QueuedEventsComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(s);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
+#endif
+
+        Fw::String sStr;
+        s.toString(sStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningHigh ", sStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
+    }
+#endif
+}
+
+void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
+    // Check throttle value
+    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventWarningLowThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottled ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
+#endif
+}
+
+void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+    // Check throttle value & throttle timeout
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+            // The counter has overflowed, check if time interval has passed
+            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
+                Fw::TimeInterval(10, 0)) {
+                // Reset the count
+                this->m_EventWarningLowThrottledIntervalThrottle = 0;
+            } else {
+                // Throttle the event
+                return;
+            }
+        }
+
+        // Reset the throttle time if needed
+        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+            // This is the first event, reset the throttle time
+            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+        }
+
+        // Increment the count
+        this->m_EventWarningLowThrottledIntervalThrottle++;
+    }
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottledInterval ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
 #endif
 }
 
@@ -3806,56 +2350,45 @@ void QueuedEventsComponentBase ::
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventActivityLowThrottledThrottle = 0;
-}
-
-void QueuedEventsComponentBase ::
-  log_FATAL_EventFatalThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventFatalThrottledThrottle = 0;
-}
-
-void QueuedEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventWarningLowThrottledThrottle = 0;
-}
-
-void QueuedEventsComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
-{
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
+void QueuedEventsComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
     // Reset throttle counter
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    this->m_EventActivityLowThrottledThrottle = 0;
+}
 
-    // Reset the throttle time
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-  }
+void QueuedEventsComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventFatalThrottledThrottle = 0;
+}
+
+void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledThrottle = 0;
+}
+
+void QueuedEventsComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        // Reset throttle counter
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+
+        // Reset the throttle time
+        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedEventsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedEventsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3865,892 +2398,526 @@ Fw::Time QueuedEventsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedEventsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedEventsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedEventsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDEVENTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      break;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDEVENTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedEventsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                              FwIndexType portNum,
+                                              FwOpcodeType opCode,
+                                              U32 cmdSeq,
+                                              Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedEventsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedEventsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedEventsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedEventsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedEventsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedEventsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedEventsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedEventsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedEventsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedEventsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedEventsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedEventsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedEventsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedEventsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedEventsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedEventsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedEventsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedEventsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedEventsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str2,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedEventsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedEventsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                  FwIndexType portNum,
+                                                  U32 u32,
+                                                  F32 f32,
+                                                  bool b,
+                                                  const Fw::StringBase& str1,
+                                                  const E& e,
+                                                  const A& a,
+                                                  const S& s) {
+    FW_ASSERT(callComp);
+    QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4759,80 +2926,39 @@ void QueuedEventsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedEventsComponentBase ::
-  eventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::LogBuffer& args
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::eventOut_out(FwIndexType portNum,
+                                              FwEventIdType id,
+                                              Fw::Time& timeTag,
+                                              const Fw::LogSeverity& severity,
+                                              Fw::LogBuffer& args) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_eventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_eventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    args
-  );
+    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void QueuedEventsComponentBase ::
-  textEventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::TextLogString& text
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::textEventOut_out(FwIndexType portNum,
+                                                  FwEventIdType id,
+                                                  Fw::Time& timeTag,
+                                                  const Fw::LogSeverity& severity,
+                                                  Fw::TextLogString& text) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_textEventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_textEventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    text
-  );
+    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
 }
 
 #endif
 
-void QueuedEventsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedEventsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedExternalParamsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDEXTERNALPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedExternalParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void QueuedExternalParamsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedExternalParamsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedExternalParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,141 @@ Fw::InputCmdPort* QueuedExternalParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedExternalParamsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedExternalParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedExternalParamsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedExternalParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedExternalParamsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedExternalParamsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedExternalParamsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedExternalParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +756,63 @@ Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                       Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedExternalParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedExternalParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +823,67 @@ void QueuedExternalParamsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                            Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +894,57 @@ void QueuedExternalParamsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                       Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedExternalParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedExternalParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +955,25 @@ void QueuedExternalParamsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,298 +982,192 @@ void QueuedExternalParamsComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedExternalParamsComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  loadParameters()
-{
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedExternalParamsComponentBase ::loadParameters() {
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-  FwPrmIdType _id{};
-  Fw::ParamBuffer _paramBuffer;
+    FwPrmIdType _id{};
+    Fw::ParamBuffer _paramBuffer;
 
-  _id = _baseId + PARAMID_PARAMI32EXT;
+    _id = _baseId + PARAMID_PARAMI32EXT;
 
-  // Get serialized parameter ParamI32Ext
-  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamI32Ext
+    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMI32EXT,
-    this->m_param_ParamI32Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMF64EXT;
-
-  // Get serialized parameter ParamF64Ext
-  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMF64EXT,
-    this->m_param_ParamF64Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMSTRINGEXT;
-
-  // Get serialized parameter ParamStringExt
-  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-    Fw::String _val = Fw::String("external default");
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMF64EXT;
+
+    // Get serialized parameter ParamF64Ext
+    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMENUMEXT;
+    _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
-  // Get serialized parameter ParamEnumExt
-  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStringExt
+    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMENUMEXT,
-    this->m_param_ParamEnumExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+        Fw::String _val = Fw::String("external default");
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAYEXT;
+    _id = _baseId + PARAMID_PARAMENUMEXT;
 
-  // Get serialized parameter ParamArrayExt
-  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnumExt
+    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-    A _val = A({1, 2, 3});
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+    // Get serialized parameter ParamArrayExt
+    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+        A _val = A({1, 2, 3});
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+    // Get serialized parameter ParamStructExt
+    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
+                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-  // Get serialized parameter ParamStructExt
-  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMSTRUCTEXT,
-    this->m_param_ParamStructExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  // Call notifier
-  this->parametersLoaded();
+    // Call notifier
+    this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedExternalParamsComponentBase ::
-  QueuedExternalParamsComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
+QueuedExternalParamsComponentBase ::QueuedExternalParamsComponentBase(const char* compName)
+    : Fw::QueuedComponentBase(compName) {}
 
-}
-
-QueuedExternalParamsComponentBase ::
-  ~QueuedExternalParamsComponentBase()
-{
-
-}
+QueuedExternalParamsComponentBase ::~QueuedExternalParamsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1892,96 +1175,62 @@ QueuedExternalParamsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1992,92 +1241,59 @@ bool QueuedExternalParamsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedExternalParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2088,143 +1304,90 @@ bool QueuedExternalParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedExternalParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                           FwOpcodeType opCode,
+                                                           U32 cmdSeq,
+                                                           Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_PARAMI32EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_PARAMI32EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
+        case OPCODE_PARAMI32EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_PARAMI32EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -2233,941 +1396,561 @@ void QueuedExternalParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedExternalParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedExternalParamsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedExternalParamsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedExternalParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedExternalParamsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedExternalParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedExternalParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedExternalParamsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedExternalParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                                AliasPrim1 u32,
+                                                                                AliasPrim2 f32,
+                                                                                AliasBool b,
+                                                                                const Fw::StringBase& str2,
+                                                                                const AliasEnum& e,
+                                                                                const AliasArray& a,
+                                                                                const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedExternalParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                      AliasPrim1 u32,
+                                                                                      AliasPrim2 f32,
+                                                                                      AliasBool b,
+                                                                                      const Fw::StringBase& str2,
+                                                                                      const AliasEnum& e,
+                                                                                      const AliasArray& a,
+                                                                                      const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                             U32 u32,
+                                                                             F32 f32,
+                                                                             bool b,
+                                                                             const Fw::StringBase& str1,
+                                                                             const E& e,
+                                                                             const A& a,
+                                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedExternalParamsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedExternalParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedExternalParamsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedExternalParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3178,85 +1961,63 @@ void QueuedExternalParamsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedExternalParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedExternalParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedExternalParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedExternalParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedExternalParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedExternalParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3265,209 +2026,103 @@ void QueuedExternalParamsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedExternalParamsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedExternalParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedExternalParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                           AliasPrim1 u32,
+                                                           AliasPrim2 f32,
+                                                           AliasBool b,
+                                                           const Fw::StringBase& str2,
+                                                           const AliasEnum& e,
+                                                           const AliasArray& a,
+                                                           const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedExternalParamsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedExternalParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedExternalParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                             AliasPrim1 u32,
+                                                                             AliasPrim2 f32,
+                                                                             AliasBool b,
+                                                                             const Fw::StringBase& str2,
+                                                                             const AliasEnum& e,
+                                                                             const AliasArray& a,
+                                                                             const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedExternalParamsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedExternalParamsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedExternalParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str2,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3476,213 +2131,169 @@ F32 QueuedExternalParamsComponentBase ::
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedExternalParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  parameterUpdated(FwPrmIdType id)
-{
-  // Do nothing by default
+void QueuedExternalParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
+    // Do nothing by default
 }
 
-void QueuedExternalParamsComponentBase ::
-  parametersLoaded()
-{
-  // Do nothing by default
+void QueuedExternalParamsComponentBase ::parametersLoaded() {
+    // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-I32 QueuedExternalParamsComponentBase ::
-  paramGet_ParamI32Ext(Fw::ParamValid& valid)
-{
-  I32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamI32Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+I32 QueuedExternalParamsComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
+    I32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamI32Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-F64 QueuedExternalParamsComponentBase ::
-  paramGet_ParamF64Ext(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+F64 QueuedExternalParamsComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-Fw::ParamString QueuedExternalParamsComponentBase ::
-  paramGet_ParamStringExt(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStringExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+Fw::ParamString QueuedExternalParamsComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStringExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-E QueuedExternalParamsComponentBase ::
-  paramGet_ParamEnumExt(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnumExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+E QueuedExternalParamsComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnumExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-A QueuedExternalParamsComponentBase ::
-  paramGet_ParamArrayExt(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArrayExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+A QueuedExternalParamsComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArrayExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-S QueuedExternalParamsComponentBase ::
-  paramGet_ParamStructExt(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStructExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+S QueuedExternalParamsComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStructExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
-{
-  FW_ASSERT(paramExternalDelegatePtr != nullptr);
-  this->paramDelegatePtr = paramExternalDelegatePtr;
+void QueuedExternalParamsComponentBase ::registerExternalParameters(
+    Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
+    FW_ASSERT(paramExternalDelegatePtr != nullptr);
+    this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedExternalParamsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedExternalParamsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3692,892 +2303,528 @@ Fw::Time QueuedExternalParamsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedExternalParamsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedExternalParamsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedExternalParamsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDEXTERNALPARAMS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      break;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDEXTERNALPARAMS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedExternalParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                AliasPrim1 u32,
+                                                                AliasPrim2 f32,
+                                                                AliasBool b,
+                                                                const Fw::StringBase& str2,
+                                                                const AliasEnum& e,
+                                                                const AliasArray& a,
+                                                                const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedExternalParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                  FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedExternalParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedExternalParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedExternalParamsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedExternalParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedExternalParamsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedExternalParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedExternalParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                             FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedExternalParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedExternalParamsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedExternalParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                           FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedExternalParamsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedExternalParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                 FwIndexType portNum,
+                                                                                 AliasPrim1 u32,
+                                                                                 AliasPrim2 f32,
+                                                                                 AliasBool b,
+                                                                                 const Fw::StringBase& str2,
+                                                                                 const AliasEnum& e,
+                                                                                 const AliasArray& a,
+                                                                                 const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedExternalParamsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedExternalParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedExternalParamsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedExternalParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedExternalParamsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedExternalParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4586,112 +2833,51 @@ void QueuedExternalParamsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void QueuedExternalParamsComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                            FwOpcodeType opCode,
+                                                            U32 cmdSeq,
+                                                            const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-Fw::ParamValid QueuedExternalParamsComponentBase ::
-  prmGetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::ParamValid QueuedExternalParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                                 FwPrmIdType id,
+                                                                 Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_prmGetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void QueuedExternalParamsComponentBase ::
-  prmSetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::prmSetOut_out(FwIndexType portNum,
+                                                       FwPrmIdType id,
+                                                       Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmSetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_prmSetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void QueuedExternalParamsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedExternalParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4700,396 +2886,306 @@ void QueuedExternalParamsComponentBase ::
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMI32EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMI32EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMF64EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMF64EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRINGEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMENUMEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMENUMEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMARRAYEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRUCTEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    }
+    return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSave_ParamI32Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamI32Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSave_ParamF64Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamF64Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSave_ParamStringExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamStringExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSave_ParamEnumExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamEnumExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSave_ParamArrayExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamArrayExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::
-  paramSave_ParamStructExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamStructExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedExternalParamsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDEXTERNALPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedExternalParamsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void QueuedExternalParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStore
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedExternalParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedExternalParamsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,141 +967,213 @@ Fw::InputCmdPort* QueuedExternalParamsComponentBase ::get_cmdIn_InputPort(FwInde
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedExternalParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedExternalParamsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedExternalParamsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedExternalParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedExternalParamsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedExternalParamsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedExternalParamsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedExternalParamsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedExternalParamsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedExternalParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedExternalParamsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedExternalParamsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedExternalParamsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -756,63 +1184,120 @@ Ports::InputTypedPort* QueuedExternalParamsComponentBase ::get_typedSync_InputPo
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                       Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -823,67 +1308,116 @@ void QueuedExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portN
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                            Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -894,57 +1428,106 @@ void QueuedExternalParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexTy
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                       Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedExternalParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedExternalParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -955,25 +1538,46 @@ void QueuedExternalParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portN
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -982,192 +1586,298 @@ void QueuedExternalParamsComponentBase ::set_typedOut_OutputPort(FwIndexType por
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedExternalParamsComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+  );
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::loadParameters() {
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedExternalParamsComponentBase ::
+  loadParameters()
+{
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-    FwPrmIdType _id{};
-    Fw::ParamBuffer _paramBuffer;
+  FwPrmIdType _id{};
+  Fw::ParamBuffer _paramBuffer;
 
-    _id = _baseId + PARAMID_PARAMI32EXT;
+  _id = _baseId + PARAMID_PARAMI32EXT;
 
-    // Get serialized parameter ParamI32Ext
-    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamI32Ext
+  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMI32EXT,
+    this->m_param_ParamI32Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMF64EXT;
+
+  // Get serialized parameter ParamF64Ext
+  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMF64EXT,
+    this->m_param_ParamF64Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRINGEXT;
+
+  // Get serialized parameter ParamStringExt
+  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
     }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMF64EXT;
-
-    // Get serialized parameter ParamF64Ext
-    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+    Fw::String _val = Fw::String("external default");
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRINGEXT;
+  _id = _baseId + PARAMID_PARAMENUMEXT;
 
-    // Get serialized parameter ParamStringExt
-    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamEnumExt
+  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-        Fw::String _val = Fw::String("external default");
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMENUMEXT,
+    this->m_param_ParamEnumExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMENUMEXT;
+  _id = _baseId + PARAMID_PARAMARRAYEXT;
 
-    // Get serialized parameter ParamEnumExt
-    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamArrayExt
+  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
-                                                     _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
     }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMARRAYEXT;
-
-    // Get serialized parameter ParamArrayExt
-    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-        A _val = A({1, 2, 3});
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-    // Get serialized parameter ParamStructExt
-    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+    A _val = A({1, 2, 3});
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
-                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parametersLoaded();
+  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+  // Get serialized parameter ParamStructExt
+  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMSTRUCTEXT,
+    this->m_param_ParamStructExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  // Call notifier
+  this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedExternalParamsComponentBase ::QueuedExternalParamsComponentBase(const char* compName)
-    : Fw::QueuedComponentBase(compName) {}
+QueuedExternalParamsComponentBase ::
+  QueuedExternalParamsComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
 
-QueuedExternalParamsComponentBase ::~QueuedExternalParamsComponentBase() {}
+}
+
+QueuedExternalParamsComponentBase ::
+  ~QueuedExternalParamsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1175,62 +1885,96 @@ QueuedExternalParamsComponentBase ::~QueuedExternalParamsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedExternalParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedExternalParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedExternalParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1241,59 +1985,92 @@ bool QueuedExternalParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexTy
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedExternalParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedExternalParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedExternalParamsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1304,90 +2081,143 @@ bool QueuedExternalParamsComponentBase ::isConnected_typedReturnOut_OutputPort(F
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                           FwOpcodeType opCode,
-                                                           U32 cmdSeq,
-                                                           Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedExternalParamsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_PARAMI32EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_PARAMI32EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_PARAMI32EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
     }
+
+    case OPCODE_PARAMI32EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1396,561 +2226,941 @@ void QueuedExternalParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedExternalParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedExternalParamsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedExternalParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedExternalParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedExternalParamsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedExternalParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedExternalParamsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedExternalParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedExternalParamsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedExternalParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                                AliasPrim1 u32,
-                                                                                AliasPrim2 f32,
-                                                                                AliasBool b,
-                                                                                const Fw::StringBase& str2,
-                                                                                const AliasEnum& e,
-                                                                                const AliasArray& a,
-                                                                                const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedExternalParamsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedExternalParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                      AliasPrim1 u32,
-                                                                                      AliasPrim2 f32,
-                                                                                      AliasBool b,
-                                                                                      const Fw::StringBase& str2,
-                                                                                      const AliasEnum& e,
-                                                                                      const AliasArray& a,
-                                                                                      const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedExternalParamsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedExternalParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedExternalParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                             U32 u32,
-                                                                             F32 f32,
-                                                                             bool b,
-                                                                             const Fw::StringBase& str1,
-                                                                             const E& e,
-                                                                             const A& a,
-                                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedExternalParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedExternalParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedExternalParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedExternalParamsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedExternalParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedExternalParamsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedExternalParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1961,63 +3171,85 @@ void QueuedExternalParamsComponentBase ::typedSync_handlerBase(FwIndexType portN
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) {
-    // Default: no-op
+void QueuedExternalParamsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedExternalParamsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Default: no-op
+void QueuedExternalParamsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Default: no-op
+void QueuedExternalParamsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Default: no-op
+void QueuedExternalParamsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedExternalParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Default: no-op
+void QueuedExternalParamsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2026,103 +3258,209 @@ void QueuedExternalParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwInd
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedExternalParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedExternalParamsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedExternalParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedExternalParamsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedExternalParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                           AliasPrim1 u32,
-                                                           AliasPrim2 f32,
-                                                           AliasBool b,
-                                                           const Fw::StringBase& str2,
-                                                           const AliasEnum& e,
-                                                           const AliasArray& a,
-                                                           const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedExternalParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedExternalParamsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedExternalParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                             AliasPrim1 u32,
-                                                                             AliasPrim2 f32,
-                                                                             AliasBool b,
-                                                                             const Fw::StringBase& str2,
-                                                                             const AliasEnum& e,
-                                                                             const AliasArray& a,
-                                                                             const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedExternalParamsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedExternalParamsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedExternalParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str2,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedExternalParamsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2131,169 +3469,213 @@ F32 QueuedExternalParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedExternalParamsComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
-    // Do nothing by default
+void QueuedExternalParamsComponentBase ::
+  parameterUpdated(FwPrmIdType id)
+{
+  // Do nothing by default
 }
 
-void QueuedExternalParamsComponentBase ::parametersLoaded() {
-    // Do nothing by default
+void QueuedExternalParamsComponentBase ::
+  parametersLoaded()
+{
+  // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-I32 QueuedExternalParamsComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
-    I32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamI32Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+I32 QueuedExternalParamsComponentBase ::
+  paramGet_ParamI32Ext(Fw::ParamValid& valid)
+{
+  I32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamI32Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 QueuedExternalParamsComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+F64 QueuedExternalParamsComponentBase ::
+  paramGet_ParamF64Ext(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString QueuedExternalParamsComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStringExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+Fw::ParamString QueuedExternalParamsComponentBase ::
+  paramGet_ParamStringExt(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStringExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E QueuedExternalParamsComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnumExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+E QueuedExternalParamsComponentBase ::
+  paramGet_ParamEnumExt(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnumExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A QueuedExternalParamsComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArrayExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+A QueuedExternalParamsComponentBase ::
+  paramGet_ParamArrayExt(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArrayExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S QueuedExternalParamsComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStructExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+S QueuedExternalParamsComponentBase ::
+  paramGet_ParamStructExt(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStructExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::registerExternalParameters(
-    Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
-    FW_ASSERT(paramExternalDelegatePtr != nullptr);
-    this->paramDelegatePtr = paramExternalDelegatePtr;
+void QueuedExternalParamsComponentBase ::
+  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
+{
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
+  this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedExternalParamsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedExternalParamsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2303,528 +3685,892 @@ Fw::Time QueuedExternalParamsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedExternalParamsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedExternalParamsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedExternalParamsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDEXTERNALPARAMS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDEXTERNALPARAMS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedExternalParamsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                AliasPrim1 u32,
-                                                                AliasPrim2 f32,
-                                                                AliasBool b,
-                                                                const Fw::StringBase& str2,
-                                                                const AliasEnum& e,
-                                                                const AliasArray& a,
-                                                                const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedExternalParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                  FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedExternalParamsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedExternalParamsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedExternalParamsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedExternalParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedExternalParamsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedExternalParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedExternalParamsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedExternalParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                             FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedExternalParamsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedExternalParamsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedExternalParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedExternalParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                           FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedExternalParamsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedExternalParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                 FwIndexType portNum,
-                                                                                 AliasPrim1 u32,
-                                                                                 AliasPrim2 f32,
-                                                                                 AliasBool b,
-                                                                                 const Fw::StringBase& str2,
-                                                                                 const AliasEnum& e,
-                                                                                 const AliasArray& a,
-                                                                                 const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedExternalParamsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedExternalParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedExternalParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedExternalParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedExternalParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedExternalParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedExternalParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedExternalParamsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedExternalParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedExternalParamsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedExternalParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedExternalParamsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2833,51 +4579,112 @@ void QueuedExternalParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBa
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedExternalParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void QueuedExternalParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                            FwOpcodeType opCode,
-                                                            U32 cmdSeq,
-                                                            const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-Fw::ParamValid QueuedExternalParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                                 FwPrmIdType id,
-                                                                 Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::ParamValid QueuedExternalParamsComponentBase ::
+  prmGetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_prmGetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void QueuedExternalParamsComponentBase ::prmSetOut_out(FwIndexType portNum,
-                                                       FwPrmIdType id,
-                                                       Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  prmSetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmSetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_prmSetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void QueuedExternalParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedExternalParamsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2886,306 +4693,396 @@ void QueuedExternalParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw:
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMI32EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMI32EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMF64EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMF64EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRINGEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMENUMEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMENUMEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMARRAYEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRUCTEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
+  return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamI32Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSave_ParamI32Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamF64Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSave_ParamF64Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamStringExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSave_ParamStringExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamEnumExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSave_ParamEnumExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamArrayExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSave_ParamArrayExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedExternalParamsComponentBase ::paramSave_ParamStructExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedExternalParamsComponentBase ::
+  paramSave_ParamStructExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedGetProductsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDGETPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,768 +20,1190 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedGetProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+QueuedGetProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-QueuedGetProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const QueuedGetProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+QueuedGetProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const QueuedGetProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const QueuedGetProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const QueuedGetProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                 FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void QueuedGetProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts()); port++) {
-        this->m_productGetOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_productGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -790,10 +1212,15 @@ void QueuedGetProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreTyp
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedGetProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedGetProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -804,140 +1231,213 @@ Fw::InputCmdPort* QueuedGetProductsComponentBase ::get_cmdIn_InputPort(FwIndexTy
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedGetProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedGetProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedGetProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedGetProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedGetProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedGetProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedGetProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedGetProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -948,77 +1448,148 @@ Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedSync_InputPort(
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                    Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_productGetOut_OutputPort(FwIndexType portNum, Fw::InputDpGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_productGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_productGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1029,66 +1600,116 @@ void QueuedGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum,
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                     Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                           Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                   Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1099,62 +1720,120 @@ void QueuedGetProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType 
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1165,24 +1844,46 @@ void QueuedGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum,
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1191,10 +1892,18 @@ void QueuedGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNu
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedGetProductsComponentBase ::QueuedGetProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+QueuedGetProductsComponentBase ::
+  QueuedGetProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-QueuedGetProductsComponentBase ::~QueuedGetProductsComponentBase() {}
+}
+
+QueuedGetProductsComponentBase ::
+  ~QueuedGetProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1202,76 +1911,118 @@ QueuedGetProductsComponentBase ::~QueuedGetProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGetProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_productGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_productGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productGetOut_OutputPort[portNum].isConnected();
+  return this->m_productGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedGetProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedGetProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1282,59 +2033,92 @@ bool QueuedGetProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType 
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGetProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGetProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1345,19 +2129,24 @@ bool QueuedGetProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIn
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                        FwOpcodeType opCode,
-                                                        U32 cmdSeq,
-                                                        Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedGetProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1366,561 +2155,941 @@ void QueuedGetProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedGetProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGetProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGetProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGetProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedGetProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedGetProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedGetProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedGetProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedGetProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGetProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGetProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedGetProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedGetProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                             AliasPrim1 u32,
-                                                                             AliasPrim2 f32,
-                                                                             AliasBool b,
-                                                                             const Fw::StringBase& str2,
-                                                                             const AliasEnum& e,
-                                                                             const AliasArray& a,
-                                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedGetProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedGetProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                   AliasPrim1 u32,
-                                                                                   AliasPrim2 f32,
-                                                                                   AliasBool b,
-                                                                                   const Fw::StringBase& str2,
-                                                                                   const AliasEnum& e,
-                                                                                   const AliasArray& a,
-                                                                                   const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGetProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGetProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGetProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGetProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGetProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGetProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedGetProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedGetProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedGetProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedGetProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGetProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1931,63 +3100,85 @@ void QueuedGetProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    // Default: no-op
+void QueuedGetProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedGetProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Default: no-op
+void QueuedGetProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Default: no-op
+void QueuedGetProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    // Default: no-op
+void QueuedGetProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    // Default: no-op
+void QueuedGetProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1996,103 +3187,209 @@ void QueuedGetProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexT
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedGetProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedGetProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedGetProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGetProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedGetProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedGetProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                    AliasPrim1 u32,
-                                                                    AliasPrim2 f32,
-                                                                    AliasBool b,
-                                                                    const Fw::StringBase& str2,
-                                                                    const AliasEnum& e,
-                                                                    const AliasArray& a,
-                                                                    const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedGetProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedGetProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                          AliasPrim1 u32,
-                                                                          AliasPrim2 f32,
-                                                                          AliasBool b,
-                                                                          const Fw::StringBase& str2,
-                                                                          const AliasEnum& e,
-                                                                          const AliasArray& a,
-                                                                          const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGetProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGetProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedGetProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str2,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedGetProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2101,39 +3398,47 @@ F32 QueuedGetProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void QueuedGetProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedGetProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedGetProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2143,506 +3448,868 @@ Fw::Time QueuedGetProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedGetProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedGetProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedGetProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == QUEUEDGETPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == QUEUEDGETPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedGetProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedGetProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGetProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedGetProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedGetProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGetProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedGetProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGetProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedGetProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedGetProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGetProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedGetProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedGetProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedGetProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedGetProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                              FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedGetProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGetProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGetProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGetProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGetProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                    FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGetProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedGetProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedGetProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedGetProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedGetProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGetProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGetProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2651,33 +4318,70 @@ void QueuedGetProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase*
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-Fw::Success QueuedGetProductsComponentBase ::productGetOut_out(FwIndexType portNum,
-                                                               FwDpIdType id,
-                                                               FwSizeType dataSize,
-                                                               Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::Success QueuedGetProductsComponentBase ::
+  productGetOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize,
+      Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_productGetOut_OutputPort[portNum].invoke(id, dataSize, buffer);
+  FW_ASSERT(
+    this->m_productGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_productGetOut_OutputPort[portNum].invoke(
+    id,
+    dataSize,
+    buffer
+  );
 }
 
-void QueuedGetProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                         FwDpIdType id,
-                                                         const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void QueuedGetProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGetProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2686,20 +4390,24 @@ void QueuedGetProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Ti
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-Fw::Success::T QueuedGetProductsComponentBase ::dpGet(ContainerId::T containerId,
-                                                      FwSizeType dataSize,
-                                                      FwDpPriorityType priority,
-                                                      DpContainer& container) {
-    const FwDpIdType baseId = this->getIdBase();
-    const FwDpIdType globalId = baseId + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    Fw::Buffer buffer;
-    const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
-    if (status == Fw::Success::SUCCESS) {
-        // Assign a fresh DpContainer into container
-        // This action clears out all the container state
-        container = DpContainer(globalId, buffer, baseId);
-        container.setPriority(priority);
-    }
-    return status;
+Fw::Success::T QueuedGetProductsComponentBase ::
+  dpGet(
+      ContainerId::T containerId,
+      FwSizeType dataSize,
+      FwDpPriorityType priority,
+      DpContainer& container
+  )
+{
+  const FwDpIdType baseId = this->getIdBase();
+  const FwDpIdType globalId = baseId + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  Fw::Buffer buffer;
+  const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
+  if (status == Fw::Success::SUCCESS) {
+    // Assign a fresh DpContainer into container
+    // This action clears out all the container state
+    container = DpContainer(globalId, buffer, baseId);
+    container.setPriority(priority);
+  }
+  return status;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedGetProductsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDGETPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,1197 +20,768 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedGetProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+QueuedGetProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+QueuedGetProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-QueuedGetProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const QueuedGetProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const QueuedGetProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const QueuedGetProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const QueuedGetProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                 FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void QueuedGetProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_productGetOut_OutputPort[port].init();
+    // Connect output port productGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productGetOut_OutputPorts()); port++) {
+        this->m_productGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1219,15 +790,10 @@ void QueuedGetProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedGetProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedGetProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -1238,213 +804,140 @@ Fw::InputCmdPort* QueuedGetProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedGetProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedGetProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedGetProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedGetProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedGetProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedGetProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedGetProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedGetProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedGetProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedGetProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedGetProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedGetProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGetProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGetProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1455,148 +948,77 @@ Ports::InputTypedPort* QueuedGetProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                    Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_productGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_productGetOut_OutputPort(FwIndexType portNum, Fw::InputDpGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_productGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGetProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedGetProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1607,116 +1029,66 @@ void QueuedGetProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                     Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                           Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                   Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1727,120 +1099,62 @@ void QueuedGetProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGetProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedGetProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1851,46 +1165,24 @@ void QueuedGetProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGetProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1899,18 +1191,10 @@ void QueuedGetProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedGetProductsComponentBase ::
-  QueuedGetProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+QueuedGetProductsComponentBase ::QueuedGetProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-QueuedGetProductsComponentBase ::
-  ~QueuedGetProductsComponentBase()
-{
-
-}
+QueuedGetProductsComponentBase ::~QueuedGetProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1918,118 +1202,76 @@ QueuedGetProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_productGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_productGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productGetOut_OutputPort[portNum].isConnected();
+    return this->m_productGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2040,92 +1282,59 @@ bool QueuedGetProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGetProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGetProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2136,24 +1345,19 @@ bool QueuedGetProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedGetProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                        FwOpcodeType opCode,
+                                                        U32 cmdSeq,
+                                                        Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -2162,941 +1366,561 @@ void QueuedGetProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGetProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGetProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGetProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedGetProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedGetProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedGetProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedGetProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGetProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGetProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedGetProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedGetProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                             AliasPrim1 u32,
+                                                                             AliasPrim2 f32,
+                                                                             AliasBool b,
+                                                                             const Fw::StringBase& str2,
+                                                                             const AliasEnum& e,
+                                                                             const AliasArray& a,
+                                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGetProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                   AliasPrim1 u32,
+                                                                                   AliasPrim2 f32,
+                                                                                   AliasBool b,
+                                                                                   const Fw::StringBase& str2,
+                                                                                   const AliasEnum& e,
+                                                                                   const AliasArray& a,
+                                                                                   const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGetProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedGetProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedGetProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedGetProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedGetProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGetProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3107,85 +1931,63 @@ void QueuedGetProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedGetProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedGetProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGetProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGetProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGetProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    // Default: no-op
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGetProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3194,209 +1996,103 @@ void QueuedGetProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedGetProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedGetProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGetProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedGetProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedGetProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedGetProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                    AliasPrim1 u32,
+                                                                    AliasPrim2 f32,
+                                                                    AliasBool b,
+                                                                    const Fw::StringBase& str2,
+                                                                    const AliasEnum& e,
+                                                                    const AliasArray& a,
+                                                                    const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGetProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                          AliasPrim1 u32,
+                                                                          AliasPrim2 f32,
+                                                                          AliasBool b,
+                                                                          const Fw::StringBase& str2,
+                                                                          const AliasEnum& e,
+                                                                          const AliasArray& a,
+                                                                          const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedGetProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedGetProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedGetProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str2,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3405,47 +2101,39 @@ F32 QueuedGetProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void QueuedGetProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedGetProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedGetProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3455,868 +2143,506 @@ Fw::Time QueuedGetProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedGetProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedGetProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedGetProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == QUEUEDGETPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == QUEUEDGETPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedGetProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedGetProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGetProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedGetProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedGetProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGetProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedGetProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGetProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedGetProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGetProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedGetProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedGetProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedGetProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedGetProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedGetProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                              FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                    FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedGetProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedGetProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedGetProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedGetProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedGetProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGetProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4325,70 +2651,33 @@ void QueuedGetProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-Fw::Success QueuedGetProductsComponentBase ::
-  productGetOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize,
-      Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::Success QueuedGetProductsComponentBase ::productGetOut_out(FwIndexType portNum,
+                                                               FwDpIdType id,
+                                                               FwSizeType dataSize,
+                                                               Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_productGetOut_OutputPort[portNum].invoke(
-    id,
-    dataSize,
-    buffer
-  );
+    FW_ASSERT(this->m_productGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_productGetOut_OutputPort[portNum].invoke(id, dataSize, buffer);
 }
 
-void QueuedGetProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                         FwDpIdType id,
+                                                         const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void QueuedGetProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGetProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4397,24 +2686,20 @@ void QueuedGetProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-Fw::Success::T QueuedGetProductsComponentBase ::
-  dpGet(
-      ContainerId::T containerId,
-      FwSizeType dataSize,
-      FwDpPriorityType priority,
-      DpContainer& container
-  )
-{
-  const FwDpIdType baseId = this->getIdBase();
-  const FwDpIdType globalId = baseId + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  Fw::Buffer buffer;
-  const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
-  if (status == Fw::Success::SUCCESS) {
-    // Assign a fresh DpContainer into container
-    // This action clears out all the container state
-    container = DpContainer(globalId, buffer, baseId);
-    container.setPriority(priority);
-  }
-  return status;
+Fw::Success::T QueuedGetProductsComponentBase ::dpGet(ContainerId::T containerId,
+                                                      FwSizeType dataSize,
+                                                      FwDpPriorityType priority,
+                                                      DpContainer& container) {
+    const FwDpIdType baseId = this->getIdBase();
+    const FwDpIdType globalId = baseId + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    Fw::Buffer buffer;
+    const Fw::Success::T status = this->productGetOut_out(0, globalId, size, buffer);
+    if (status == Fw::Success::SUCCESS) {
+        // Assign a fresh DpContainer into container
+        // This action clears out all the container state
+        container = DpContainer(globalId, buffer, baseId);
+        container.setPriority(priority);
+    }
+    return status;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedGuardedProductsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDGUARDEDPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,785 +20,1216 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedGuardedProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id,
-                                                              const Fw::Buffer& buffer,
-                                                              FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+QueuedGuardedProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-QueuedGuardedProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const QueuedGuardedProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+QueuedGuardedProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const QueuedGuardedProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const QueuedGuardedProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const QueuedGuardedProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                     FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void QueuedGuardedProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -807,17 +1238,26 @@ void QueuedGuardedProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStor
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedGuardedProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedGuardedProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedGuardedProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* QueuedGuardedProductsComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -828,142 +1268,213 @@ Fw::InputDpResponsePort* QueuedGuardedProductsComponentBase ::get_productRecvIn_
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedGuardedProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedGuardedProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedGuardedProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedGuardedProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedGuardedProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedGuardedProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::get_typedReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -974,79 +1485,148 @@ Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedSync_InputP
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                           Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1057,67 +1637,116 @@ void QueuedGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType port
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                             Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1128,73 +1757,134 @@ void QueuedGuardedProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexT
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                           Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
-                                                                      Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1205,25 +1895,46 @@ void QueuedGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType port
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                       Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1232,10 +1943,18 @@ void QueuedGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType po
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedGuardedProductsComponentBase ::QueuedGuardedProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+QueuedGuardedProductsComponentBase ::
+  QueuedGuardedProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-QueuedGuardedProductsComponentBase ::~QueuedGuardedProductsComponentBase() {}
+}
+
+QueuedGuardedProductsComponentBase ::
+  ~QueuedGuardedProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1243,76 +1962,118 @@ QueuedGuardedProductsComponentBase ::~QueuedGuardedProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGuardedProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedGuardedProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedGuardedProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1323,59 +2084,92 @@ bool QueuedGuardedProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexT
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGuardedProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedGuardedProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1386,37 +2180,53 @@ bool QueuedGuardedProductsComponentBase ::isConnected_typedReturnOut_OutputPort(
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                            FwOpcodeType opCode,
-                                                            U32 cmdSeq,
-                                                            Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedGuardedProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void QueuedGuardedProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                    FwDpIdType id,
-                                                                    const Fw::Buffer& buffer,
-                                                                    const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->productRecvIn_handler(portNum, id, buffer, status);
+  // Call handler function
+  this->productRecvIn_handler(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
 // ----------------------------------------------------------------------
@@ -1425,561 +2235,941 @@ void QueuedGuardedProductsComponentBase ::productRecvIn_handlerBase(FwIndexType 
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGuardedProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedGuardedProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedGuardedProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedGuardedProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedGuardedProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGuardedProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedGuardedProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                                 AliasPrim1 u32,
-                                                                                 AliasPrim2 f32,
-                                                                                 AliasBool b,
-                                                                                 const Fw::StringBase& str2,
-                                                                                 const AliasEnum& e,
-                                                                                 const AliasArray& a,
-                                                                                 const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedGuardedProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                       AliasPrim1 u32,
-                                                                                       AliasPrim2 f32,
-                                                                                       AliasBool b,
-                                                                                       const Fw::StringBase& str2,
-                                                                                       const AliasEnum& e,
-                                                                                       const AliasArray& a,
-                                                                                       const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGuardedProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                              U32 u32,
-                                                                              F32 f32,
-                                                                              bool b,
-                                                                              const Fw::StringBase& str1,
-                                                                              const E& e,
-                                                                              const A& a,
-                                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                             U32 u32,
-                                                                             F32 f32,
-                                                                             bool b,
-                                                                             const Fw::StringBase& str1,
-                                                                             const E& e,
-                                                                             const A& a,
-                                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedGuardedProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedGuardedProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedGuardedProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedGuardedProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1990,63 +3180,85 @@ void QueuedGuardedProductsComponentBase ::typedSync_handlerBase(FwIndexType port
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    // Default: no-op
+void QueuedGuardedProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedGuardedProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Default: no-op
+void QueuedGuardedProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Default: no-op
+void QueuedGuardedProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                             U32 u32,
-                                                                             F32 f32,
-                                                                             bool b,
-                                                                             const Fw::StringBase& str1,
-                                                                             const E& e,
-                                                                             const A& a,
-                                                                             const S& s) {
-    // Default: no-op
+void QueuedGuardedProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                            U32 u32,
-                                                                            F32 f32,
-                                                                            bool b,
-                                                                            const Fw::StringBase& str1,
-                                                                            const E& e,
-                                                                            const A& a,
-                                                                            const S& s) {
-    // Default: no-op
+void QueuedGuardedProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2055,103 +3267,209 @@ void QueuedGuardedProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIn
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedGuardedProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedGuardedProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGuardedProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedGuardedProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedGuardedProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedGuardedProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedGuardedProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedGuardedProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedGuardedProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2160,39 +3478,47 @@ F32 QueuedGuardedProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void QueuedGuardedProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedGuardedProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedGuardedProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2202,518 +3528,887 @@ Fw::Time QueuedGuardedProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedGuardedProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedGuardedProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedGuardedProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == QUEUEDGUARDEDPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == QUEUEDGUARDEDPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       FwOpcodeType opCode,
-                                                       U32 cmdSeq,
-                                                       Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedGuardedProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               FwDpIdType id,
-                                                               const Fw::Buffer& buffer,
-                                                               const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void QueuedGuardedProductsComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                   FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGuardedProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedGuardedProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedGuardedProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGuardedProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                    FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedGuardedProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGuardedProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedGuardedProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                              FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGuardedProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedGuardedProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedGuardedProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedGuardedProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                  FwIndexType portNum,
-                                                                                  AliasPrim1 u32,
-                                                                                  AliasPrim2 f32,
-                                                                                  AliasBool b,
-                                                                                  const Fw::StringBase& str2,
-                                                                                  const AliasEnum& e,
-                                                                                  const AliasArray& a,
-                                                                                  const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedGuardedProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedGuardedProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedGuardedProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedGuardedProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str2,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedGuardedProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedGuardedProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2722,32 +4417,68 @@ void QueuedGuardedProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentB
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
-                                                                FwDpIdType id,
-                                                                FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  productRequestOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+  FW_ASSERT(
+    this->m_productRequestOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productRequestOut_OutputPort[portNum].invoke(
+    id,
+    dataSize
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void QueuedGuardedProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedGuardedProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2756,58 +4487,71 @@ void QueuedGuardedProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
-    const FwDpIdType globalId = this->getIdBase() + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    this->productRequestOut_out(0, globalId, size);
+void QueuedGuardedProductsComponentBase ::
+  dpRequest(
+      ContainerId::T containerId,
+      FwSizeType dataSize
+  )
+{
+  const FwDpIdType globalId = this->getIdBase() + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedGuardedProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                                FwDpIdType id,
-                                                                const Fw::Buffer& buffer,
-                                                                const Fw::Success& status) {
-    DpContainer container;
-    if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
-    }
-    // Convert global id to local id
-    const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
-    const FwDpIdType localId = id - idBase;
-    // Switch on the local id
-    switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
-    }
+void QueuedGuardedProductsComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  DpContainer container;
+  if (status == Fw::Success::SUCCESS) {
+    container = DpContainer(id, buffer, this->getIdBase());
+  }
+  // Convert global id to local id
+  const FwDpIdType idBase = this->getIdBase();
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
+  const FwDpIdType localId = id - idBase;
+  // Switch on the local id
+  switch (localId) {
+    case ContainerId::Container1:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container1);
+      // Call the handler
+      this->dpRecv_Container1_handler(container, status.e);
+      break;
+    case ContainerId::Container2:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container2);
+      // Call the handler
+      this->dpRecv_Container2_handler(container, status.e);
+      break;
+    case ContainerId::Container3:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container3);
+      // Call the handler
+      this->dpRecv_Container3_handler(container, status.e);
+      break;
+    case ContainerId::Container4:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container4);
+      // Call the handler
+      this->dpRecv_Container4_handler(container, status.e);
+      break;
+    case ContainerId::Container5:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container5);
+      // Call the handler
+      this->dpRecv_Container5_handler(container, status.e);
+      break;
+    default:
+      FW_ASSERT(0);
+      break;
+  }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedGuardedProductsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDGUARDEDPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,1223 +20,785 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedGuardedProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+QueuedGuardedProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id,
+                                                              const Fw::Buffer& buffer,
+                                                              FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+QueuedGuardedProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-QueuedGuardedProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const QueuedGuardedProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const QueuedGuardedProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const QueuedGuardedProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const QueuedGuardedProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                     FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void QueuedGuardedProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1245,26 +807,17 @@ void QueuedGuardedProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedGuardedProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedGuardedProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedGuardedProductsComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* QueuedGuardedProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -1275,213 +828,142 @@ Fw::InputDpResponsePort* QueuedGuardedProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedGuardedProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedGuardedProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedGuardedProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedGuardedProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedGuardedProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedGuardedProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedGuardedProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedGuardedProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedGuardedProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::get_typedReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedGuardedProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1492,148 +974,79 @@ Ports::InputTypedPort* QueuedGuardedProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                           Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGuardedProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedGuardedProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1644,116 +1057,67 @@ void QueuedGuardedProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                             Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1764,134 +1128,73 @@ void QueuedGuardedProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                           Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedGuardedProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum,
+                                                                      Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedGuardedProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1902,46 +1205,25 @@ void QueuedGuardedProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                       Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1950,18 +1232,10 @@ void QueuedGuardedProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedGuardedProductsComponentBase ::
-  QueuedGuardedProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+QueuedGuardedProductsComponentBase ::QueuedGuardedProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-QueuedGuardedProductsComponentBase ::
-  ~QueuedGuardedProductsComponentBase()
-{
-
-}
+QueuedGuardedProductsComponentBase ::~QueuedGuardedProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1969,118 +1243,76 @@ QueuedGuardedProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2091,92 +1323,59 @@ bool QueuedGuardedProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedGuardedProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedGuardedProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2187,53 +1386,37 @@ bool QueuedGuardedProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedGuardedProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                            FwOpcodeType opCode,
+                                                            U32 cmdSeq,
+                                                            Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
-void QueuedGuardedProductsComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                    FwDpIdType id,
+                                                                    const Fw::Buffer& buffer,
+                                                                    const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->productRecvIn_handler(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+    // Call handler function
+    this->productRecvIn_handler(portNum, id, buffer, status);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
 // ----------------------------------------------------------------------
@@ -2242,941 +1425,561 @@ void QueuedGuardedProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGuardedProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGuardedProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedGuardedProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedGuardedProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedGuardedProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedGuardedProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGuardedProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedGuardedProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedGuardedProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                                 AliasPrim1 u32,
+                                                                                 AliasPrim2 f32,
+                                                                                 AliasBool b,
+                                                                                 const Fw::StringBase& str2,
+                                                                                 const AliasEnum& e,
+                                                                                 const AliasArray& a,
+                                                                                 const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGuardedProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                       AliasPrim1 u32,
+                                                                                       AliasPrim2 f32,
+                                                                                       AliasBool b,
+                                                                                       const Fw::StringBase& str2,
+                                                                                       const AliasEnum& e,
+                                                                                       const AliasArray& a,
+                                                                                       const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                              U32 u32,
+                                                                              F32 f32,
+                                                                              bool b,
+                                                                              const Fw::StringBase& str1,
+                                                                              const E& e,
+                                                                              const A& a,
+                                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                             U32 u32,
+                                                                             F32 f32,
+                                                                             bool b,
+                                                                             const Fw::StringBase& str1,
+                                                                             const E& e,
+                                                                             const A& a,
+                                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedGuardedProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedGuardedProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedGuardedProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedGuardedProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3187,85 +1990,63 @@ void QueuedGuardedProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedGuardedProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedGuardedProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGuardedProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGuardedProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGuardedProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                             U32 u32,
+                                                                             F32 f32,
+                                                                             bool b,
+                                                                             const Fw::StringBase& str1,
+                                                                             const E& e,
+                                                                             const A& a,
+                                                                             const S& s) {
+    // Default: no-op
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedGuardedProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                            U32 u32,
+                                                                            F32 f32,
+                                                                            bool b,
+                                                                            const Fw::StringBase& str1,
+                                                                            const E& e,
+                                                                            const A& a,
+                                                                            const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3274,209 +2055,103 @@ void QueuedGuardedProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedGuardedProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedGuardedProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGuardedProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedGuardedProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedGuardedProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedGuardedProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedGuardedProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedGuardedProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3485,47 +2160,39 @@ F32 QueuedGuardedProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void QueuedGuardedProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedGuardedProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedGuardedProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3535,887 +2202,518 @@ Fw::Time QueuedGuardedProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedGuardedProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedGuardedProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedGuardedProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == QUEUEDGUARDEDPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == QUEUEDGUARDEDPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedGuardedProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       FwOpcodeType opCode,
+                                                       U32 cmdSeq,
+                                                       Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void QueuedGuardedProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               FwDpIdType id,
+                                                               const Fw::Buffer& buffer,
+                                                               const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGuardedProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                   FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedGuardedProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedGuardedProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGuardedProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedGuardedProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                    FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedGuardedProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedGuardedProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedGuardedProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                              FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedGuardedProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedGuardedProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedGuardedProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedGuardedProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedGuardedProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                  FwIndexType portNum,
+                                                                                  AliasPrim1 u32,
+                                                                                  AliasPrim2 f32,
+                                                                                  AliasBool b,
+                                                                                  const Fw::StringBase& str2,
+                                                                                  const AliasEnum& e,
+                                                                                  const AliasArray& a,
+                                                                                  const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedGuardedProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedGuardedProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedGuardedProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedGuardedProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str2,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedGuardedProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4424,68 +2722,32 @@ void QueuedGuardedProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  productRequestOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
+                                                                FwDpIdType id,
+                                                                FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productRequestOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productRequestOut_OutputPort[portNum].invoke(
-    id,
-    dataSize
-  );
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedGuardedProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4494,71 +2756,58 @@ void QueuedGuardedProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedGuardedProductsComponentBase ::
-  dpRequest(
-      ContainerId::T containerId,
-      FwSizeType dataSize
-  )
-{
-  const FwDpIdType globalId = this->getIdBase() + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  this->productRequestOut_out(0, globalId, size);
+void QueuedGuardedProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+    const FwDpIdType globalId = this->getIdBase() + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedGuardedProductsComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  DpContainer container;
-  if (status == Fw::Success::SUCCESS) {
-    container = DpContainer(id, buffer, this->getIdBase());
-  }
-  // Convert global id to local id
-  const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(
-    id >= idBase,
-    static_cast<FwAssertArgType>(id),
-    static_cast<FwAssertArgType>(idBase)
-  );
-  const FwDpIdType localId = id - idBase;
-  // Switch on the local id
-  switch (localId) {
-    case ContainerId::Container1:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container1);
-      // Call the handler
-      this->dpRecv_Container1_handler(container, status.e);
-      break;
-    case ContainerId::Container2:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container2);
-      // Call the handler
-      this->dpRecv_Container2_handler(container, status.e);
-      break;
-    case ContainerId::Container3:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container3);
-      // Call the handler
-      this->dpRecv_Container3_handler(container, status.e);
-      break;
-    case ContainerId::Container4:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container4);
-      // Call the handler
-      this->dpRecv_Container4_handler(container, status.e);
-      break;
-    case ContainerId::Container5:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container5);
-      // Call the handler
-      this->dpRecv_Container5_handler(container, status.e);
-      break;
-    default:
-      FW_ASSERT(0);
-      break;
-  }
+void QueuedGuardedProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                                FwDpIdType id,
+                                                                const Fw::Buffer& buffer,
+                                                                const Fw::Success& status) {
+    DpContainer container;
+    if (status == Fw::Success::SUCCESS) {
+        container = DpContainer(id, buffer, this->getIdBase());
+    }
+    // Convert global id to local id
+    const FwDpIdType idBase = this->getIdBase();
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    const FwDpIdType localId = id - idBase;
+    // Switch on the local id
+    switch (localId) {
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
+    }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -12,215 +12,133 @@
 #include "QueuedNoArgsPortsOnlyComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDNOARGSPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     NOARGSASYNC_NOARGS,
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = 0,
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedNoArgsPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -229,48 +147,33 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsReturnGuarded_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
 #endif
@@ -281,32 +184,19 @@ Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -317,18 +207,11 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -337,18 +220,10 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedNoArgsPortsOnlyComponentBase ::
-  QueuedNoArgsPortsOnlyComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
+QueuedNoArgsPortsOnlyComponentBase ::QueuedNoArgsPortsOnlyComponentBase(const char* compName)
+    : Fw::QueuedComponentBase(compName) {}
 
-}
-
-QueuedNoArgsPortsOnlyComponentBase ::
-  ~QueuedNoArgsPortsOnlyComponentBase()
-{
-
-}
+QueuedNoArgsPortsOnlyComponentBase ::~QueuedNoArgsPortsOnlyComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -356,26 +231,18 @@ QueuedNoArgsPortsOnlyComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedNoArgsPortsOnlyComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedNoArgsPortsOnlyComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedNoArgsPortsOnlyComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedNoArgsPortsOnlyComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -386,103 +253,76 @@ bool QueuedNoArgsPortsOnlyComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedNoArgsPortsOnlyComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedNoArgsPortsOnlyComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
 // ----------------------------------------------------------------------
@@ -493,10 +333,8 @@ U32 QueuedNoArgsPortsOnlyComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedNoArgsPortsOnlyComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -505,34 +343,20 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedNoArgsPortsOnlyComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
 #endif
@@ -544,145 +368,106 @@ U32 QueuedNoArgsPortsOnlyComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedNoArgsPortsOnlyComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedNoArgsPortsOnlyComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDNOARGSPORTSONLY_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  return MSG_DISPATCH_OK;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDNOARGSPORTSONLY_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
+    }
+
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    switch (_msgType) {
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
+    }
+
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                    FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -34,9 +34,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -12,133 +12,208 @@
 #include "QueuedNoArgsPortsOnlyComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDNOARGSPORTSONLY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     NOARGSASYNC_NOARGS,
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = 0,
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedNoArgsPortsOnlyComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -147,33 +222,48 @@ void QueuedNoArgsPortsOnlyComponentBase ::init(FwSizeType queueDepth, FwEnumStor
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedNoArgsPortsOnlyComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsReturnGuarded_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
 #endif
@@ -184,19 +274,32 @@ Ports::InputNoArgsReturnPort* QueuedNoArgsPortsOnlyComponentBase ::get_noArgsRet
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedNoArgsPortsOnlyComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedNoArgsPortsOnlyComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -207,11 +310,18 @@ void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsReturnOut_OutputPort(FwIndex
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedNoArgsPortsOnlyComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -220,10 +330,18 @@ void QueuedNoArgsPortsOnlyComponentBase ::set_noArgsOut_OutputPort(FwIndexType p
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedNoArgsPortsOnlyComponentBase ::QueuedNoArgsPortsOnlyComponentBase(const char* compName)
-    : Fw::QueuedComponentBase(compName) {}
+QueuedNoArgsPortsOnlyComponentBase ::
+  QueuedNoArgsPortsOnlyComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
 
-QueuedNoArgsPortsOnlyComponentBase ::~QueuedNoArgsPortsOnlyComponentBase() {}
+}
+
+QueuedNoArgsPortsOnlyComponentBase ::
+  ~QueuedNoArgsPortsOnlyComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -231,18 +349,26 @@ QueuedNoArgsPortsOnlyComponentBase ::~QueuedNoArgsPortsOnlyComponentBase() {}
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedNoArgsPortsOnlyComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedNoArgsPortsOnlyComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedNoArgsPortsOnlyComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedNoArgsPortsOnlyComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -253,76 +379,103 @@ bool QueuedNoArgsPortsOnlyComponentBase ::isConnected_noArgsReturnOut_OutputPort
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedNoArgsPortsOnlyComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedNoArgsPortsOnlyComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedNoArgsPortsOnlyComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedNoArgsPortsOnlyComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
 // ----------------------------------------------------------------------
@@ -333,8 +486,10 @@ U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnSync_handlerBase(FwIndexTyp
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedNoArgsPortsOnlyComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -343,20 +498,34 @@ void QueuedNoArgsPortsOnlyComponentBase ::noArgsAsync_preMsgHook(FwIndexType por
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedNoArgsPortsOnlyComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedNoArgsPortsOnlyComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
 #endif
@@ -368,106 +537,145 @@ U32 QueuedNoArgsPortsOnlyComponentBase ::noArgsReturnOut_out(FwIndexType portNum
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedNoArgsPortsOnlyComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedNoArgsPortsOnlyComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDNOARGSPORTSONLY_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDNOARGSPORTSONLY_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
-    }
-
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    switch (_msgType) {
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
-    }
-
-    return MSG_DISPATCH_OK;
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                    FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedNoArgsPortsOnlyComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedNoArgsPortsOnlyComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedOverflowComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDOVERFLOW_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVINHOOK_DPRESPONSE,
     ASSERTASYNC_TYPED,
@@ -23,268 +23,426 @@ enum MsgTypeEnum {
     CMD_CMD_HOOK,
     CMD_CMD_PARAMS_PRIORITY_HOOK,
     INT_IF_INTERNALHOOKDROP,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE productRecvInHookPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE assertAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE blockAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE dropAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE hookAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedOverflowComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwSizeType msgSize,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvInHook
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts()); port++) {
-        this->m_productRecvInHook_InputPort[port].init();
-        this->m_productRecvInHook_InputPort[port].addCallComp(this, m_p_productRecvInHook_in);
-        this->m_productRecvInHook_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port assertAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts()); port++) {
-        this->m_assertAsync_InputPort[port].init();
-        this->m_assertAsync_InputPort[port].addCallComp(this, m_p_assertAsync_in);
-        this->m_assertAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_assertAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port blockAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts()); port++) {
-        this->m_blockAsync_InputPort[port].init();
-        this->m_blockAsync_InputPort[port].addCallComp(this, m_p_blockAsync_in);
-        this->m_blockAsync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvInHook
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts());
+    port++
+  ) {
+    this->m_productRecvInHook_InputPort[port].init();
+    this->m_productRecvInHook_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvInHook_in
+    );
+    this->m_productRecvInHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_blockAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port dropAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts()); port++) {
-        this->m_dropAsync_InputPort[port].init();
-        this->m_dropAsync_InputPort[port].addCallComp(this, m_p_dropAsync_in);
-        this->m_dropAsync_InputPort[port].setPortNum(port);
+  // Connect input port assertAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts());
+    port++
+  ) {
+    this->m_assertAsync_InputPort[port].init();
+    this->m_assertAsync_InputPort[port].addCallComp(
+      this,
+      m_p_assertAsync_in
+    );
+    this->m_assertAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_dropAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_assertAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port hookAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts()); port++) {
-        this->m_hookAsync_InputPort[port].init();
-        this->m_hookAsync_InputPort[port].addCallComp(this, m_p_hookAsync_in);
-        this->m_hookAsync_InputPort[port].setPortNum(port);
+  // Connect input port blockAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts());
+    port++
+  ) {
+    this->m_blockAsync_InputPort[port].init();
+    this->m_blockAsync_InputPort[port].addCallComp(
+      this,
+      m_p_blockAsync_in
+    );
+    this->m_blockAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_hookAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_blockAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncHook
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts()); port++) {
-        this->m_serialAsyncHook_InputPort[port].init();
-        this->m_serialAsyncHook_InputPort[port].addCallComp(this, m_p_serialAsyncHook_in);
-        this->m_serialAsyncHook_InputPort[port].setPortNum(port);
+  // Connect input port dropAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts());
+    port++
+  ) {
+    this->m_dropAsync_InputPort[port].init();
+    this->m_dropAsync_InputPort[port].addCallComp(
+      this,
+      m_p_dropAsync_in
+    );
+    this->m_dropAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_dropAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port hookAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts());
+    port++
+  ) {
+    this->m_hookAsync_InputPort[port].init();
+    this->m_hookAsync_InputPort[port].addCallComp(
+      this,
+      m_p_hookAsync_in
+    );
+    this->m_hookAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_hookAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port serialAsyncHook
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncHook_InputPort[port].init();
+    this->m_serialAsyncHook_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncHook_in
+    );
+    this->m_serialAsyncHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Passed-in size added to port number and message type enumeration sizes.
-    this->m_msgSize = FW_MAX(
-        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+  // Passed-in size added to port number and message type enumeration sizes.
+  this->m_msgSize = FW_MAX(
+    msgSize +
+    static_cast<FwSizeType>(sizeof(FwIndexType)) +
+    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
 
-    // Create the queue
-    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -293,17 +451,26 @@ void QueuedOverflowComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSiz
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedOverflowComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedOverflowComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedOverflowComponentBase ::get_productRecvInHook_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* QueuedOverflowComponentBase ::
+  get_productRecvInHook_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvInHook_InputPort[portNum];
+  return &this->m_productRecvInHook_InputPort[portNum];
 }
 
 #endif
@@ -314,30 +481,48 @@ Fw::InputDpResponsePort* QueuedOverflowComponentBase ::get_productRecvInHook_Inp
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::get_assertAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedOverflowComponentBase ::
+  get_assertAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_assertAsync_InputPort[portNum];
+  return &this->m_assertAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::get_blockAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedOverflowComponentBase ::
+  get_blockAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_blockAsync_InputPort[portNum];
+  return &this->m_blockAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::get_dropAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedOverflowComponentBase ::
+  get_dropAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_dropAsync_InputPort[portNum];
+  return &this->m_dropAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::get_hookAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedOverflowComponentBase ::
+  get_hookAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_hookAsync_InputPort[portNum];
+  return &this->m_hookAsync_InputPort[portNum];
 }
 
 #endif
@@ -348,11 +533,15 @@ Ports::InputTypedPort* QueuedOverflowComponentBase ::get_hookAsync_InputPort(FwI
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* QueuedOverflowComponentBase ::get_serialAsyncHook_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* QueuedOverflowComponentBase ::
+  get_serialAsyncHook_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncHook_InputPort[portNum];
+  return &this->m_serialAsyncHook_InputPort[portNum];
 }
 
 #endif
@@ -363,62 +552,120 @@ Fw::InputSerializePort* QueuedOverflowComponentBase ::get_serialAsyncHook_InputP
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -429,55 +676,106 @@ void QueuedOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -486,21 +784,38 @@ void QueuedOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedOverflowComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_HOOK);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_HOOK
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK
+  );
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedOverflowComponentBase ::QueuedOverflowComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
+QueuedOverflowComponentBase ::
+  QueuedOverflowComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
 
-QueuedOverflowComponentBase ::~QueuedOverflowComponentBase() {}
+}
+
+QueuedOverflowComponentBase ::
+  ~QueuedOverflowComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -508,62 +823,96 @@ QueuedOverflowComponentBase ::~QueuedOverflowComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedOverflowComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedOverflowComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedOverflowComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedOverflowComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -574,73 +923,117 @@ bool QueuedOverflowComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType por
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                     FwOpcodeType opCode,
-                                                     U32 cmdSeq,
-                                                     Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedOverflowComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_CMD_HOOK: {
-            this->CMD_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
-            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_CMD_HOOK: {
+      this->CMD_HOOK_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
     }
+
+    case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
+      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void QueuedOverflowComponentBase ::productRecvInHook_handlerBase(FwIndexType portNum,
-                                                                 FwDpIdType id,
-                                                                 const Fw::Buffer& buffer,
-                                                                 const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  productRecvInHook_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    productRecvInHook_preMsgHook(portNum, id, buffer, status);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  productRecvInHook_preMsgHook(
+    portNum,
+    id,
+    buffer,
+    status
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument id
-    _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument id
+  _status = msg.serializeFrom(id);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msg.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument status
-    _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument status
+  _status = msg.serializeFrom(status);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->productRecvInHook_overflowHook(portNum, id, buffer, status);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->productRecvInHook_overflowHook(portNum, id, buffer, status);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -649,252 +1042,442 @@ void QueuedOverflowComponentBase ::productRecvInHook_handlerBase(FwIndexType por
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::assertAsync_handlerBase(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  assertAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    assertAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  assertAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedOverflowComponentBase ::blockAsync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  blockAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    blockAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  blockAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedOverflowComponentBase ::dropAsync_handlerBase(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  dropAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    dropAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  dropAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(DROPASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(DROPASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedOverflowComponentBase ::hookAsync_handlerBase(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  hookAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    hookAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  hookAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(HOOKASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(HOOKASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -903,38 +1486,62 @@ void QueuedOverflowComponentBase ::hookAsync_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::serialAsyncHook_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  serialAsyncHook_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncHook
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncHook
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->serialAsyncHook_overflowHook(portNum, buffer);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->serialAsyncHook_overflowHook(portNum, buffer);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -945,11 +1552,15 @@ void QueuedOverflowComponentBase ::serialAsyncHook_handlerBase(FwIndexType portN
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::productRecvInHook_preMsgHook(FwIndexType portNum,
-                                                                FwDpIdType id,
-                                                                const Fw::Buffer& buffer,
-                                                                const Fw::Success& status) {
-    // Default: no-op
+void QueuedOverflowComponentBase ::
+  productRecvInHook_preMsgHook(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -960,48 +1571,64 @@ void QueuedOverflowComponentBase ::productRecvInHook_preMsgHook(FwIndexType port
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::assertAsync_preMsgHook(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Default: no-op
+void QueuedOverflowComponentBase ::
+  assertAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedOverflowComponentBase ::blockAsync_preMsgHook(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    // Default: no-op
+void QueuedOverflowComponentBase ::
+  blockAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedOverflowComponentBase ::dropAsync_preMsgHook(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Default: no-op
+void QueuedOverflowComponentBase ::
+  dropAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedOverflowComponentBase ::hookAsync_preMsgHook(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Default: no-op
+void QueuedOverflowComponentBase ::
+  hookAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1012,8 +1639,13 @@ void QueuedOverflowComponentBase ::hookAsync_preMsgHook(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::serialAsyncHook_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void QueuedOverflowComponentBase ::
+  serialAsyncHook_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1028,37 +1660,54 @@ void QueuedOverflowComponentBase ::serialAsyncHook_preMsgHook(FwIndexType portNu
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::internalHookDrop_internalInterfaceInvoke() {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedOverflowComponentBase ::
+  internalHookDrop_internalInterfaceInvoke()
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->internalHookDrop_overflowHook();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->internalHookDrop_overflowHook();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedOverflowComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -1067,86 +1716,132 @@ void QueuedOverflowComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdS
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::CMD_HOOK_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_HOOK_preMsgHook(opCode, cmdSeq);
+void QueuedOverflowComponentBase ::
+  CMD_HOOK_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_HOOK_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(FwOpcodeType opCode,
-                                                                           U32 cmdSeq,
-                                                                           Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode, cmdSeq);
+void QueuedOverflowComponentBase ::
+  CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1157,481 +1852,749 @@ void QueuedOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(FwOpc
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::CMD_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedOverflowComponentBase ::
+  CMD_HOOK_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedOverflowComponentBase ::
+  CMD_PARAMS_PRIORITY_HOOK_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedOverflowComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedOverflowComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::doDispatch() {
-    U8 _msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
+  doDispatch()
+{
+  U8 _msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer _msg(
+    _msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDOVERFLOW_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port productRecvInHook
+    case PRODUCTRECVINHOOK_DPRESPONSE: {
+      // Deserialize argument id
+      FwDpIdType id;
+      _deserStatus = _msg.deserializeTo(id);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument buffer
+      Fw::Buffer buffer;
+      _deserStatus = _msg.deserializeTo(buffer);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument status
+      Fw::Success status;
+      _deserStatus = _msg.deserializeTo(status);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->productRecvInHook_handler(
+        portNum,
+        id,
+        buffer,
+        status
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port assertAsync
+    case ASSERTASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    if (_msgType == QUEUEDOVERFLOW_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->assertAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port blockAsync
+    case BLOCKASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port productRecvInHook
-        case PRODUCTRECVINHOOK_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvInHook_handler(portNum, id, buffer, status);
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            break;
-        }
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-        // Handle async input port assertAsync
-        case ASSERTASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->blockAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      break;
+    }
 
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port dropAsync
+    case DROPASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->assertAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            break;
-        }
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-        // Handle async input port blockAsync
-        case BLOCKASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->dropAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      break;
+    }
 
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port hookAsync
+    case HOOKASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->blockAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            break;
-        }
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-        // Handle async input port dropAsync
-        case DROPASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->hookAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      break;
+    }
 
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port serialAsyncHook
+    case SERIALASYNCHOOK_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncHook_handler(portNum, serHandBuff);
 
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      break;
+    }
 
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle command CMD_HOOK
+    case CMD_CMD_HOOK: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->dropAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            break;
-        }
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-        // Handle async input port hookAsync
-        case HOOKASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Reset buffer
+      args.resetDeser();
 
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->hookAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncHook
-        case SERIALASYNCHOOK_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncHook_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle command CMD_HOOK
-        case CMD_CMD_HOOK: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
 #endif
 
-            // Call handler function
-            this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
+      // Call handler function
+      this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
 
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY_HOOK
-        case CMD_CMD_PARAMS_PRIORITY_HOOK: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle internal interface internalHookDrop
-        case INT_IF_INTERNALHOOKDROP: {
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalHookDrop_internalInterfaceHandler();
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle command CMD_PARAMS_PRIORITY_HOOK
+    case CMD_CMD_PARAMS_PRIORITY_HOOK: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalHookDrop
+    case INT_IF_INTERNALHOOKDROP: {
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalHookDrop_internalInterfaceHandler();
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                FwIndexType portNum,
-                                                FwOpcodeType opCode,
-                                                U32 cmdSeq,
-                                                Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedOverflowComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void QueuedOverflowComponentBase ::m_p_productRecvInHook_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            FwDpIdType id,
-                                                            const Fw::Buffer& buffer,
-                                                            const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-    compPtr->productRecvInHook_handlerBase(portNum, id, buffer, status);
+void QueuedOverflowComponentBase ::
+  m_p_productRecvInHook_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+  compPtr->productRecvInHook_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::m_p_assertAsync_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) {
-    FW_ASSERT(callComp);
-    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-    compPtr->assertAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedOverflowComponentBase ::
+  m_p_assertAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+  compPtr->assertAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedOverflowComponentBase ::m_p_blockAsync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-    compPtr->blockAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedOverflowComponentBase ::
+  m_p_blockAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+  compPtr->blockAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedOverflowComponentBase ::m_p_dropAsync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) {
-    FW_ASSERT(callComp);
-    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-    compPtr->dropAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedOverflowComponentBase ::
+  m_p_dropAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+  compPtr->dropAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedOverflowComponentBase ::m_p_hookAsync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) {
-    FW_ASSERT(callComp);
-    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-    compPtr->hookAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedOverflowComponentBase ::
+  m_p_hookAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+  compPtr->hookAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1640,12 +2603,19 @@ void QueuedOverflowComponentBase ::m_p_hookAsync_in(Fw::PassiveComponentBase* ca
 
 #if FW_PORT_SERIALIZATION
 
-void QueuedOverflowComponentBase ::m_p_serialAsyncHook_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-    compPtr->serialAsyncHook_handlerBase(portNum, buffer);
+void QueuedOverflowComponentBase ::
+  m_p_serialAsyncHook_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+  compPtr->serialAsyncHook_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
 #endif
@@ -1656,31 +2626,68 @@ void QueuedOverflowComponentBase ::m_p_serialAsyncHook_in(Fw::PassiveComponentBa
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void QueuedOverflowComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-void QueuedOverflowComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedOverflowComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -1689,13 +2696,17 @@ void QueuedOverflowComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time&
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::productRecvInHook_handler(const FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer,
-                                                             const Fw::Success& status) {
-    (void)portNum;
-    (void)id;
-    (void)buffer;
-    (void)status;
-    // No data products defined
+void QueuedOverflowComponentBase ::
+  productRecvInHook_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  (void) portNum;
+  (void) id;
+  (void) buffer;
+  (void) status;
+  // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedOverflowComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDOVERFLOW_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVINHOOK_DPRESPONSE,
     ASSERTASYNC_TYPED,
@@ -23,433 +23,268 @@ namespace {
     CMD_CMD_HOOK,
     CMD_CMD_PARAMS_PRIORITY_HOOK,
     INT_IF_INTERNALHOOKDROP,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE productRecvInHookPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE assertAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE blockAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE dropAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE hookAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwSizeType msgSize,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedOverflowComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvInHook
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts());
-    port++
-  ) {
-    this->m_productRecvInHook_InputPort[port].init();
-    this->m_productRecvInHook_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvInHook_in
-    );
-    this->m_productRecvInHook_InputPort[port].setPortNum(port);
+    // Connect input port productRecvInHook
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvInHook_InputPorts()); port++) {
+        this->m_productRecvInHook_InputPort[port].init();
+        this->m_productRecvInHook_InputPort[port].addCallComp(this, m_p_productRecvInHook_in);
+        this->m_productRecvInHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvInHook_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port assertAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts());
-    port++
-  ) {
-    this->m_assertAsync_InputPort[port].init();
-    this->m_assertAsync_InputPort[port].addCallComp(
-      this,
-      m_p_assertAsync_in
-    );
-    this->m_assertAsync_InputPort[port].setPortNum(port);
+    // Connect input port assertAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_assertAsync_InputPorts()); port++) {
+        this->m_assertAsync_InputPort[port].init();
+        this->m_assertAsync_InputPort[port].addCallComp(this, m_p_assertAsync_in);
+        this->m_assertAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_assertAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_assertAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_assertAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port blockAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts());
-    port++
-  ) {
-    this->m_blockAsync_InputPort[port].init();
-    this->m_blockAsync_InputPort[port].addCallComp(
-      this,
-      m_p_blockAsync_in
-    );
-    this->m_blockAsync_InputPort[port].setPortNum(port);
+    // Connect input port blockAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_blockAsync_InputPorts()); port++) {
+        this->m_blockAsync_InputPort[port].init();
+        this->m_blockAsync_InputPort[port].addCallComp(this, m_p_blockAsync_in);
+        this->m_blockAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_blockAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_blockAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_blockAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port dropAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts());
-    port++
-  ) {
-    this->m_dropAsync_InputPort[port].init();
-    this->m_dropAsync_InputPort[port].addCallComp(
-      this,
-      m_p_dropAsync_in
-    );
-    this->m_dropAsync_InputPort[port].setPortNum(port);
+    // Connect input port dropAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_dropAsync_InputPorts()); port++) {
+        this->m_dropAsync_InputPort[port].init();
+        this->m_dropAsync_InputPort[port].addCallComp(this, m_p_dropAsync_in);
+        this->m_dropAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_dropAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_dropAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_dropAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port hookAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts());
-    port++
-  ) {
-    this->m_hookAsync_InputPort[port].init();
-    this->m_hookAsync_InputPort[port].addCallComp(
-      this,
-      m_p_hookAsync_in
-    );
-    this->m_hookAsync_InputPort[port].setPortNum(port);
+    // Connect input port hookAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_hookAsync_InputPorts()); port++) {
+        this->m_hookAsync_InputPort[port].init();
+        this->m_hookAsync_InputPort[port].addCallComp(this, m_p_hookAsync_in);
+        this->m_hookAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_hookAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_hookAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_hookAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncHook
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncHook_InputPort[port].init();
-    this->m_serialAsyncHook_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncHook_in
-    );
-    this->m_serialAsyncHook_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncHook
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncHook_InputPorts()); port++) {
+        this->m_serialAsyncHook_InputPort[port].init();
+        this->m_serialAsyncHook_InputPort[port].addCallComp(this, m_p_serialAsyncHook_in);
+        this->m_serialAsyncHook_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncHook_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Passed-in size added to port number and message type enumeration sizes.
-  this->m_msgSize = FW_MAX(
-    msgSize +
-    static_cast<FwSizeType>(sizeof(FwIndexType)) +
-    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
+    // Passed-in size added to port number and message type enumeration sizes.
+    this->m_msgSize = FW_MAX(
+        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -458,26 +293,17 @@ void QueuedOverflowComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedOverflowComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedOverflowComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedOverflowComponentBase ::
-  get_productRecvInHook_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* QueuedOverflowComponentBase ::get_productRecvInHook_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvInHook_InputPort[portNum];
+    return &this->m_productRecvInHook_InputPort[portNum];
 }
 
 #endif
@@ -488,48 +314,30 @@ Fw::InputDpResponsePort* QueuedOverflowComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::
-  get_assertAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedOverflowComponentBase ::get_assertAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_assertAsync_InputPort[portNum];
+    return &this->m_assertAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::
-  get_blockAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedOverflowComponentBase ::get_blockAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_blockAsync_InputPort[portNum];
+    return &this->m_blockAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::
-  get_dropAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedOverflowComponentBase ::get_dropAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_dropAsync_InputPort[portNum];
+    return &this->m_dropAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedOverflowComponentBase ::
-  get_hookAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedOverflowComponentBase ::get_hookAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_hookAsync_InputPort[portNum];
+    return &this->m_hookAsync_InputPort[portNum];
 }
 
 #endif
@@ -540,15 +348,11 @@ Ports::InputTypedPort* QueuedOverflowComponentBase ::
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* QueuedOverflowComponentBase ::
-  get_serialAsyncHook_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* QueuedOverflowComponentBase ::get_serialAsyncHook_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncHook_InputPort[portNum];
+    return &this->m_serialAsyncHook_InputPort[portNum];
 }
 
 #endif
@@ -559,120 +363,62 @@ Fw::InputSerializePort* QueuedOverflowComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedOverflowComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedOverflowComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -683,106 +429,55 @@ void QueuedOverflowComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedOverflowComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedOverflowComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedOverflowComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -791,38 +486,21 @@ void QueuedOverflowComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedOverflowComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_HOOK
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_HOOK);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK);
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedOverflowComponentBase ::
-  QueuedOverflowComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
+QueuedOverflowComponentBase ::QueuedOverflowComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
 
-}
-
-QueuedOverflowComponentBase ::
-  ~QueuedOverflowComponentBase()
-{
-
-}
+QueuedOverflowComponentBase ::~QueuedOverflowComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -830,96 +508,62 @@ QueuedOverflowComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedOverflowComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedOverflowComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedOverflowComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedOverflowComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedOverflowComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -930,117 +574,73 @@ bool QueuedOverflowComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedOverflowComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                     FwOpcodeType opCode,
+                                                     U32 cmdSeq,
+                                                     Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_CMD_HOOK: {
+            this->CMD_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_CMD_HOOK: {
-      this->CMD_HOOK_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
+        case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
+            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_CMD_PARAMS_PRIORITY_HOOK: {
-      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
-void QueuedOverflowComponentBase ::
-  productRecvInHook_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::productRecvInHook_handlerBase(FwIndexType portNum,
+                                                                 FwDpIdType id,
+                                                                 const Fw::Buffer& buffer,
+                                                                 const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvInHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  productRecvInHook_preMsgHook(
-    portNum,
-    id,
-    buffer,
-    status
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    productRecvInHook_preMsgHook(portNum, id, buffer, status);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument id
-  _status = msg.serializeFrom(id);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument id
+    _status = msg.serializeFrom(id);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msg.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msg.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument status
-  _status = msg.serializeFrom(status);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument status
+    _status = msg.serializeFrom(status);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->productRecvInHook_overflowHook(portNum, id, buffer, status);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->productRecvInHook_overflowHook(portNum, id, buffer, status);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1049,442 +649,252 @@ void QueuedOverflowComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  assertAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::assertAsync_handlerBase(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_assertAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  assertAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    assertAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedOverflowComponentBase ::
-  blockAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::blockAsync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_blockAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  blockAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    blockAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedOverflowComponentBase ::
-  dropAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::dropAsync_handlerBase(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_dropAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  dropAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    dropAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(DROPASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(DROPASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedOverflowComponentBase ::
-  hookAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::hookAsync_handlerBase(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_hookAsync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  hookAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    hookAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(HOOKASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(HOOKASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->hookAsync_overflowHook(portNum, u32, f32, b, str1, e, a, s);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1493,62 +903,38 @@ void QueuedOverflowComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  serialAsyncHook_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::serialAsyncHook_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncHook_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncHook
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncHook
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->serialAsyncHook_overflowHook(portNum, buffer);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->serialAsyncHook_overflowHook(portNum, buffer);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1559,15 +945,11 @@ void QueuedOverflowComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  productRecvInHook_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
+void QueuedOverflowComponentBase ::productRecvInHook_preMsgHook(FwIndexType portNum,
+                                                                FwDpIdType id,
+                                                                const Fw::Buffer& buffer,
+                                                                const Fw::Success& status) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1578,64 +960,48 @@ void QueuedOverflowComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  assertAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedOverflowComponentBase ::assertAsync_preMsgHook(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Default: no-op
 }
 
-void QueuedOverflowComponentBase ::
-  blockAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedOverflowComponentBase ::blockAsync_preMsgHook(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    // Default: no-op
 }
 
-void QueuedOverflowComponentBase ::
-  dropAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedOverflowComponentBase ::dropAsync_preMsgHook(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Default: no-op
 }
 
-void QueuedOverflowComponentBase ::
-  hookAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedOverflowComponentBase ::hookAsync_preMsgHook(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1646,13 +1012,8 @@ void QueuedOverflowComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  serialAsyncHook_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void QueuedOverflowComponentBase ::serialAsyncHook_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -1667,54 +1028,37 @@ void QueuedOverflowComponentBase ::
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  internalHookDrop_internalInterfaceInvoke()
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedOverflowComponentBase ::internalHookDrop_internalInterfaceInvoke() {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->internalHookDrop_overflowHook();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->internalHookDrop_overflowHook();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedOverflowComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -1723,132 +1067,86 @@ void QueuedOverflowComponentBase ::
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  CMD_HOOK_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_HOOK_preMsgHook(opCode,cmdSeq);
+void QueuedOverflowComponentBase ::CMD_HOOK_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_HOOK_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedOverflowComponentBase ::
-  CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode,cmdSeq);
+void QueuedOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_cmdHandlerBase(FwOpcodeType opCode,
+                                                                           U32 cmdSeq,
+                                                                           Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_HOOK_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -1859,749 +1157,481 @@ void QueuedOverflowComponentBase ::
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  CMD_HOOK_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedOverflowComponentBase ::CMD_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedOverflowComponentBase ::
-  CMD_PARAMS_PRIORITY_HOOK_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedOverflowComponentBase ::CMD_PARAMS_PRIORITY_HOOK_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedOverflowComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedOverflowComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
-  doDispatch()
-{
-  U8 _msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer _msg(
-    _msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::doDispatch() {
+    U8 _msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDOVERFLOW_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port productRecvInHook
-    case PRODUCTRECVINHOOK_DPRESPONSE: {
-      // Deserialize argument id
-      FwDpIdType id;
-      _deserStatus = _msg.deserializeTo(id);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument buffer
-      Fw::Buffer buffer;
-      _deserStatus = _msg.deserializeTo(buffer);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument status
-      Fw::Success status;
-      _deserStatus = _msg.deserializeTo(status);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->productRecvInHook_handler(
-        portNum,
-        id,
-        buffer,
-        status
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port assertAsync
-    case ASSERTASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->assertAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == QUEUEDOVERFLOW_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port blockAsync
-    case BLOCKASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port productRecvInHook
+        case PRODUCTRECVINHOOK_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvInHook_handler(portNum, id, buffer, status);
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->blockAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port dropAsync
-    case DROPASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->dropAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port hookAsync
-    case HOOKASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->hookAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port serialAsyncHook
-    case SERIALASYNCHOOK_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncHook_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle command CMD_HOOK
-    case CMD_CMD_HOOK: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle async input port assertAsync
+        case ASSERTASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->assertAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port blockAsync
+        case BLOCKASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->blockAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port dropAsync
+        case DROPASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->dropAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port hookAsync
+        case HOOKASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->hookAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncHook
+        case SERIALASYNCHOOK_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncHook_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle command CMD_HOOK
+        case CMD_CMD_HOOK: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_HOOK_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY_HOOK
-    case CMD_CMD_PARAMS_PRIORITY_HOOK: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_HOOK
+        case CMD_CMD_PARAMS_PRIORITY_HOOK: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_HOOK_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
+            break;
+        }
+
+        // Handle internal interface internalHookDrop
+        case INT_IF_INTERNALHOOKDROP: {
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalHookDrop_internalInterfaceHandler();
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle internal interface internalHookDrop
-    case INT_IF_INTERNALHOOKDROP: {
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalHookDrop_internalInterfaceHandler();
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedOverflowComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                FwIndexType portNum,
+                                                FwOpcodeType opCode,
+                                                U32 cmdSeq,
+                                                Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void QueuedOverflowComponentBase ::
-  m_p_productRecvInHook_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-  compPtr->productRecvInHook_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void QueuedOverflowComponentBase ::m_p_productRecvInHook_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            FwDpIdType id,
+                                                            const Fw::Buffer& buffer,
+                                                            const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+    compPtr->productRecvInHook_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  m_p_assertAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-  compPtr->assertAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedOverflowComponentBase ::m_p_assertAsync_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) {
+    FW_ASSERT(callComp);
+    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+    compPtr->assertAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedOverflowComponentBase ::
-  m_p_blockAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-  compPtr->blockAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedOverflowComponentBase ::m_p_blockAsync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+    compPtr->blockAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedOverflowComponentBase ::
-  m_p_dropAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-  compPtr->dropAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedOverflowComponentBase ::m_p_dropAsync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) {
+    FW_ASSERT(callComp);
+    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+    compPtr->dropAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedOverflowComponentBase ::
-  m_p_hookAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-  compPtr->hookAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedOverflowComponentBase ::m_p_hookAsync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) {
+    FW_ASSERT(callComp);
+    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+    compPtr->hookAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -2610,19 +1640,12 @@ void QueuedOverflowComponentBase ::
 
 #if FW_PORT_SERIALIZATION
 
-void QueuedOverflowComponentBase ::
-  m_p_serialAsyncHook_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
-  compPtr->serialAsyncHook_handlerBase(
-    portNum,
-    buffer
-  );
+void QueuedOverflowComponentBase ::m_p_serialAsyncHook_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
+    compPtr->serialAsyncHook_handlerBase(portNum, buffer);
 }
 
 #endif
@@ -2633,68 +1656,31 @@ void QueuedOverflowComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void QueuedOverflowComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-void QueuedOverflowComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedOverflowComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -2703,17 +1689,13 @@ void QueuedOverflowComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedOverflowComponentBase ::
-  productRecvInHook_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  (void) portNum;
-  (void) id;
-  (void) buffer;
-  (void) status;
-  // No data products defined
+void QueuedOverflowComponentBase ::productRecvInHook_handler(const FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer,
+                                                             const Fw::Success& status) {
+    (void)portNum;
+    (void)id;
+    (void)buffer;
+    (void)status;
+    // No data products defined
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -53,9 +53,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedParamsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedParamsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void QueuedParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType ins
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedParamsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,139 +967,213 @@ Fw::InputCmdPort* QueuedParamsComponentBase ::get_cmdIn_InputPort(FwIndexType po
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedParamsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedParamsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedParamsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedParamsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedParamsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedParamsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedParamsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedParamsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedParamsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedParamsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedParamsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedParamsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedParamsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -754,62 +1184,120 @@ Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedSync_InputPort(FwInd
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -820,64 +1308,116 @@ void QueuedParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -888,55 +1428,106 @@ void QueuedParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portN
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -947,24 +1538,46 @@ void QueuedParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -973,169 +1586,244 @@ void QueuedParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedParamsComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+  );
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::loadParameters() {
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedParamsComponentBase ::
+  loadParameters()
+{
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-    FwPrmIdType _id{};
-    Fw::ParamBuffer _paramBuffer;
+  FwPrmIdType _id{};
+  Fw::ParamBuffer _paramBuffer;
 
-    _id = _baseId + PARAMID_PARAMU32;
+  _id = _baseId + PARAMID_PARAMU32;
 
-    // Get serialized parameter ParamU32
-    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamU32
+  this->m_param_ParamU32_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
-        }
+  // Deserialize parameter
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMF64;
+  _id = _baseId + PARAMID_PARAMF64;
 
-    // Get serialized parameter ParamF64
-    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamF64
+  this->m_param_ParamF64_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
-        }
+  // Deserialize parameter
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRING;
+  _id = _baseId + PARAMID_PARAMSTRING;
 
-    // Get serialized parameter ParamString
-    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamString
+  this->m_param_ParamString_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
-    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamString = Fw::String("default");
+  }
+  else {
+    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamString = Fw::String("default");
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMENUM;
+
+  // Get serialized parameter ParamEnum
+  this->m_param_ParamEnum_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMENUM;
+  _id = _baseId + PARAMID_PARAMARRAY;
 
-    // Get serialized parameter ParamEnum
-    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamArray
+  this->m_param_ParamArray_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
-        }
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
+  }
+  else {
+    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamArray = A({1, 2, 3});
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMARRAY;
+  _id = _baseId + PARAMID_PARAMSTRUCT;
 
-    // Get serialized parameter ParamArray
-    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamStruct
+  this->m_param_ParamStruct_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+  // Deserialize parameter
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamArray = A({1, 2, 3});
-    }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRUCT;
-
-    // Get serialized parameter ParamStruct
-    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    // Call notifier
-    this->parametersLoaded();
+  // Call notifier
+  this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedParamsComponentBase ::QueuedParamsComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
+QueuedParamsComponentBase ::
+  QueuedParamsComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
 
-QueuedParamsComponentBase ::~QueuedParamsComponentBase() {}
+}
+
+QueuedParamsComponentBase ::
+  ~QueuedParamsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1143,62 +1831,96 @@ QueuedParamsComponentBase ::~QueuedParamsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1209,59 +1931,92 @@ bool QueuedParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portN
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedParamsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1272,90 +2027,143 @@ bool QueuedParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexTy
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedParamsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_PARAMU32_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_PARAMU32_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamString();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_PARAMU32_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
     }
+
+    case OPCODE_PARAMU32_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamString();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1364,561 +2172,941 @@ void QueuedParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedParamsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedParamsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedParamsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedParamsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedParamsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedParamsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedParamsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedParamsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1929,63 +3117,85 @@ void QueuedParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    // Default: no-op
+void QueuedParamsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedParamsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Default: no-op
+void QueuedParamsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void QueuedParamsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void QueuedParamsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void QueuedParamsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1994,103 +3204,209 @@ void QueuedParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType p
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedParamsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedParamsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                   AliasPrim1 u32,
-                                                   AliasPrim2 f32,
-                                                   AliasBool b,
-                                                   const Fw::StringBase& str2,
-                                                   const AliasEnum& e,
-                                                   const AliasArray& a,
-                                                   const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedParamsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedParamsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedParamsComponentBase ::typedOut_out(FwIndexType portNum,
-                                              U32 u32,
-                                              F32 f32,
-                                              bool b,
-                                              const Fw::StringBase& str1,
-                                              const E& e,
-                                              const A& a,
-                                              const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str2,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedParamsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2099,105 +3415,130 @@ F32 QueuedParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedParamsComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
-    // Do nothing by default
+void QueuedParamsComponentBase ::
+  parameterUpdated(FwPrmIdType id)
+{
+  // Do nothing by default
 }
 
-void QueuedParamsComponentBase ::parametersLoaded() {
-    // Do nothing by default
+void QueuedParamsComponentBase ::
+  parametersLoaded()
+{
+  // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 QueuedParamsComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
-    U32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamU32_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamU32;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+U32 QueuedParamsComponentBase ::
+  paramGet_ParamU32(Fw::ParamValid& valid)
+{
+  U32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamU32_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamU32;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 QueuedParamsComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamF64;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+F64 QueuedParamsComponentBase ::
+  paramGet_ParamF64(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamF64;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString QueuedParamsComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamString_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamString;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+Fw::ParamString QueuedParamsComponentBase ::
+  paramGet_ParamString(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamString_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamString;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E QueuedParamsComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnum_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamEnum;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+E QueuedParamsComponentBase ::
+  paramGet_ParamEnum(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnum_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamEnum;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A QueuedParamsComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArray_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamArray;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+A QueuedParamsComponentBase ::
+  paramGet_ParamArray(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArray_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamArray;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S QueuedParamsComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStruct_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamStruct;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+S QueuedParamsComponentBase ::
+  paramGet_ParamStruct(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStruct_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamStruct;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedParamsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedParamsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2207,526 +3548,892 @@ Fw::Time QueuedParamsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedParamsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedParamsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedParamsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDPARAMS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDPARAMS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                              FwIndexType portNum,
-                                              FwOpcodeType opCode,
-                                              U32 cmdSeq,
-                                              Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedParamsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedParamsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedParamsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedParamsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedParamsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedParamsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedParamsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedParamsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedParamsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedParamsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedParamsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str2,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedParamsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                  FwIndexType portNum,
-                                                  U32 u32,
-                                                  F32 f32,
-                                                  bool b,
-                                                  const Fw::StringBase& str1,
-                                                  const E& e,
-                                                  const A& a,
-                                                  const S& s) {
-    FW_ASSERT(callComp);
-    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedParamsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2735,49 +4442,112 @@ void QueuedParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* call
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void QueuedParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                    FwOpcodeType opCode,
-                                                    U32 cmdSeq,
-                                                    const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-Fw::ParamValid QueuedParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                         FwPrmIdType id,
-                                                         Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::ParamValid QueuedParamsComponentBase ::
+  prmGetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_prmGetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void QueuedParamsComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  prmSetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmSetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_prmSetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void QueuedParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedParamsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2786,252 +4556,294 @@ void QueuedParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& t
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
-    U32 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSet_ParamU32(Fw::SerialBufferBase& val)
+{
+  U32 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamU32 = _localVal;
-    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamU32 = _localVal;
+  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMU32);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMU32);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
-    F64 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSet_ParamF64(Fw::SerialBufferBase& val)
+{
+  F64 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamF64 = _localVal;
-    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamF64 = _localVal;
+  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMF64);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMF64);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
-    Fw::ParamString _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSet_ParamString(Fw::SerialBufferBase& val)
+{
+  Fw::ParamString _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamString = _localVal;
-    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamString = _localVal;
+  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
-    E _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSet_ParamEnum(Fw::SerialBufferBase& val)
+{
+  E _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamEnum = _localVal;
-    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamEnum = _localVal;
+  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMENUM);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
-    A _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSet_ParamArray(Fw::SerialBufferBase& val)
+{
+  A _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamArray = _localVal;
-    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamArray = _localVal;
+  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
-    S _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSet_ParamStruct(Fw::SerialBufferBase& val)
+{
+  S _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamStruct = _localVal;
-    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamStruct = _localVal;
+  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  return Fw::CmdResponse::OK;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamU32() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamU32);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSave_ParamU32()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamU32);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamF64() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamF64);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSave_ParamF64()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamF64);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamString() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamString);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSave_ParamString()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamString);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamEnum() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSave_ParamEnum()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamArray() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamArray);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSave_ParamArray()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamArray);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamStruct() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::
+  paramSave_ParamStruct()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedParamsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDPARAMS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedParamsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void QueuedParamsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedParamsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedParamsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,139 @@ Fw::InputCmdPort* QueuedParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedParamsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedParamsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedParamsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedParamsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedParamsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedParamsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedParamsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedParamsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedParamsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedParamsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedParamsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedParamsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedParamsComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedParamsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedParamsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedParamsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedParamsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +754,62 @@ Ports::InputTypedPort* QueuedParamsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +820,64 @@ void QueuedParamsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +888,55 @@ void QueuedParamsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedParamsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedParamsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +947,24 @@ void QueuedParamsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedParamsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,244 +973,169 @@ void QueuedParamsComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedParamsComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  loadParameters()
-{
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedParamsComponentBase ::loadParameters() {
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-  FwPrmIdType _id{};
-  Fw::ParamBuffer _paramBuffer;
+    FwPrmIdType _id{};
+    Fw::ParamBuffer _paramBuffer;
 
-  _id = _baseId + PARAMID_PARAMU32;
+    _id = _baseId + PARAMID_PARAMU32;
 
-  // Get serialized parameter ParamU32
-  this->m_param_ParamU32_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamU32
+    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64;
+    _id = _baseId + PARAMID_PARAMF64;
 
-  // Get serialized parameter ParamF64
-  this->m_param_ParamF64_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamF64
+    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRING;
+    _id = _baseId + PARAMID_PARAMSTRING;
 
-  // Get serialized parameter ParamString
-  this->m_param_ParamString_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamString
+    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
-  }
-  else {
-    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamString = Fw::String("default");
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMENUM;
-
-  // Get serialized parameter ParamEnum
-  this->m_param_ParamEnum_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamString = Fw::String("default");
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAY;
+    _id = _baseId + PARAMID_PARAMENUM;
 
-  // Get serialized parameter ParamArray
-  this->m_param_ParamArray_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnum
+    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter
+    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  else {
-    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamArray = A({1, 2, 3});
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCT;
+    _id = _baseId + PARAMID_PARAMARRAY;
 
-  // Get serialized parameter ParamStruct
-  this->m_param_ParamStruct_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamArray
+    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
-  }
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamArray = A({1, 2, 3});
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parametersLoaded();
+    _id = _baseId + PARAMID_PARAMSTRUCT;
+
+    // Get serialized parameter ParamStruct
+    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
+    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+        }
+    }
+
+    this->m_paramLock.unlock();
+
+    // Call notifier
+    this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedParamsComponentBase ::
-  QueuedParamsComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
+QueuedParamsComponentBase ::QueuedParamsComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
 
-}
-
-QueuedParamsComponentBase ::
-  ~QueuedParamsComponentBase()
-{
-
-}
+QueuedParamsComponentBase ::~QueuedParamsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1838,96 +1143,62 @@ QueuedParamsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedParamsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedParamsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedParamsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1938,92 +1209,59 @@ bool QueuedParamsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedParamsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedParamsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedParamsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2034,143 +1272,90 @@ bool QueuedParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedParamsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_PARAMU32_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_PARAMU32_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
+        case OPCODE_PARAMU32_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamString();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_PARAMU32_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamString();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -2179,941 +1364,561 @@ void QueuedParamsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedParamsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedParamsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedParamsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedParamsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedParamsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedParamsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedParamsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedParamsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedParamsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedParamsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedParamsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedParamsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedParamsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedParamsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedParamsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedParamsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedParamsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedParamsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedParamsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedParamsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedParamsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedParamsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedParamsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedParamsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedParamsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedParamsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3124,85 +1929,63 @@ void QueuedParamsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedParamsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedParamsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedParamsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedParamsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedParamsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Default: no-op
 }
 
-void QueuedParamsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedParamsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void QueuedParamsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedParamsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void QueuedParamsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedParamsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3211,209 +1994,103 @@ void QueuedParamsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedParamsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedParamsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedParamsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedParamsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedParamsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                   AliasPrim1 u32,
+                                                   AliasPrim2 f32,
+                                                   AliasBool b,
+                                                   const Fw::StringBase& str2,
+                                                   const AliasEnum& e,
+                                                   const AliasArray& a,
+                                                   const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedParamsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedParamsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedParamsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedParamsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedParamsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::typedOut_out(FwIndexType portNum,
+                                              U32 u32,
+                                              F32 f32,
+                                              bool b,
+                                              const Fw::StringBase& str1,
+                                              const E& e,
+                                              const A& a,
+                                              const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedParamsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedParamsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str2,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3422,130 +2099,105 @@ F32 QueuedParamsComponentBase ::
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedParamsComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  parameterUpdated(FwPrmIdType id)
-{
-  // Do nothing by default
+void QueuedParamsComponentBase ::parameterUpdated(FwPrmIdType id) {
+    // Do nothing by default
 }
 
-void QueuedParamsComponentBase ::
-  parametersLoaded()
-{
-  // Do nothing by default
+void QueuedParamsComponentBase ::parametersLoaded() {
+    // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 QueuedParamsComponentBase ::
-  paramGet_ParamU32(Fw::ParamValid& valid)
-{
-  U32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamU32_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamU32;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+U32 QueuedParamsComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
+    U32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamU32_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamU32;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-F64 QueuedParamsComponentBase ::
-  paramGet_ParamF64(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamF64;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+F64 QueuedParamsComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamF64;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-Fw::ParamString QueuedParamsComponentBase ::
-  paramGet_ParamString(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamString_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamString;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+Fw::ParamString QueuedParamsComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamString_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamString;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-E QueuedParamsComponentBase ::
-  paramGet_ParamEnum(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnum_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamEnum;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+E QueuedParamsComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnum_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamEnum;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-A QueuedParamsComponentBase ::
-  paramGet_ParamArray(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArray_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamArray;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+A QueuedParamsComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArray_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamArray;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-S QueuedParamsComponentBase ::
-  paramGet_ParamStruct(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStruct_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamStruct;
-  }
-  this->m_paramLock.unlock();
-  return _local;
+S QueuedParamsComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStruct_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamStruct;
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedParamsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedParamsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3555,892 +2207,526 @@ Fw::Time QueuedParamsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedParamsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedParamsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedParamsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDPARAMS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      break;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDPARAMS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedParamsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                              FwIndexType portNum,
+                                              FwOpcodeType opCode,
+                                              U32 cmdSeq,
+                                              Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedParamsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedParamsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedParamsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedParamsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedParamsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedParamsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedParamsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedParamsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedParamsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedParamsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedParamsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedParamsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedParamsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedParamsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedParamsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedParamsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedParamsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedParamsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedParamsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str2,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedParamsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedParamsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                  FwIndexType portNum,
+                                                  U32 u32,
+                                                  F32 f32,
+                                                  bool b,
+                                                  const Fw::StringBase& str1,
+                                                  const E& e,
+                                                  const A& a,
+                                                  const S& s) {
+    FW_ASSERT(callComp);
+    QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4449,112 +2735,49 @@ void QueuedParamsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedParamsComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void QueuedParamsComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                    FwOpcodeType opCode,
+                                                    U32 cmdSeq,
+                                                    const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-Fw::ParamValid QueuedParamsComponentBase ::
-  prmGetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::ParamValid QueuedParamsComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                         FwPrmIdType id,
+                                                         Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_prmGetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void QueuedParamsComponentBase ::
-  prmSetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmSetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_prmSetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void QueuedParamsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedParamsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4563,294 +2786,252 @@ void QueuedParamsComponentBase ::
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSet_ParamU32(Fw::SerialBufferBase& val)
-{
-  U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
+    U32 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamU32 = _localVal;
-  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamU32 = _localVal;
+    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMU32);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMU32);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSet_ParamF64(Fw::SerialBufferBase& val)
-{
-  F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
+    F64 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamF64 = _localVal;
-  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamF64 = _localVal;
+    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMF64);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMF64);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSet_ParamString(Fw::SerialBufferBase& val)
-{
-  Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
+    Fw::ParamString _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamString = _localVal;
-  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamString = _localVal;
+    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSet_ParamEnum(Fw::SerialBufferBase& val)
-{
-  E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
+    E _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamEnum = _localVal;
-  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamEnum = _localVal;
+    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMENUM);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSet_ParamArray(Fw::SerialBufferBase& val)
-{
-  A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
+    A _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamArray = _localVal;
-  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamArray = _localVal;
+    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSet_ParamStruct(Fw::SerialBufferBase& val)
-{
-  S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedParamsComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
+    S _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamStruct = _localVal;
-  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamStruct = _localVal;
+    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+    return Fw::CmdResponse::OK;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSave_ParamU32()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamU32);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamU32() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamU32);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSave_ParamF64()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamF64);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamF64() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamF64);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSave_ParamString()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamString);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamString() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamString);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSave_ParamEnum()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamEnum() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSave_ParamArray()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamArray);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamArray() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamArray);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedParamsComponentBase ::
-  paramSave_ParamStruct()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedParamsComponentBase ::paramSave_ParamStruct() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -88,9 +88,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedSerialComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDSERIAL_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -35,11 +35,11 @@ namespace {
     INT_IF_INTERNALPRIORITYDROP,
     INT_IF_INTERNALSTRING,
     INT_IF_INTERNALSTRUCT,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -47,1127 +47,683 @@ namespace {
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
     // Size of internalArray argument list
-    BYTE internalArrayIntIfSize[
-      A::SERIALIZED_SIZE
-    ];
+    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
     // Size of internalEnum argument list
-    BYTE internalEnumIntIfSize[
-      E::SERIALIZED_SIZE
-    ];
+    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
     // Size of internalPrimitive argument list
-    BYTE internalPrimitiveIntIfSize[
-      sizeof(U32) +
-      sizeof(F32) +
-      sizeof(U8)
-    ];
+    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
     // Size of internalString argument list
-    BYTE internalStringIntIfSize[
-      Fw::InternalInterfaceString::SERIALIZED_SIZE +
-      Fw::InternalInterfaceString::SERIALIZED_SIZE
-    ];
+    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
+                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
     // Size of internalStruct argument list
-    BYTE internalStructIntIfSize[
-      S::SERIALIZED_SIZE
-    ];
-  };
+    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwSizeType msgSize,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedSerialComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts());
-    port++
-  ) {
-    this->m_serialAsync_InputPort[port].init();
-    this->m_serialAsync_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsync_in
-    );
-    this->m_serialAsync_InputPort[port].setPortNum(port);
+    // Connect input port serialAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts()); port++) {
+        this->m_serialAsync_InputPort[port].init();
+        this->m_serialAsync_InputPort[port].addCallComp(this, m_p_serialAsync_in);
+        this->m_serialAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncAssert_InputPort[port].init();
-    this->m_serialAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncAssert_in
-    );
-    this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts()); port++) {
+        this->m_serialAsyncAssert_InputPort[port].init();
+        this->m_serialAsyncAssert_InputPort[port].addCallComp(this, m_p_serialAsyncAssert_in);
+        this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncBlockPriority_InputPort[port].init();
-    this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncBlockPriority_in
-    );
-    this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_serialAsyncBlockPriority_InputPort[port].init();
+        this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_serialAsyncBlockPriority_in);
+        this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_serialAsyncDropPriority_InputPort[port].init();
-    this->m_serialAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_serialAsyncDropPriority_in
-    );
-    this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port serialAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_serialAsyncDropPriority_InputPort[port].init();
+        this->m_serialAsyncDropPriority_InputPort[port].addCallComp(this, m_p_serialAsyncDropPriority_in);
+        this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts());
-    port++
-  ) {
-    this->m_serialGuarded_InputPort[port].init();
-    this->m_serialGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_serialGuarded_in
-    );
-    this->m_serialGuarded_InputPort[port].setPortNum(port);
+    // Connect input port serialGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts()); port++) {
+        this->m_serialGuarded_InputPort[port].init();
+        this->m_serialGuarded_InputPort[port].addCallComp(this, m_p_serialGuarded_in);
+        this->m_serialGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port serialSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts());
-    port++
-  ) {
-    this->m_serialSync_InputPort[port].init();
-    this->m_serialSync_InputPort[port].addCallComp(
-      this,
-      m_p_serialSync_in
-    );
-    this->m_serialSync_InputPort[port].setPortNum(port);
+    // Connect input port serialSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts()); port++) {
+        this->m_serialSync_InputPort[port].init();
+        this->m_serialSync_InputPort[port].addCallComp(this, m_p_serialSync_in);
+        this->m_serialSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port serialOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts());
-    port++
-  ) {
-    this->m_serialOut_OutputPort[port].init();
+    // Connect output port serialOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts()); port++) {
+        this->m_serialOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_serialOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_serialOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Passed-in size added to port number and message type enumeration sizes.
-  this->m_msgSize = FW_MAX(
-    msgSize +
-    static_cast<FwSizeType>(sizeof(FwIndexType)) +
-    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
+    // Passed-in size added to port number and message type enumeration sizes.
+    this->m_msgSize = FW_MAX(
+        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1176,15 +732,10 @@ void QueuedSerialComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedSerialComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedSerialComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -1195,213 +746,139 @@ Fw::InputCmdPort* QueuedSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedSerialComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedSerialComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedSerialComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedSerialComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSerialComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSerialComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedSerialComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedSerialComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSerialComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedSerialComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedSerialComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedSerialComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedSerialComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedSerialComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedSerialComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1412,70 +889,46 @@ Ports::InputTypedPort* QueuedSerialComponentBase ::
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::
-  get_serialAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsync_InputPort[portNum];
+    return &this->m_serialAsync_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::
-  get_serialAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncAssert_InputPort[portNum];
+    return &this->m_serialAsyncAssert_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::
-  get_serialAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncBlockPriority_InputPort[portNum];
+    return &this->m_serialAsyncBlockPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::
-  get_serialAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialAsyncDropPriority_InputPort[portNum];
+    return &this->m_serialAsyncDropPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::
-  get_serialGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialGuarded_InputPort[portNum];
+    return &this->m_serialGuarded_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::
-  get_serialSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_serialSync_InputPort[portNum];
+    return &this->m_serialSync_InputPort[portNum];
 }
 
 #endif
@@ -1486,120 +939,62 @@ Fw::InputSerializePort* QueuedSerialComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSerialComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedSerialComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1610,116 +1005,64 @@ void QueuedSerialComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1730,106 +1073,55 @@ void QueuedSerialComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSerialComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedSerialComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1840,46 +1132,24 @@ void QueuedSerialComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1890,18 +1160,11 @@ void QueuedSerialComponentBase ::
 // Connect typed and serial input ports to serial output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  set_serialOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPortBase* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::set_serialOut_OutputPort(FwIndexType portNum, Fw::InputPortBase* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1910,586 +1173,368 @@ void QueuedSerialComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedSerialComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_ASYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  loadParameters()
-{
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedSerialComponentBase ::loadParameters() {
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-  FwPrmIdType _id{};
-  Fw::ParamBuffer _paramBuffer;
+    FwPrmIdType _id{};
+    Fw::ParamBuffer _paramBuffer;
 
-  _id = _baseId + PARAMID_PARAMU32;
+    _id = _baseId + PARAMID_PARAMU32;
 
-  // Get serialized parameter ParamU32
-  this->m_param_ParamU32_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamU32
+    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64;
+    _id = _baseId + PARAMID_PARAMF64;
 
-  // Get serialized parameter ParamF64
-  this->m_param_ParamF64_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamF64
+    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRING;
+    _id = _baseId + PARAMID_PARAMSTRING;
 
-  // Get serialized parameter ParamString
-  this->m_param_ParamString_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamString
+    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
-  }
-  else {
-    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamString = Fw::String("default");
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMENUM;
-
-  // Get serialized parameter ParamEnum
-  this->m_param_ParamEnum_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamString = Fw::String("default");
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAY;
+    _id = _baseId + PARAMID_PARAMENUM;
 
-  // Get serialized parameter ParamArray
-  this->m_param_ParamArray_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnum
+    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter
+    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  else {
-    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamArray = A({1, 2, 3});
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCT;
+    _id = _baseId + PARAMID_PARAMARRAY;
 
-  // Get serialized parameter ParamStruct
-  this->m_param_ParamStruct_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamArray
+    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
-  }
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamArray = A({1, 2, 3});
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMI32EXT;
+    _id = _baseId + PARAMID_PARAMSTRUCT;
 
-  // Get serialized parameter ParamI32Ext
-  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStruct
+    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMI32EXT,
-    this->m_param_ParamI32Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter
+    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64EXT;
+    _id = _baseId + PARAMID_PARAMI32EXT;
 
-  // Get serialized parameter ParamF64Ext
-  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamI32Ext
+    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMF64EXT,
-    this->m_param_ParamF64Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMSTRINGEXT;
-
-  // Get serialized parameter ParamStringExt
-  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-    Fw::String _val = Fw::String("external default");
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMF64EXT;
+
+    // Get serialized parameter ParamF64Ext
+    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMENUMEXT;
+    _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
-  // Get serialized parameter ParamEnumExt
-  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStringExt
+    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMENUMEXT,
-    this->m_param_ParamEnumExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+        Fw::String _val = Fw::String("external default");
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAYEXT;
+    _id = _baseId + PARAMID_PARAMENUMEXT;
 
-  // Get serialized parameter ParamArrayExt
-  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnumExt
+    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-    A _val = A({1, 2, 3});
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+    // Get serialized parameter ParamArrayExt
+    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+        A _val = A({1, 2, 3});
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+    // Get serialized parameter ParamStructExt
+    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
+                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-  // Get serialized parameter ParamStructExt
-  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMSTRUCTEXT,
-    this->m_param_ParamStructExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  // Call notifier
-  this->parametersLoaded();
+    // Call notifier
+    this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedSerialComponentBase ::
-  QueuedSerialComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
-  this->m_EventActivityLowThrottledThrottle = 0;
-  this->m_EventFatalThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledIntervalThrottle = 0;
+QueuedSerialComponentBase ::QueuedSerialComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {
+    this->m_EventActivityLowThrottledThrottle = 0;
+    this->m_EventFatalThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-QueuedSerialComponentBase ::
-  ~QueuedSerialComponentBase()
-{
-
-}
+QueuedSerialComponentBase ::~QueuedSerialComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -2497,96 +1542,62 @@ QueuedSerialComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSerialComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedSerialComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedSerialComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2597,92 +1608,59 @@ bool QueuedSerialComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSerialComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2693,15 +1671,11 @@ bool QueuedSerialComponentBase ::
 // Connection status queries for serial output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSerialComponentBase ::
-  isConnected_serialOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSerialComponentBase ::isConnected_serialOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_serialOut_OutputPort[portNum].isConnected();
+    return this->m_serialOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2712,416 +1686,247 @@ bool QueuedSerialComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedSerialComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                   FwOpcodeType opCode,
+                                                   U32 cmdSeq,
+                                                   Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_CMD_SYNC: {
+            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_CMD_SYNC: {
-      this->CMD_SYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
+        case OPCODE_CMD_SYNC_PRIMITIVE: {
+            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRING: {
+            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ENUM: {
+            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ARRAY: {
+            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRUCT: {
+            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED: {
+            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_PRIMITIVE: {
+            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRING: {
+            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ENUM: {
+            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ARRAY: {
+            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRUCT: {
+            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_ASYNC: {
+            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PRIORITY: {
+            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY: {
+            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_DROP: {
+            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_PARAMU32_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMU32_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamString();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMI32EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMI32EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_CMD_SYNC_PRIMITIVE: {
-      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRING: {
-      this->CMD_SYNC_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ENUM: {
-      this->CMD_SYNC_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ARRAY: {
-      this->CMD_SYNC_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRUCT: {
-      this->CMD_SYNC_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED: {
-      this->CMD_GUARDED_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_PRIMITIVE: {
-      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRING: {
-      this->CMD_GUARDED_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ENUM: {
-      this->CMD_GUARDED_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ARRAY: {
-      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRUCT: {
-      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_ASYNC: {
-      this->CMD_ASYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PRIORITY: {
-      this->CMD_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY: {
-      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_DROP: {
-      this->CMD_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_PARAMU32_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMU32_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamString();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMI32EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMI32EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -3130,941 +1935,561 @@ void QueuedSerialComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedSerialComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSerialComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSerialComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedSerialComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedSerialComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedSerialComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedSerialComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedSerialComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSerialComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSerialComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedSerialComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedSerialComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedSerialComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedSerialComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSerialComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSerialComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedSerialComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedSerialComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedSerialComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedSerialComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str2,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSerialComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -4073,265 +2498,151 @@ void QueuedSerialComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  serialAsync_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::serialAsync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsync
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsync
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  serialAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::serialAsyncAssert_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncAssert
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncAssert
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  serialAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::serialAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                      Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncBlockPriority
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncBlockPriority
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  serialAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::serialAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                     Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Declare buffer for serialAsyncDropPriority
-  U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(
-    msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Declare buffer for serialAsyncDropPriority
+    U8 msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msgSerBuff.serializeFrom(
-    static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msgSerBuff.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msgSerBuff.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msgSerBuff.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msgSerBuff.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  serialGuarded_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::serialGuarded_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->serialGuarded_handler(
-    portNum,
-    buffer
-  );
+    // Call handler function
+    this->serialGuarded_handler(portNum, buffer);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-void QueuedSerialComponentBase ::
-  serialSync_handlerBase(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::serialSync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->serialSync_handler(
-    portNum,
-    buffer
-  );
+    // Call handler function
+    this->serialSync_handler(portNum, buffer);
 }
 
 // ----------------------------------------------------------------------
@@ -4342,85 +2653,63 @@ void QueuedSerialComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                            AliasPrim1 u32,
+                                                            AliasPrim2 f32,
+                                                            AliasBool b,
+                                                            const Fw::StringBase& str2,
+                                                            const AliasEnum& e,
+                                                            const AliasArray& a,
+                                                            const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -4431,40 +2720,21 @@ void QueuedSerialComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  serialAsync_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::serialAsync_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  serialAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::serialAsyncAssert_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  serialAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::serialAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                     Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
-void QueuedSerialComponentBase ::
-  serialAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  // Default: no-op
+void QueuedSerialComponentBase ::serialAsyncDropPriority_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4473,209 +2743,103 @@ void QueuedSerialComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedSerialComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedSerialComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedSerialComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSerialComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedSerialComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                   AliasPrim1 u32,
+                                                   AliasPrim2 f32,
+                                                   AliasBool b,
+                                                   const Fw::StringBase& str2,
+                                                   const AliasEnum& e,
+                                                   const AliasArray& a,
+                                                   const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedSerialComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedSerialComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedSerialComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSerialComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedSerialComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::typedOut_out(FwIndexType portNum,
+                                              U32 u32,
+                                              F32 f32,
+                                              bool b,
+                                              const Fw::StringBase& str1,
+                                              const E& e,
+                                              const A& a,
+                                              const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedSerialComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedSerialComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str2,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -4686,24 +2850,12 @@ F32 QueuedSerialComponentBase ::
 // Invocation functions for serial output ports
 // ----------------------------------------------------------------------
 
-Fw::SerializeStatus QueuedSerialComponentBase ::
-  serialOut_out(
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::SerializeStatus QueuedSerialComponentBase ::serialOut_out(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_serialOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_serialOut_OutputPort[portNum].invokeSerial(
-    buffer
-  );
+    FW_ASSERT(this->m_serialOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_serialOut_OutputPort[portNum].invokeSerial(buffer);
 }
 
 #endif
@@ -4712,264 +2864,162 @@ Fw::SerializeStatus QueuedSerialComponentBase ::
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  internalArray_internalInterfaceInvoke(const A& a)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  internalEnum_internalInterfaceInvoke(const E& e)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  internalPrimitive_internalInterfaceInvoke(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  internalPriorityDrop_internalInterfaceInvoke()
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  internalString_internalInterfaceInvoke(
-      const Fw::InternalInterfaceString& str1,
-      const Fw::InternalInterfaceString& str2
-  )
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
+                                                                        const Fw::InternalInterfaceString& str2) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(str1);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(str1);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  internalStruct_internalInterfaceInvoke(const S& s)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedSerialComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -4978,965 +3028,619 @@ void QueuedSerialComponentBase ::
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  CMD_SYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedSerialComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void QueuedSerialComponentBase ::
-  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 }
 
-void QueuedSerialComponentBase ::
-  CMD_SYNC_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 }
 
-void QueuedSerialComponentBase ::
-  CMD_SYNC_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
 }
 
-void QueuedSerialComponentBase ::
-  CMD_SYNC_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                               U32 cmdSeq,
+                                                               Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
 }
 
-void QueuedSerialComponentBase ::
-  CMD_SYNC_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
 }
 
-void QueuedSerialComponentBase ::
-  CMD_GUARDED_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedSerialComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedSerialComponentBase ::
-  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                      U32 cmdSeq,
+                                                                      Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedSerialComponentBase ::
-  CMD_GUARDED_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedSerialComponentBase ::
-  CMD_GUARDED_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedSerialComponentBase ::
-  CMD_GUARDED_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedSerialComponentBase ::
-  CMD_GUARDED_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                   U32 cmdSeq,
+                                                                   Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedSerialComponentBase ::
-  CMD_ASYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
+void QueuedSerialComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  CMD_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+void QueuedSerialComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                    U32 cmdSeq,
+                                                                    Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  CMD_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+void QueuedSerialComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
+                                                                         U32 cmdSeq,
+                                                                         Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -5947,782 +3651,508 @@ void QueuedSerialComponentBase ::
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  CMD_ASYNC_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedSerialComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedSerialComponentBase ::
-  CMD_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedSerialComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedSerialComponentBase ::
-  CMD_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedSerialComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedSerialComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  log_ACTIVITY_HI_EventActivityHigh() const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
+void QueuedSerialComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
 
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logBuff
-    );
-  }
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
+    }
 
-  // Emit the event on the text log port
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity High occurred";
+        const char* _formatString = "(%s) %s: Event Activity High occurred";
 #else
-    const char* _formatString =
-      "%s: Event Activity High occurred";
+        const char* _formatString = "%s: Event Activity High occurred";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventActivityHigh "
-    );
+                          "EventActivityHigh ");
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
+    }
 #endif
 }
 
-void QueuedSerialComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  // Check throttle value
-  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventActivityLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(3));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(F32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U8))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#else
-    const char* _formatString =
-      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventActivityLowThrottled ",
-      u32,
-      static_cast<F64>(f32),
-      b
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedSerialComponentBase ::
-  log_COMMAND_EventCommand(
-      const Fw::StringBase& str1,
-      const Fw::StringBase& str2
-  ) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(2));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    _status = str1.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = str2.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-    const char* _formatString =
-      "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventCommand ",
-      str1.toChar(),
-      str2.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedSerialComponentBase ::
-  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(E::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-    Fw::String eStr;
-    e.toString(eStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventDiagnostic ",
-      eStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedSerialComponentBase ::
-  log_FATAL_EventFatalThrottled(const A& a)
-{
-  // Check throttle value
-  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventFatalThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serializeFrom(static_cast<U8>(4));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = _logBuff.serializeFrom(static_cast<U32>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(A::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Fatal occurred with argument: %s";
-#endif
-
-    Fw::String aStr;
-    a.toString(aStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventFatalThrottled ",
-      aStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedSerialComponentBase ::
-  log_WARNING_HI_EventWarningHigh(const S& s) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(S::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Warning High occurred with argument: %s";
-#endif
-
-    Fw::String sStr;
-    s.toString(sStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningHigh ",
-      sStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled()
-{
-  // Check throttle value
-  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventWarningLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
-#else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningLowThrottled "
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval()
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-  // Check throttle value & throttle timeout
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
-    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-      // The counter has overflowed, check if time interval has passed
-      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
-        // Reset the count
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
-      } else {
-        // Throttle the event
+void QueuedSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
+    // Check throttle value
+    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
         return;
-      }
+    } else {
+        this->m_EventActivityLowThrottledThrottle++;
     }
 
-    // Reset the throttle time if needed
-    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-      // This is the first event, reset the throttle time
-      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
     }
 
-    // Increment the count
-    this->m_EventWarningLowThrottledIntervalThrottle++;
-  }
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(3));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(u32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Emit the event on the text log port
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(f32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(b);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
+        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
+        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventWarningLowThrottledInterval "
-    );
+                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
+    }
+#endif
+}
+
+void QueuedSerialComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
+                                                          const Fw::StringBase& str2) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(2));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
+                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventCommand ", str1.toChar(), str2.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
+    }
+#endif
+}
+
+void QueuedSerialComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(e);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+        Fw::String eStr;
+        e.toString(eStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventDiagnostic ", eStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
+    }
+#endif
+}
+
+void QueuedSerialComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
+    // Check throttle value
+    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventFatalThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+        _status = _logBuff.serializeFrom(static_cast<U8>(4));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = _logBuff.serializeFrom(static_cast<U32>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(a);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
+#endif
+
+        Fw::String aStr;
+        a.toString(aStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventFatalThrottled ", aStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
+    }
+#endif
+}
+
+void QueuedSerialComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(s);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
+#endif
+
+        Fw::String sStr;
+        s.toString(sStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningHigh ", sStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
+    }
+#endif
+}
+
+void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
+    // Check throttle value
+    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventWarningLowThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottled ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
+#endif
+}
+
+void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+    // Check throttle value & throttle timeout
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+            // The counter has overflowed, check if time interval has passed
+            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
+                Fw::TimeInterval(10, 0)) {
+                // Reset the count
+                this->m_EventWarningLowThrottledIntervalThrottle = 0;
+            } else {
+                // Throttle the event
+                return;
+            }
+        }
+
+        // Reset the throttle time if needed
+        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+            // This is the first event, reset the throttle time
+            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+        }
+
+        // Increment the count
+        this->m_EventWarningLowThrottledIntervalThrottle++;
+    }
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottledInterval ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
 #endif
 }
 
@@ -6730,662 +4160,438 @@ void QueuedSerialComponentBase ::
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventActivityLowThrottledThrottle = 0;
-}
-
-void QueuedSerialComponentBase ::
-  log_FATAL_EventFatalThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventFatalThrottledThrottle = 0;
-}
-
-void QueuedSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventWarningLowThrottledThrottle = 0;
-}
-
-void QueuedSerialComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
-{
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
+void QueuedSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
     // Reset throttle counter
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    this->m_EventActivityLowThrottledThrottle = 0;
+}
 
-    // Reset the throttle time
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-  }
+void QueuedSerialComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventFatalThrottledThrottle = 0;
+}
+
+void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledThrottle = 0;
+}
+
+void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        // Reset throttle counter
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+
+        // Reset the throttle time
+        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  tlmWrite(
-      FwChanIdType id,
-      Fw::TlmBuffer& _tlmBuff,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    if (
-      this->isConnected_timeGetOut_OutputPort(0) &&
-      (_tlmTime ==  Fw::ZERO_TIME)
-    ) {
-      this->timeGetOut_out(0, _tlmTime);
+void QueuedSerialComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
+            this->timeGetOut_out(0, _tlmTime);
+        }
+
+        FwChanIdType _id;
+        _id = this->getIdBase() + id;
+
+        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
     }
-
-    FwChanIdType _id;
-    _id = this->getIdBase() + id;
-
-    this->tlmOut_out(
-      0,
-      _id,
-      _tlmTime,
-      _tlmBuff
-    );
-  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelU32Format(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+void QueuedSerialComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-    this->tlmWrite(
-      CHANNELID_CHANNELU32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelF32Format(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelStringFormat(
-      const Fw::StringBase& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serializeTo(
-      _tlmBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRINGFORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelEnum(
-      const E& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUM,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelArrayFreq(
-      const A& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELARRAYFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelStructFreq(
-      const S& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRUCTFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelU32Limits(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelF32Limits(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelF64(
-      F64 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF64,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelU32OnChange(
-      U32 arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelU32OnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelU32OnChange) {
-      return;
+        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
     }
-    else {
-      this->m_last_ChannelU32OnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelU32OnChange = false;
-    this->m_last_ChannelU32OnChange = arg;
-  }
-
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32ONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
 }
 
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelEnumOnChange(
-      const E& arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelEnumOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelEnumOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelEnumOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelEnumOnChange = false;
-    this->m_last_ChannelEnumOnChange = arg;
-  }
+void QueuedSerialComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUMONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
+    }
 }
 
-void QueuedSerialComponentBase ::
-  tlmWrite_ChannelBoolOnChange(
-      bool arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelBoolOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelBoolOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelBoolOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelBoolOnChange = false;
-    this->m_last_ChannelBoolOnChange = arg;
-  }
+void QueuedSerialComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat =
+            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
+                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
+    }
+}
 
-    this->tlmWrite(
-      CHANNELID_CHANNELBOOLONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+void QueuedSerialComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelU32OnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelU32OnChange) {
+            return;
+        } else {
+            this->m_last_ChannelU32OnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelU32OnChange = false;
+        this->m_last_ChannelU32OnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelEnumOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelEnumOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelEnumOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelEnumOnChange = false;
+        this->m_last_ChannelEnumOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedSerialComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelBoolOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelBoolOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelBoolOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelBoolOnChange = false;
+        this->m_last_ChannelBoolOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  parameterUpdated(FwPrmIdType id)
-{
-  // Do nothing by default
+void QueuedSerialComponentBase ::parameterUpdated(FwPrmIdType id) {
+    // Do nothing by default
 }
 
-void QueuedSerialComponentBase ::
-  parametersLoaded()
-{
-  // Do nothing by default
+void QueuedSerialComponentBase ::parametersLoaded() {
+    // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 QueuedSerialComponentBase ::
-  paramGet_ParamU32(Fw::ParamValid& valid)
-{
-  U32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamU32_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamU32;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-F64 QueuedSerialComponentBase ::
-  paramGet_ParamF64(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamF64;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-Fw::ParamString QueuedSerialComponentBase ::
-  paramGet_ParamString(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamString_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamString;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-E QueuedSerialComponentBase ::
-  paramGet_ParamEnum(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnum_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamEnum;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-A QueuedSerialComponentBase ::
-  paramGet_ParamArray(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArray_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamArray;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-S QueuedSerialComponentBase ::
-  paramGet_ParamStruct(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStruct_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamStruct;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-I32 QueuedSerialComponentBase ::
-  paramGet_ParamI32Ext(Fw::ParamValid& valid)
-{
-  I32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamI32Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+U32 QueuedSerialComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
+    U32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamU32_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamU32;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-F64 QueuedSerialComponentBase ::
-  paramGet_ParamF64Ext(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+F64 QueuedSerialComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamF64;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-Fw::ParamString QueuedSerialComponentBase ::
-  paramGet_ParamStringExt(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStringExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+Fw::ParamString QueuedSerialComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamString_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamString;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-E QueuedSerialComponentBase ::
-  paramGet_ParamEnumExt(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnumExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+E QueuedSerialComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnum_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamEnum;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-A QueuedSerialComponentBase ::
-  paramGet_ParamArrayExt(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArrayExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+A QueuedSerialComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArray_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamArray;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-S QueuedSerialComponentBase ::
-  paramGet_ParamStructExt(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStructExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+S QueuedSerialComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStruct_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamStruct;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+I32 QueuedSerialComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
+    I32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamI32Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+F64 QueuedSerialComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+Fw::ParamString QueuedSerialComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStringExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+E QueuedSerialComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnumExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+A QueuedSerialComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArrayExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+S QueuedSerialComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStructExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
-{
-  FW_ASSERT(paramExternalDelegatePtr != nullptr);
-  this->paramDelegatePtr = paramExternalDelegatePtr;
+void QueuedSerialComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
+    FW_ASSERT(paramExternalDelegatePtr != nullptr);
+    this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedSerialComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedSerialComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -7395,1414 +4601,907 @@ Fw::Time QueuedSerialComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedSerialComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedSerialComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedSerialComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
-  doDispatch()
-{
-  U8 _msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer _msg(
-    _msgBuff,
-    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-  );
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::doDispatch() {
+    U8 _msgBuff[this->m_msgSize];
+    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDSERIAL_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      break;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDSERIAL_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
-    }
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port serialAsync
-    case SERIALASYNC_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsync_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle async input port serialAsyncAssert
-    case SERIALASYNCASSERT_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncAssert_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle async input port serialAsyncBlockPriority
-    case SERIALASYNCBLOCKPRIORITY_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle async input port serialAsyncDropPriority
-    case SERIALASYNCDROPPRIORITY_SERIAL: {
-      // Deserialize serialized buffer into new buffer
-      U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(
-        handBuff,
-        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
-      );
-      _deserStatus = _msg.deserializeTo(serHandBuff);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      this->serialAsyncDropPriority_handler(portNum, serHandBuff);
-
-      break;
-    }
-
-    // Handle command CMD_ASYNC
-    case CMD_CMD_ASYNC: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port serialAsync
+        case SERIALASYNC_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsync_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncAssert
+        case SERIALASYNCASSERT_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncAssert_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncBlockPriority
+        case SERIALASYNCBLOCKPRIORITY_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle async input port serialAsyncDropPriority
+        case SERIALASYNCDROPPRIORITY_SERIAL: {
+            // Deserialize serialized buffer into new buffer
+            U8 handBuff[this->m_msgSize];
+            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
+            _deserStatus = _msg.deserializeTo(serHandBuff);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            this->serialAsyncDropPriority_handler(portNum, serHandBuff);
+
+            break;
+        }
+
+        // Handle command CMD_ASYNC
+        case CMD_CMD_ASYNC: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PRIORITY
-    case CMD_CMD_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_PRIORITY
+        case CMD_CMD_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY
-    case CMD_CMD_PARAMS_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY
+        case CMD_CMD_PARAMS_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
-    }
-
-    // Handle command CMD_DROP
-    case CMD_CMD_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_DROP
+        case CMD_CMD_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY_DROP
-    case CMD_CMD_PARAMS_PRIORITY_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_DROP
+        case CMD_CMD_PARAMS_PRIORITY_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
+            break;
+        }
+
+        // Handle internal interface internalArray
+        case INT_IF_INTERNALARRAY: {
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalArray_internalInterfaceHandler(a);
+
+            break;
+        }
+
+        // Handle internal interface internalEnum
+        case INT_IF_INTERNALENUM: {
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalEnum_internalInterfaceHandler(e);
+
+            break;
+        }
+
+        // Handle internal interface internalPrimitive
+        case INT_IF_INTERNALPRIMITIVE: {
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
+
+            break;
+        }
+
+        // Handle internal interface internalPriorityDrop
+        case INT_IF_INTERNALPRIORITYDROP: {
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalPriorityDrop_internalInterfaceHandler();
+
+            break;
+        }
+
+        // Handle internal interface internalString
+        case INT_IF_INTERNALSTRING: {
+            Fw::InternalInterfaceString str1;
+            _deserStatus = _msg.deserializeTo(str1);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            Fw::InternalInterfaceString str2;
+            _deserStatus = _msg.deserializeTo(str2);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalString_internalInterfaceHandler(str1, str2);
+
+            break;
+        }
+
+        // Handle internal interface internalStruct
+        case INT_IF_INTERNALSTRUCT: {
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalStruct_internalInterfaceHandler(s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle internal interface internalArray
-    case INT_IF_INTERNALARRAY: {
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalArray_internalInterfaceHandler(
-        a
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalEnum
-    case INT_IF_INTERNALENUM: {
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalEnum_internalInterfaceHandler(
-        e
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalPrimitive
-    case INT_IF_INTERNALPRIMITIVE: {
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalPrimitive_internalInterfaceHandler(
-        u32,
-        f32,
-        b
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalPriorityDrop
-    case INT_IF_INTERNALPRIORITYDROP: {
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalPriorityDrop_internalInterfaceHandler();
-
-      break;
-    }
-
-    // Handle internal interface internalString
-    case INT_IF_INTERNALSTRING: {
-      Fw::InternalInterfaceString str1;
-      _deserStatus = _msg.deserializeTo(str1);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      Fw::InternalInterfaceString str2;
-      _deserStatus = _msg.deserializeTo(str2);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalString_internalInterfaceHandler(
-        str1,
-        str2
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalStruct
-    case INT_IF_INTERNALSTRUCT: {
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalStruct_internalInterfaceHandler(
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedSerialComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                              FwIndexType portNum,
+                                              FwOpcodeType opCode,
+                                              U32 cmdSeq,
+                                              Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedSerialComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSerialComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                          FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedSerialComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedSerialComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSerialComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedSerialComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSerialComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedSerialComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedSerialComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSerialComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedSerialComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedSerialComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedSerialComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedSerialComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedSerialComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedSerialComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedSerialComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedSerialComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedSerialComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str2,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSerialComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                  FwIndexType portNum,
+                                                  U32 u32,
+                                                  F32 f32,
+                                                  bool b,
+                                                  const Fw::StringBase& str1,
+                                                  const E& e,
+                                                  const A& a,
+                                                  const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -8811,94 +5510,52 @@ void QueuedSerialComponentBase ::
 
 #if FW_PORT_SERIALIZATION
 
-void QueuedSerialComponentBase ::
-  m_p_serialAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->serialAsync_handlerBase(
-    portNum,
-    buffer
-  );
+void QueuedSerialComponentBase ::m_p_serialAsync_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->serialAsync_handlerBase(portNum, buffer);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_serialAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->serialAsyncAssert_handlerBase(
-    portNum,
-    buffer
-  );
+void QueuedSerialComponentBase ::m_p_serialAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->serialAsyncAssert_handlerBase(portNum, buffer);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_serialAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->serialAsyncBlockPriority_handlerBase(
-    portNum,
-    buffer
-  );
+void QueuedSerialComponentBase ::m_p_serialAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->serialAsyncBlockPriority_handlerBase(portNum, buffer);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_serialAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->serialAsyncDropPriority_handlerBase(
-    portNum,
-    buffer
-  );
+void QueuedSerialComponentBase ::m_p_serialAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->serialAsyncDropPriority_handlerBase(portNum, buffer);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_serialGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->serialGuarded_handlerBase(
-    portNum,
-    buffer
-  );
+void QueuedSerialComponentBase ::m_p_serialGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->serialGuarded_handlerBase(portNum, buffer);
 }
 
-void QueuedSerialComponentBase ::
-  m_p_serialSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      Fw::LinearBufferBase& buffer
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-  compPtr->serialSync_handlerBase(
-    portNum,
-    buffer
-  );
+void QueuedSerialComponentBase ::m_p_serialSync_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   Fw::LinearBufferBase& buffer) {
+    FW_ASSERT(callComp);
+    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+    compPtr->serialSync_handlerBase(portNum, buffer);
 }
 
 #endif
@@ -8909,192 +5566,86 @@ void QueuedSerialComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void QueuedSerialComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                    FwOpcodeType opCode,
+                                                    U32 cmdSeq,
+                                                    const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-void QueuedSerialComponentBase ::
-  eventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::LogBuffer& args
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::eventOut_out(FwIndexType portNum,
+                                              FwEventIdType id,
+                                              Fw::Time& timeTag,
+                                              const Fw::LogSeverity& severity,
+                                              Fw::LogBuffer& args) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_eventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_eventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    args
-  );
+    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
 }
 
-Fw::ParamValid QueuedSerialComponentBase ::
-  prmGetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::ParamValid QueuedSerialComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                         FwPrmIdType id,
+                                                         Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_prmGetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void QueuedSerialComponentBase ::
-  prmSetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmSetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_prmSetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void QueuedSerialComponentBase ::
-  textEventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::TextLogString& text
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::textEventOut_out(FwIndexType portNum,
+                                                  FwEventIdType id,
+                                                  Fw::Time& timeTag,
+                                                  const Fw::LogSeverity& severity,
+                                                  Fw::TextLogString& text) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_textEventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_textEventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    text
-  );
+    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
 }
 
 #endif
 
-void QueuedSerialComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
-void QueuedSerialComponentBase ::
-  tlmOut_out(
-      FwIndexType portNum,
-      FwChanIdType id,
-      Fw::Time& timeTag,
-      Fw::TlmBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSerialComponentBase ::tlmOut_out(FwIndexType portNum,
+                                            FwChanIdType id,
+                                            Fw::Time& timeTag,
+                                            Fw::TlmBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_tlmOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_tlmOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    val
-  );
+    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
 }
 
 #endif
@@ -9103,684 +5654,552 @@ void QueuedSerialComponentBase ::
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamU32(Fw::SerialBufferBase& val)
-{
-  U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
+    U32 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamU32 = _localVal;
-  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamU32 = _localVal;
+    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMU32);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMU32);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamF64(Fw::SerialBufferBase& val)
-{
-  F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
+    F64 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamF64 = _localVal;
-  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamF64 = _localVal;
+    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMF64);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMF64);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamString(Fw::SerialBufferBase& val)
-{
-  Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
+    Fw::ParamString _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamString = _localVal;
-  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamString = _localVal;
+    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamEnum(Fw::SerialBufferBase& val)
-{
-  E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
+    E _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamEnum = _localVal;
-  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamEnum = _localVal;
+    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMENUM);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamArray(Fw::SerialBufferBase& val)
-{
-  A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
+    A _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamArray = _localVal;
-  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamArray = _localVal;
+    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamStruct(Fw::SerialBufferBase& val)
-{
-  S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
+    S _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamStruct = _localVal;
-  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamStruct = _localVal;
+    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMI32EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMI32EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMF64EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMF64EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRINGEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMENUMEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMENUMEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMARRAYEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRUCTEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    }
+    return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamU32()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamU32);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamU32() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamU32);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamF64()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamF64);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamF64() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamF64);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamString()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamString);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamString() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamString);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamEnum()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamEnum() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamArray()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamArray);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamArray() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamArray);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamStruct()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamStruct() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamI32Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamI32Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamF64Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamF64Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamStringExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamStringExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamEnumExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamEnumExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamArrayExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamArrayExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::
-  paramSave_ParamStructExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamStructExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedSerialComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDSERIAL_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -35,11 +35,11 @@ enum MsgTypeEnum {
     INT_IF_INTERNALPRIORITYDROP,
     INT_IF_INTERNALSTRING,
     INT_IF_INTERNALSTRUCT,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -47,683 +47,1120 @@ union BuffUnion {
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
     // Size of internalArray argument list
-    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
+    BYTE internalArrayIntIfSize[
+      A::SERIALIZED_SIZE
+    ];
     // Size of internalEnum argument list
-    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
+    BYTE internalEnumIntIfSize[
+      E::SERIALIZED_SIZE
+    ];
     // Size of internalPrimitive argument list
-    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
+    BYTE internalPrimitiveIntIfSize[
+      sizeof(U32) +
+      sizeof(F32) +
+      sizeof(U8)
+    ];
     // Size of internalString argument list
-    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
-                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
+    BYTE internalStringIntIfSize[
+      Fw::InternalInterfaceString::SERIALIZED_SIZE +
+      Fw::InternalInterfaceString::SERIALIZED_SIZE
+    ];
     // Size of internalStruct argument list
-    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
-};
+    BYTE internalStructIntIfSize[
+      S::SERIALIZED_SIZE
+    ];
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedSerialComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwSizeType msgSize,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts()); port++) {
-        this->m_serialAsync_InputPort[port].init();
-        this->m_serialAsync_InputPort[port].addCallComp(this, m_p_serialAsync_in);
-        this->m_serialAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts()); port++) {
-        this->m_serialAsyncAssert_InputPort[port].init();
-        this->m_serialAsyncAssert_InputPort[port].addCallComp(this, m_p_serialAsyncAssert_in);
-        this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_serialAsyncBlockPriority_InputPort[port].init();
-        this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_serialAsyncBlockPriority_in);
-        this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port serialAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsync_InputPorts());
+    port++
+  ) {
+    this->m_serialAsync_InputPort[port].init();
+    this->m_serialAsync_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsync_in
+    );
+    this->m_serialAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_serialAsyncDropPriority_InputPort[port].init();
-        this->m_serialAsyncDropPriority_InputPort[port].addCallComp(this, m_p_serialAsyncDropPriority_in);
-        this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port serialAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncAssert_InputPort[port].init();
+    this->m_serialAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncAssert_in
+    );
+    this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts()); port++) {
-        this->m_serialGuarded_InputPort[port].init();
-        this->m_serialGuarded_InputPort[port].addCallComp(this, m_p_serialGuarded_in);
-        this->m_serialGuarded_InputPort[port].setPortNum(port);
+  // Connect input port serialAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncBlockPriority_InputPort[port].init();
+    this->m_serialAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncBlockPriority_in
+    );
+    this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port serialSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts()); port++) {
-        this->m_serialSync_InputPort[port].init();
-        this->m_serialSync_InputPort[port].addCallComp(this, m_p_serialSync_in);
-        this->m_serialSync_InputPort[port].setPortNum(port);
+  // Connect input port serialAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_serialAsyncDropPriority_InputPort[port].init();
+    this->m_serialAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_serialAsyncDropPriority_in
+    );
+    this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port serialGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialGuarded_InputPorts());
+    port++
+  ) {
+    this->m_serialGuarded_InputPort[port].init();
+    this->m_serialGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_serialGuarded_in
+    );
+    this->m_serialGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port serialSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialSync_InputPorts());
+    port++
+  ) {
+    this->m_serialSync_InputPort[port].init();
+    this->m_serialSync_InputPort[port].addCallComp(
+      this,
+      m_p_serialSync_in
+    );
+    this->m_serialSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port serialOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts()); port++) {
-        this->m_serialOut_OutputPort[port].init();
+  // Connect output port serialOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_serialOut_OutputPorts());
+    port++
+  ) {
+    this->m_serialOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_serialOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_serialOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Passed-in size added to port number and message type enumeration sizes.
-    this->m_msgSize = FW_MAX(
-        msgSize + static_cast<FwSizeType>(sizeof(FwIndexType)) + static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
-        static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+  // Passed-in size added to port number and message type enumeration sizes.
+  this->m_msgSize = FW_MAX(
+    msgSize +
+    static_cast<FwSizeType>(sizeof(FwIndexType)) +
+    static_cast<FwSizeType>(sizeof(FwEnumStoreType)),
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
 
-    // Create the queue
-    Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(queueDepth, this->m_msgSize);
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -732,10 +1169,15 @@ void QueuedSerialComponentBase ::init(FwSizeType queueDepth, FwSizeType msgSize,
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedSerialComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedSerialComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -746,139 +1188,213 @@ Fw::InputCmdPort* QueuedSerialComponentBase ::get_cmdIn_InputPort(FwIndexType po
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedSerialComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedSerialComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedSerialComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedSerialComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSerialComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSerialComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedSerialComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedSerialComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSerialComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedSerialComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedSerialComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedSerialComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedSerialComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedSerialComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedSerialComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSerialComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSerialComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSerialComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSerialComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSerialComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSerialComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSerialComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSerialComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -889,46 +1405,70 @@ Ports::InputTypedPort* QueuedSerialComponentBase ::get_typedSync_InputPort(FwInd
 // Getters for serial input ports
 // ----------------------------------------------------------------------
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* QueuedSerialComponentBase ::
+  get_serialAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsync_InputPort[portNum];
+  return &this->m_serialAsync_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* QueuedSerialComponentBase ::
+  get_serialAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncAssert_InputPort[portNum];
+  return &this->m_serialAsyncAssert_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* QueuedSerialComponentBase ::
+  get_serialAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncBlockPriority_InputPort[portNum];
+  return &this->m_serialAsyncBlockPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* QueuedSerialComponentBase ::
+  get_serialAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialAsyncDropPriority_InputPort[portNum];
+  return &this->m_serialAsyncDropPriority_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* QueuedSerialComponentBase ::
+  get_serialGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialGuarded_InputPort[portNum];
+  return &this->m_serialGuarded_InputPort[portNum];
 }
 
-Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputSerializePort* QueuedSerialComponentBase ::
+  get_serialSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_serialSync_InputPort[portNum];
+  return &this->m_serialSync_InputPort[portNum];
 }
 
 #endif
@@ -939,62 +1479,120 @@ Fw::InputSerializePort* QueuedSerialComponentBase ::get_serialSync_InputPort(FwI
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1005,64 +1603,116 @@ void QueuedSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSerialComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1073,55 +1723,106 @@ void QueuedSerialComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portN
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSerialComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedSerialComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1132,24 +1833,46 @@ void QueuedSerialComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1160,11 +1883,18 @@ void QueuedSerialComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw
 // Connect typed and serial input ports to serial output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::set_serialOut_OutputPort(FwIndexType portNum, Fw::InputPortBase* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  set_serialOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPortBase* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_serialOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1173,368 +1903,586 @@ void QueuedSerialComponentBase ::set_serialOut_OutputPort(FwIndexType portNum, F
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedSerialComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_ASYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+  );
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::loadParameters() {
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedSerialComponentBase ::
+  loadParameters()
+{
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-    FwPrmIdType _id{};
-    Fw::ParamBuffer _paramBuffer;
+  FwPrmIdType _id{};
+  Fw::ParamBuffer _paramBuffer;
 
-    _id = _baseId + PARAMID_PARAMU32;
+  _id = _baseId + PARAMID_PARAMU32;
 
-    // Get serialized parameter ParamU32
-    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamU32
+  this->m_param_ParamU32_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMF64;
-
-    // Get serialized parameter ParamF64
-    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRING;
-
-    // Get serialized parameter ParamString
-    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamString = Fw::String("default");
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMENUM;
-
-    // Get serialized parameter ParamEnum
-    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMARRAY;
-
-    // Get serialized parameter ParamArray
-    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamArray = A({1, 2, 3});
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCT;
-
-    // Get serialized parameter ParamStruct
-    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMI32EXT;
-
-    // Get serialized parameter ParamI32Ext
-    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMF64EXT;
+  _id = _baseId + PARAMID_PARAMF64;
 
-    // Get serialized parameter ParamF64Ext
-    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamF64
+  this->m_param_ParamF64_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRINGEXT;
+  _id = _baseId + PARAMID_PARAMSTRING;
 
-    // Get serialized parameter ParamStringExt
-    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamString
+  this->m_param_ParamString_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-        Fw::String _val = Fw::String("external default");
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMENUMEXT;
-
-    // Get serialized parameter ParamEnumExt
-    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
+  }
+  else {
+    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamString = Fw::String("default");
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMARRAYEXT;
+  _id = _baseId + PARAMID_PARAMENUM;
 
-    // Get serialized parameter ParamArrayExt
-    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamEnum
+  this->m_param_ParamEnum_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-        A _val = A({1, 2, 3});
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-    // Get serialized parameter ParamStructExt
-    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
-                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parametersLoaded();
+  _id = _baseId + PARAMID_PARAMARRAY;
+
+  // Get serialized parameter ParamArray
+  this->m_param_ParamArray_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamArray = A({1, 2, 3});
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRUCT;
+
+  // Get serialized parameter ParamStruct
+  this->m_param_ParamStruct_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMI32EXT;
+
+  // Get serialized parameter ParamI32Ext
+  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMI32EXT,
+    this->m_param_ParamI32Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMF64EXT;
+
+  // Get serialized parameter ParamF64Ext
+  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMF64EXT,
+    this->m_param_ParamF64Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRINGEXT;
+
+  // Get serialized parameter ParamStringExt
+  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+    Fw::String _val = Fw::String("external default");
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMENUMEXT;
+
+  // Get serialized parameter ParamEnumExt
+  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMENUMEXT,
+    this->m_param_ParamEnumExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+  // Get serialized parameter ParamArrayExt
+  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+    A _val = A({1, 2, 3});
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+  // Get serialized parameter ParamStructExt
+  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMSTRUCTEXT,
+    this->m_param_ParamStructExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  // Call notifier
+  this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedSerialComponentBase ::QueuedSerialComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {
-    this->m_EventActivityLowThrottledThrottle = 0;
-    this->m_EventFatalThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+QueuedSerialComponentBase ::
+  QueuedSerialComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
+  this->m_EventActivityLowThrottledThrottle = 0;
+  this->m_EventFatalThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-QueuedSerialComponentBase ::~QueuedSerialComponentBase() {}
+QueuedSerialComponentBase ::
+  ~QueuedSerialComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1542,62 +2490,96 @@ QueuedSerialComponentBase ::~QueuedSerialComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSerialComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedSerialComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedSerialComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1608,59 +2590,92 @@ bool QueuedSerialComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portN
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSerialComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSerialComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1671,11 +2686,15 @@ bool QueuedSerialComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexTy
 // Connection status queries for serial output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSerialComponentBase ::isConnected_serialOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSerialComponentBase ::
+  isConnected_serialOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_serialOut_OutputPort[portNum].isConnected();
+  return this->m_serialOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1686,247 +2705,416 @@ bool QueuedSerialComponentBase ::isConnected_serialOut_OutputPort(FwIndexType po
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                   FwOpcodeType opCode,
-                                                   U32 cmdSeq,
-                                                   Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedSerialComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_CMD_SYNC: {
-            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_CMD_SYNC_PRIMITIVE: {
-            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRING: {
-            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ENUM: {
-            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ARRAY: {
-            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRUCT: {
-            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED: {
-            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_PRIMITIVE: {
-            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRING: {
-            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ENUM: {
-            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ARRAY: {
-            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRUCT: {
-            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_ASYNC: {
-            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PRIORITY: {
-            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY: {
-            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_DROP: {
-            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_PARAMU32_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMU32_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamString();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMI32EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMI32EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_CMD_SYNC: {
+      this->CMD_SYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
     }
+
+    case OPCODE_CMD_SYNC_PRIMITIVE: {
+      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRING: {
+      this->CMD_SYNC_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ENUM: {
+      this->CMD_SYNC_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ARRAY: {
+      this->CMD_SYNC_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRUCT: {
+      this->CMD_SYNC_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED: {
+      this->CMD_GUARDED_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_PRIMITIVE: {
+      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRING: {
+      this->CMD_GUARDED_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ENUM: {
+      this->CMD_GUARDED_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ARRAY: {
+      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRUCT: {
+      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_ASYNC: {
+      this->CMD_ASYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PRIORITY: {
+      this->CMD_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY: {
+      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_DROP: {
+      this->CMD_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_PARAMU32_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMU32_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamString();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMI32EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMI32EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1935,561 +3123,941 @@ void QueuedSerialComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedSerialComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSerialComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSerialComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedSerialComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedSerialComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedSerialComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedSerialComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedSerialComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSerialComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSerialComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedSerialComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedSerialComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedSerialComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedSerialComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSerialComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSerialComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedSerialComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedSerialComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedSerialComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str2,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedSerialComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSerialComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2498,151 +4066,265 @@ void QueuedSerialComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::serialAsync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  serialAsync_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsync
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsync
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::serialAsyncAssert_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  serialAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncAssert
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncAssert
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::serialAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                      Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  serialAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncBlockPriority
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncBlockPriority
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::serialAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                     Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  serialAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Declare buffer for serialAsyncDropPriority
-    U8 msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Declare buffer for serialAsyncDropPriority
+  U8 msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msgSerBuff.serializeFrom(static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msgSerBuff.serializeFrom(
+    static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msgSerBuff.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msgSerBuff.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msgSerBuff.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msgSerBuff.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msgSerBuff, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::serialGuarded_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  serialGuarded_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->serialGuarded_handler(portNum, buffer);
+  // Call handler function
+  this->serialGuarded_handler(
+    portNum,
+    buffer
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-void QueuedSerialComponentBase ::serialSync_handlerBase(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  serialSync_handlerBase(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->serialSync_handler(portNum, buffer);
+  // Call handler function
+  this->serialSync_handler(
+    portNum,
+    buffer
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2653,63 +4335,85 @@ void QueuedSerialComponentBase ::serialSync_handlerBase(FwIndexType portNum, Fw:
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                            AliasPrim1 u32,
-                                                            AliasPrim2 f32,
-                                                            AliasBool b,
-                                                            const Fw::StringBase& str2,
-                                                            const AliasEnum& e,
-                                                            const AliasArray& a,
-                                                            const AliasStruct& s) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -2720,21 +4424,40 @@ void QueuedSerialComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType p
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::serialAsync_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  serialAsync_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::serialAsyncAssert_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  serialAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::serialAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                     Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  serialAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSerialComponentBase ::serialAsyncDropPriority_preMsgHook(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    // Default: no-op
+void QueuedSerialComponentBase ::
+  serialAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2743,103 +4466,209 @@ void QueuedSerialComponentBase ::serialAsyncDropPriority_preMsgHook(FwIndexType 
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedSerialComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedSerialComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedSerialComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSerialComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedSerialComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                   AliasPrim1 u32,
-                                                   AliasPrim2 f32,
-                                                   AliasBool b,
-                                                   const Fw::StringBase& str2,
-                                                   const AliasEnum& e,
-                                                   const AliasArray& a,
-                                                   const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedSerialComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedSerialComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedSerialComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSerialComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::typedOut_out(FwIndexType portNum,
-                                              U32 u32,
-                                              F32 f32,
-                                              bool b,
-                                              const Fw::StringBase& str1,
-                                              const E& e,
-                                              const A& a,
-                                              const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedSerialComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str2,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedSerialComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2850,12 +4679,24 @@ F32 QueuedSerialComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Invocation functions for serial output ports
 // ----------------------------------------------------------------------
 
-Fw::SerializeStatus QueuedSerialComponentBase ::serialOut_out(FwIndexType portNum, Fw::LinearBufferBase& buffer) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::SerializeStatus QueuedSerialComponentBase ::
+  serialOut_out(
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_serialOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_serialOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_serialOut_OutputPort[portNum].invokeSerial(buffer);
+  FW_ASSERT(
+    this->m_serialOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_serialOut_OutputPort[portNum].invokeSerial(
+    buffer
+  );
 }
 
 #endif
@@ -2864,162 +4705,264 @@ Fw::SerializeStatus QueuedSerialComponentBase ::serialOut_out(FwIndexType portNu
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  internalArray_internalInterfaceInvoke(const A& a)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  internalEnum_internalInterfaceInvoke(const E& e)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  internalPrimitive_internalInterfaceInvoke(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  internalPriorityDrop_internalInterfaceInvoke()
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
-                                                                        const Fw::InternalInterfaceString& str2) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  internalString_internalInterfaceInvoke(
+      const Fw::InternalInterfaceString& str1,
+      const Fw::InternalInterfaceString& str2
+  )
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(str1);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(str1);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSerialComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  internalStruct_internalInterfaceInvoke(const S& s)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedSerialComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -3028,619 +4971,965 @@ void QueuedSerialComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void QueuedSerialComponentBase ::
+  CMD_SYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void QueuedSerialComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
+  this->CMD_SYNC_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 }
 
-void QueuedSerialComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_SYNC_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_SYNC_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 }
 
-void QueuedSerialComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_SYNC_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_SYNC_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 }
 
-void QueuedSerialComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                               U32 cmdSeq,
-                                                               Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_SYNC_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_SYNC_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 }
 
-void QueuedSerialComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_SYNC_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_SYNC_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void QueuedSerialComponentBase ::
+  CMD_GUARDED_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedSerialComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                      U32 cmdSeq,
-                                                                      Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
-
-#if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-#endif
-
-    this->lock();
-
-    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
-
-    this->unLock();
-}
-
-void QueuedSerialComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Reset the buffer
-    args.resetDeser();
-
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedSerialComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_GUARDED_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
+
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_GUARDED_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedSerialComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_GUARDED_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_GUARDED_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedSerialComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                   U32 cmdSeq,
-                                                                   Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedSerialComponentBase ::
+  CMD_GUARDED_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_GUARDED_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedSerialComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
+void QueuedSerialComponentBase ::
+  CMD_GUARDED_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Reset the buffer
+  args.resetDeser();
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedSerialComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                    U32 cmdSeq,
-                                                                    Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedSerialComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+#if FW_CMD_CHECK_RESIDUAL
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
+#endif
+
+  this->lock();
+
+  this->CMD_GUARDED_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
+
+  this->unLock();
 }
 
-void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
-                                                                         U32 cmdSeq,
-                                                                         Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
+void QueuedSerialComponentBase ::
+  CMD_ASYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+void QueuedSerialComponentBase ::
+  CMD_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedSerialComponentBase ::
+  CMD_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -3651,508 +5940,782 @@ void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcod
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedSerialComponentBase ::
+  CMD_ASYNC_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedSerialComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedSerialComponentBase ::
+  CMD_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedSerialComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedSerialComponentBase ::
+  CMD_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedSerialComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedSerialComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
+void QueuedSerialComponentBase ::
+  log_ACTIVITY_HI_EventActivityHigh() const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
-    }
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logBuff
+    );
+  }
 
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity High occurred";
+    const char* _formatString =
+      "(%s) %s: Event Activity High occurred";
 #else
-        const char* _formatString = "%s: Event Activity High occurred";
+    const char* _formatString =
+      "%s: Event Activity High occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityHigh ");
+      "EventActivityHigh "
+    );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
-    }
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logString
+    );
+  }
 #endif
 }
 
-void QueuedSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
-    // Check throttle value
-    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+void QueuedSerialComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  // Check throttle value
+  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventActivityLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(u32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(F32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(f32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U8))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(b);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#else
+    const char* _formatString =
+      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventActivityLowThrottled ",
+      u32,
+      static_cast<F64>(f32),
+      b
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedSerialComponentBase ::
+  log_COMMAND_EventCommand(
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
+  ) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    _status = str1.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = str2.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+    const char* _formatString =
+      "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventCommand ",
+      str1.toChar(),
+      str2.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedSerialComponentBase ::
+  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(E::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(e);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+    Fw::String eStr;
+    e.toString(eStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventDiagnostic ",
+      eStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedSerialComponentBase ::
+  log_FATAL_EventFatalThrottled(const A& a)
+{
+  // Check throttle value
+  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventFatalThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(A::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(a);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Fatal occurred with argument: %s";
+#endif
+
+    Fw::String aStr;
+    a.toString(aStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventFatalThrottled ",
+      aStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedSerialComponentBase ::
+  log_WARNING_HI_EventWarningHigh(const S& s) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(S::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(s);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Warning High occurred with argument: %s";
+#endif
+
+    Fw::String sStr;
+    s.toString(sStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningHigh ",
+      sStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled()
+{
+  // Check throttle value
+  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventWarningLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
+#else
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningLowThrottled "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval()
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+  // Check throttle value & throttle timeout
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
+
+    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+      // The counter has overflowed, check if time interval has passed
+      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
+        // Reset the count
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+      } else {
+        // Throttle the event
         return;
-    } else {
-        this->m_EventActivityLowThrottledThrottle++;
+      }
     }
 
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+    // Reset the throttle time if needed
+    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+      // This is the first event, reset the throttle time
+      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
     }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+    // Increment the count
+    this->m_EventWarningLowThrottledIntervalThrottle++;
+  }
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(3));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
-        _status = _logBuff.serializeFrom(u32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(f32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(b);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
 #else
-        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
-    }
-#endif
-}
-
-void QueuedSerialComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1,
-                                                          const Fw::StringBase& str2) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(2));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
-                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventCommand ", str1.toChar(), str2.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
-    }
-#endif
-}
-
-void QueuedSerialComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(e);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-        Fw::String eStr;
-        e.toString(eStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventDiagnostic ", eStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
-    }
-#endif
-}
-
-void QueuedSerialComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
-    // Check throttle value
-    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventFatalThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-        _status = _logBuff.serializeFrom(static_cast<U8>(4));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = _logBuff.serializeFrom(static_cast<U32>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(a);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
-#endif
-
-        Fw::String aStr;
-        a.toString(aStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventFatalThrottled ", aStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
-    }
-#endif
-}
-
-void QueuedSerialComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(s);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
-#endif
-
-        Fw::String sStr;
-        s.toString(sStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningHigh ", sStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
-    }
-#endif
-}
-
-void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
-    // Check throttle value
-    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventWarningLowThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottled ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
-#endif
-}
-
-void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-    // Check throttle value & throttle timeout
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
-
-        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-            // The counter has overflowed, check if time interval has passed
-            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
-                Fw::TimeInterval(10, 0)) {
-                // Reset the count
-                this->m_EventWarningLowThrottledIntervalThrottle = 0;
-            } else {
-                // Throttle the event
-                return;
-            }
-        }
-
-        // Reset the throttle time if needed
-        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-            // This is the first event, reset the throttle time
-            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
-        }
-
-        // Increment the count
-        this->m_EventWarningLowThrottledIntervalThrottle++;
-    }
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottledInterval ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
+      "EventWarningLowThrottledInterval "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
 #endif
 }
 
@@ -4160,438 +6723,662 @@ void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventActivityLowThrottledThrottle = 0;
+void QueuedSerialComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventActivityLowThrottledThrottle = 0;
 }
 
-void QueuedSerialComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventFatalThrottledThrottle = 0;
+void QueuedSerialComponentBase ::
+  log_FATAL_EventFatalThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventFatalThrottledThrottle = 0;
 }
 
-void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventWarningLowThrottledThrottle = 0;
+void QueuedSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventWarningLowThrottledThrottle = 0;
 }
 
-void QueuedSerialComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
+void QueuedSerialComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
+{
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
 
-        // Reset throttle counter
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-        // Reset the throttle time
-        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-    }
+    // Reset the throttle time
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
-            this->timeGetOut_out(0, _tlmTime);
-        }
-
-        FwChanIdType _id;
-        _id = this->getIdBase() + id;
-
-        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
+void QueuedSerialComponentBase ::
+  tlmWrite(
+      FwChanIdType id,
+      Fw::TlmBuffer& _tlmBuff,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    if (
+      this->isConnected_timeGetOut_OutputPort(0) &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->timeGetOut_out(0, _tlmTime);
     }
+
+    FwChanIdType _id;
+    _id = this->getIdBase() + id;
+
+    this->tlmOut_out(
+      0,
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelU32Format(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelF32Format(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat =
-            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
-                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelStringFormat(
+      const Fw::StringBase& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = arg.serializeTo(
+      _tlmBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRINGFORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelEnum(
+      const E& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELENUM,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelArrayFreq(
+      const A& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELARRAYFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelStructFreq(
+      const S& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRUCTFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelU32Limits(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelF32Limits(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelF64(
+      F64 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF64,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelU32OnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelU32OnChange) {
-            return;
-        } else {
-            this->m_last_ChannelU32OnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelU32OnChange = false;
-        this->m_last_ChannelU32OnChange = arg;
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelU32OnChange(
+      U32 arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelU32OnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelU32OnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelU32OnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelU32OnChange = false;
+    this->m_last_ChannelU32OnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELU32ONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelEnumOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelEnumOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelEnumOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelEnumOnChange = false;
-        this->m_last_ChannelEnumOnChange = arg;
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelEnumOnChange(
+      const E& arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelEnumOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelEnumOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelEnumOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelEnumOnChange = false;
+    this->m_last_ChannelEnumOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELENUMONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedSerialComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelBoolOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelBoolOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelBoolOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelBoolOnChange = false;
-        this->m_last_ChannelBoolOnChange = arg;
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELBOOLONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::parameterUpdated(FwPrmIdType id) {
-    // Do nothing by default
+void QueuedSerialComponentBase ::
+  parameterUpdated(FwPrmIdType id)
+{
+  // Do nothing by default
 }
 
-void QueuedSerialComponentBase ::parametersLoaded() {
-    // Do nothing by default
+void QueuedSerialComponentBase ::
+  parametersLoaded()
+{
+  // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 QueuedSerialComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
-    U32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamU32_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamU32;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+U32 QueuedSerialComponentBase ::
+  paramGet_ParamU32(Fw::ParamValid& valid)
+{
+  U32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamU32_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamU32;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 QueuedSerialComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamF64;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+F64 QueuedSerialComponentBase ::
+  paramGet_ParamF64(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamF64;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString QueuedSerialComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamString_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamString;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+Fw::ParamString QueuedSerialComponentBase ::
+  paramGet_ParamString(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamString_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamString;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E QueuedSerialComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnum_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamEnum;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+E QueuedSerialComponentBase ::
+  paramGet_ParamEnum(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnum_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamEnum;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A QueuedSerialComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArray_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamArray;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+A QueuedSerialComponentBase ::
+  paramGet_ParamArray(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArray_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamArray;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S QueuedSerialComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStruct_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamStruct;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+S QueuedSerialComponentBase ::
+  paramGet_ParamStruct(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStruct_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamStruct;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-I32 QueuedSerialComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
-    I32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamI32Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+I32 QueuedSerialComponentBase ::
+  paramGet_ParamI32Ext(Fw::ParamValid& valid)
+{
+  I32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamI32Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 QueuedSerialComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+F64 QueuedSerialComponentBase ::
+  paramGet_ParamF64Ext(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString QueuedSerialComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStringExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+Fw::ParamString QueuedSerialComponentBase ::
+  paramGet_ParamStringExt(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStringExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E QueuedSerialComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnumExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+E QueuedSerialComponentBase ::
+  paramGet_ParamEnumExt(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnumExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A QueuedSerialComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArrayExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+A QueuedSerialComponentBase ::
+  paramGet_ParamArrayExt(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArrayExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S QueuedSerialComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStructExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+S QueuedSerialComponentBase ::
+  paramGet_ParamStructExt(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStructExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
-    FW_ASSERT(paramExternalDelegatePtr != nullptr);
-    this->paramDelegatePtr = paramExternalDelegatePtr;
+void QueuedSerialComponentBase ::
+  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
+{
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
+  this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedSerialComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedSerialComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -4601,907 +7388,1414 @@ Fw::Time QueuedSerialComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedSerialComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedSerialComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedSerialComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::doDispatch() {
-    U8 _msgBuff[this->m_msgSize];
-    Fw::ExternalSerializeBuffer _msg(_msgBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
+  doDispatch()
+{
+  U8 _msgBuff[this->m_msgSize];
+  Fw::ExternalSerializeBuffer _msg(
+    _msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDSERIAL_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDSERIAL_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port serialAsync
-        case SERIALASYNC_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsync_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncAssert
-        case SERIALASYNCASSERT_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncAssert_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncBlockPriority
-        case SERIALASYNCBLOCKPRIORITY_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle async input port serialAsyncDropPriority
-        case SERIALASYNCDROPPRIORITY_SERIAL: {
-            // Deserialize serialized buffer into new buffer
-            U8 handBuff[this->m_msgSize];
-            Fw::ExternalSerializeBuffer serHandBuff(handBuff, static_cast<Fw::Serializable::SizeType>(this->m_msgSize));
-            _deserStatus = _msg.deserializeTo(serHandBuff);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            this->serialAsyncDropPriority_handler(portNum, serHandBuff);
-
-            break;
-        }
-
-        // Handle command CMD_ASYNC
-        case CMD_CMD_ASYNC: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PRIORITY
-        case CMD_CMD_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY
-        case CMD_CMD_PARAMS_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle command CMD_DROP
-        case CMD_CMD_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY_DROP
-        case CMD_CMD_PARAMS_PRIORITY_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle internal interface internalArray
-        case INT_IF_INTERNALARRAY: {
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalArray_internalInterfaceHandler(a);
-
-            break;
-        }
-
-        // Handle internal interface internalEnum
-        case INT_IF_INTERNALENUM: {
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalEnum_internalInterfaceHandler(e);
-
-            break;
-        }
-
-        // Handle internal interface internalPrimitive
-        case INT_IF_INTERNALPRIMITIVE: {
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
-
-            break;
-        }
-
-        // Handle internal interface internalPriorityDrop
-        case INT_IF_INTERNALPRIORITYDROP: {
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalPriorityDrop_internalInterfaceHandler();
-
-            break;
-        }
-
-        // Handle internal interface internalString
-        case INT_IF_INTERNALSTRING: {
-            Fw::InternalInterfaceString str1;
-            _deserStatus = _msg.deserializeTo(str1);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            Fw::InternalInterfaceString str2;
-            _deserStatus = _msg.deserializeTo(str2);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalString_internalInterfaceHandler(str1, str2);
-
-            break;
-        }
-
-        // Handle internal interface internalStruct
-        case INT_IF_INTERNALSTRUCT: {
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalStruct_internalInterfaceHandler(s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port serialAsync
+    case SERIALASYNC_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsync_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle async input port serialAsyncAssert
+    case SERIALASYNCASSERT_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncAssert_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle async input port serialAsyncBlockPriority
+    case SERIALASYNCBLOCKPRIORITY_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncBlockPriority_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle async input port serialAsyncDropPriority
+    case SERIALASYNCDROPPRIORITY_SERIAL: {
+      // Deserialize serialized buffer into new buffer
+      U8 handBuff[this->m_msgSize];
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
+      _deserStatus = _msg.deserializeTo(serHandBuff);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      this->serialAsyncDropPriority_handler(portNum, serHandBuff);
+
+      break;
+    }
+
+    // Handle command CMD_ASYNC
+    case CMD_CMD_ASYNC: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PRIORITY
+    case CMD_CMD_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY
+    case CMD_CMD_PARAMS_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle command CMD_DROP
+    case CMD_CMD_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY_DROP
+    case CMD_CMD_PARAMS_PRIORITY_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalArray
+    case INT_IF_INTERNALARRAY: {
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalArray_internalInterfaceHandler(
+        a
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalEnum
+    case INT_IF_INTERNALENUM: {
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalEnum_internalInterfaceHandler(
+        e
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalPrimitive
+    case INT_IF_INTERNALPRIMITIVE: {
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalPrimitive_internalInterfaceHandler(
+        u32,
+        f32,
+        b
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalPriorityDrop
+    case INT_IF_INTERNALPRIORITYDROP: {
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalPriorityDrop_internalInterfaceHandler();
+
+      break;
+    }
+
+    // Handle internal interface internalString
+    case INT_IF_INTERNALSTRING: {
+      Fw::InternalInterfaceString str1;
+      _deserStatus = _msg.deserializeTo(str1);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      Fw::InternalInterfaceString str2;
+      _deserStatus = _msg.deserializeTo(str2);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalString_internalInterfaceHandler(
+        str1,
+        str2
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalStruct
+    case INT_IF_INTERNALSTRUCT: {
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalStruct_internalInterfaceHandler(
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                              FwIndexType portNum,
-                                              FwOpcodeType opCode,
-                                              U32 cmdSeq,
-                                              Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedSerialComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedSerialComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                          FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSerialComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedSerialComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedSerialComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSerialComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedSerialComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSerialComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedSerialComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedSerialComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSerialComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedSerialComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedSerialComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedSerialComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedSerialComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedSerialComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedSerialComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedSerialComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedSerialComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedSerialComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str2,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedSerialComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                  FwIndexType portNum,
-                                                  U32 u32,
-                                                  F32 f32,
-                                                  bool b,
-                                                  const Fw::StringBase& str1,
-                                                  const E& e,
-                                                  const A& a,
-                                                  const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSerialComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -5510,52 +8804,94 @@ void QueuedSerialComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* call
 
 #if FW_PORT_SERIALIZATION
 
-void QueuedSerialComponentBase ::m_p_serialAsync_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->serialAsync_handlerBase(portNum, buffer);
+void QueuedSerialComponentBase ::
+  m_p_serialAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->serialAsync_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_serialAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->serialAsyncAssert_handlerBase(portNum, buffer);
+void QueuedSerialComponentBase ::
+  m_p_serialAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->serialAsyncAssert_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_serialAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->serialAsyncBlockPriority_handlerBase(portNum, buffer);
+void QueuedSerialComponentBase ::
+  m_p_serialAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->serialAsyncBlockPriority_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_serialAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->serialAsyncDropPriority_handlerBase(portNum, buffer);
+void QueuedSerialComponentBase ::
+  m_p_serialAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->serialAsyncDropPriority_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_serialGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->serialGuarded_handlerBase(portNum, buffer);
+void QueuedSerialComponentBase ::
+  m_p_serialGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->serialGuarded_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
-void QueuedSerialComponentBase ::m_p_serialSync_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   Fw::LinearBufferBase& buffer) {
-    FW_ASSERT(callComp);
-    QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
-    compPtr->serialSync_handlerBase(portNum, buffer);
+void QueuedSerialComponentBase ::
+  m_p_serialSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      Fw::LinearBufferBase& buffer
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
+  compPtr->serialSync_handlerBase(
+    portNum,
+    buffer
+  );
 }
 
 #endif
@@ -5566,86 +8902,192 @@ void QueuedSerialComponentBase ::m_p_serialSync_in(Fw::PassiveComponentBase* cal
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSerialComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void QueuedSerialComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                    FwOpcodeType opCode,
-                                                    U32 cmdSeq,
-                                                    const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-void QueuedSerialComponentBase ::eventOut_out(FwIndexType portNum,
-                                              FwEventIdType id,
-                                              Fw::Time& timeTag,
-                                              const Fw::LogSeverity& severity,
-                                              Fw::LogBuffer& args) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  eventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::LogBuffer& args
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
+  FW_ASSERT(
+    this->m_eventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_eventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    args
+  );
 }
 
-Fw::ParamValid QueuedSerialComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                         FwPrmIdType id,
-                                                         Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::ParamValid QueuedSerialComponentBase ::
+  prmGetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_prmGetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void QueuedSerialComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  prmSetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmSetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_prmSetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void QueuedSerialComponentBase ::textEventOut_out(FwIndexType portNum,
-                                                  FwEventIdType id,
-                                                  Fw::Time& timeTag,
-                                                  const Fw::LogSeverity& severity,
-                                                  Fw::TextLogString& text) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  textEventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::TextLogString& text
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
+  FW_ASSERT(
+    this->m_textEventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_textEventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    text
+  );
 }
 
 #endif
 
-void QueuedSerialComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
-void QueuedSerialComponentBase ::tlmOut_out(FwIndexType portNum,
-                                            FwChanIdType id,
-                                            Fw::Time& timeTag,
-                                            Fw::TlmBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSerialComponentBase ::
+  tlmOut_out(
+      FwIndexType portNum,
+      FwChanIdType id,
+      Fw::Time& timeTag,
+      Fw::TlmBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
+  FW_ASSERT(
+    this->m_tlmOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_tlmOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    val
+  );
 }
 
 #endif
@@ -5654,552 +9096,684 @@ void QueuedSerialComponentBase ::tlmOut_out(FwIndexType portNum,
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
-    U32 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamU32(Fw::SerialBufferBase& val)
+{
+  U32 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamU32 = _localVal;
-    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamU32 = _localVal;
+  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMU32);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMU32);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
-    F64 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamF64(Fw::SerialBufferBase& val)
+{
+  F64 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamF64 = _localVal;
-    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamF64 = _localVal;
+  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMF64);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMF64);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
-    Fw::ParamString _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamString(Fw::SerialBufferBase& val)
+{
+  Fw::ParamString _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamString = _localVal;
-    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamString = _localVal;
+  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
-    E _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamEnum(Fw::SerialBufferBase& val)
+{
+  E _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamEnum = _localVal;
-    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamEnum = _localVal;
+  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMENUM);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
-    A _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamArray(Fw::SerialBufferBase& val)
+{
+  A _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamArray = _localVal;
-    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamArray = _localVal;
+  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
-    S _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamStruct(Fw::SerialBufferBase& val)
+{
+  S _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamStruct = _localVal;
-    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamStruct = _localVal;
+  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMI32EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMI32EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMF64EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMF64EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRINGEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMENUMEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMENUMEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMARRAYEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRUCTEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
+  return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamU32() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamU32);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamU32()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamU32);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamF64() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamF64);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamF64()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamF64);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamString() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamString);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamString()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamString);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamEnum() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamEnum()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamArray() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamArray);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamArray()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamArray);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamStruct() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamStruct()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamI32Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamI32Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamF64Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamF64Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamStringExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamStringExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamEnumExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamEnumExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamArrayExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamArrayExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedSerialComponentBase ::paramSave_ParamStructExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedSerialComponentBase ::
+  paramSave_ParamStructExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedSyncProductsComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDSYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,1223 +20,783 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedSyncProductsComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+QueuedSyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+QueuedSyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-QueuedSyncProductsComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const QueuedSyncProducts_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
+    const QueuedSyncProducts_Data* array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const QueuedSyncProducts_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
+    const QueuedSyncProducts_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
+    const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                                  FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                                 FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::ActiveComponentBase::init(instance);
+void QueuedSyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1245,26 +805,17 @@ void QueuedSyncProductsComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedSyncProductsComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedSyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedSyncProductsComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* QueuedSyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -1275,213 +826,140 @@ Fw::InputDpResponsePort* QueuedSyncProductsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedSyncProductsComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedSyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedSyncProductsComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedSyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedSyncProductsComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedSyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedSyncProductsComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedSyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1492,148 +970,78 @@ Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedSyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1644,116 +1052,66 @@ void QueuedSyncProductsComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                      Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                            Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                          Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                     Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1764,134 +1122,72 @@ void QueuedSyncProductsComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
+                                                                        Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
+                                                                     Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSyncProductsComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedSyncProductsComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1902,46 +1198,24 @@ void QueuedSyncProductsComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1950,18 +1224,10 @@ void QueuedSyncProductsComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedSyncProductsComponentBase ::
-  QueuedSyncProductsComponentBase(const char* compName) :
-    Fw::ActiveComponentBase(compName)
-{
+QueuedSyncProductsComponentBase ::QueuedSyncProductsComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName) {}
 
-}
-
-QueuedSyncProductsComponentBase ::
-  ~QueuedSyncProductsComponentBase()
-{
-
-}
+QueuedSyncProductsComponentBase ::~QueuedSyncProductsComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1969,118 +1235,76 @@ QueuedSyncProductsComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2091,92 +1315,59 @@ bool QueuedSyncProductsComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedSyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2187,47 +1378,31 @@ bool QueuedSyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedSyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                         FwOpcodeType opCode,
+                                                         U32 cmdSeq,
+                                                         Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
-void QueuedSyncProductsComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                                 FwDpIdType id,
+                                                                 const Fw::Buffer& buffer,
+                                                                 const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->productRecvIn_handler(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+    // Call handler function
+    this->productRecvIn_handler(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
@@ -2236,941 +1411,561 @@ void QueuedSyncProductsComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSyncProductsComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedSyncProductsComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedSyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedSyncProductsComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedSyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedSyncProductsComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedSyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                              AliasPrim1 u32,
+                                                                              AliasPrim2 f32,
+                                                                              AliasBool b,
+                                                                              const Fw::StringBase& str2,
+                                                                              const AliasEnum& e,
+                                                                              const AliasArray& a,
+                                                                              const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                    AliasPrim1 u32,
+                                                                                    AliasPrim2 f32,
+                                                                                    AliasBool b,
+                                                                                    const Fw::StringBase& str2,
+                                                                                    const AliasEnum& e,
+                                                                                    const AliasArray& a,
+                                                                                    const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                    U32 u32,
+                                                                    F32 f32,
+                                                                    bool b,
+                                                                    const Fw::StringBase& str1,
+                                                                    const E& e,
+                                                                    const A& a,
+                                                                    const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                           U32 u32,
+                                                                           F32 f32,
+                                                                           bool b,
+                                                                           const Fw::StringBase& str1,
+                                                                           const E& e,
+                                                                           const A& a,
+                                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedSyncProductsComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedSyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedSyncProductsComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedSyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -3181,85 +1976,63 @@ void QueuedSyncProductsComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedSyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedSyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                          U32 u32,
+                                                                          F32 f32,
+                                                                          bool b,
+                                                                          const Fw::StringBase& str1,
+                                                                          const E& e,
+                                                                          const A& a,
+                                                                          const S& s) {
+    // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedSyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                         U32 u32,
+                                                                         F32 f32,
+                                                                         bool b,
+                                                                         const Fw::StringBase& str1,
+                                                                         const E& e,
+                                                                         const A& a,
+                                                                         const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -3268,209 +2041,103 @@ void QueuedSyncProductsComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedSyncProductsComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedSyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                         AliasPrim1 u32,
+                                                         AliasPrim2 f32,
+                                                         AliasBool b,
+                                                         const Fw::StringBase& str2,
+                                                         const AliasEnum& e,
+                                                         const AliasArray& a,
+                                                         const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedSyncProductsComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedSyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                     AliasPrim1 u32,
+                                                                     AliasPrim2 f32,
+                                                                     AliasBool b,
+                                                                     const Fw::StringBase& str2,
+                                                                     const AliasEnum& e,
+                                                                     const AliasArray& a,
+                                                                     const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedSyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedSyncProductsComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
+                                                    U32 u32,
+                                                    F32 f32,
+                                                    bool b,
+                                                    const Fw::StringBase& str1,
+                                                    const E& e,
+                                                    const A& a,
+                                                    const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedSyncProductsComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedSyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str2,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3479,47 +2146,39 @@ F32 QueuedSyncProductsComponentBase ::
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void QueuedSyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedSyncProductsComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedSyncProductsComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3529,887 +2188,516 @@ Fw::Time QueuedSyncProductsComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedSyncProductsComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedSyncProductsComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedSyncProductsComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::BLOCKING,
-    _priority
-  );
-  FW_ASSERT(
-    _msgStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(_msgStatus)
-  );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
-  // Reset to beginning of buffer
-  _msg.resetDeser();
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-  if (_msgType == QUEUEDSYNCPRODUCTS_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == QUEUEDSYNCPRODUCTS_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedSyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    FwOpcodeType opCode,
+                                                    U32 cmdSeq,
+                                                    Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void QueuedSyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            FwDpIdType id,
+                                                            const Fw::Buffer& buffer,
+                                                            const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              AliasPrim1 u32,
+                                                              AliasPrim2 f32,
+                                                              AliasBool b,
+                                                              const Fw::StringBase& str2,
+                                                              const AliasEnum& e,
+                                                              const AliasArray& a,
+                                                              const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                                FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedSyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedSyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSyncProductsComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedSyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSyncProductsComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedSyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                           FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedSyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                AliasPrim1 u32,
+                                                                AliasPrim2 f32,
+                                                                AliasBool b,
+                                                                const Fw::StringBase& str2,
+                                                                const AliasEnum& e,
+                                                                const AliasArray& a,
+                                                                const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedSyncProductsComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedSyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                         FwIndexType portNum,
+                                                                         AliasPrim1 u32,
+                                                                         AliasPrim2 f32,
+                                                                         AliasBool b,
+                                                                         const Fw::StringBase& str2,
+                                                                         const AliasEnum& e,
+                                                                         const AliasArray& a,
+                                                                         const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedSyncProductsComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedSyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                               FwIndexType portNum,
+                                                                               AliasPrim1 u32,
+                                                                               AliasPrim2 f32,
+                                                                               AliasBool b,
+                                                                               const Fw::StringBase& str2,
+                                                                               const AliasEnum& e,
+                                                                               const AliasArray& a,
+                                                                               const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                         FwIndexType portNum,
+                                                         U32 u32,
+                                                         F32 f32,
+                                                         bool b,
+                                                         const Fw::StringBase& str1,
+                                                         const E& e,
+                                                         const A& a,
+                                                         const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                               FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str1,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                      FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                     FwIndexType portNum,
+                                                                     U32 u32,
+                                                                     F32 f32,
+                                                                     bool b,
+                                                                     const Fw::StringBase& str1,
+                                                                     const E& e,
+                                                                     const A& a,
+                                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedSyncProductsComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedSyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                                FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str2,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedSyncProductsComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedSyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str2,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedSyncProductsComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedSyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    FW_ASSERT(callComp);
+    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4418,68 +2706,32 @@ void QueuedSyncProductsComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  productRequestOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productRequestOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productRequestOut_OutputPort[portNum].invoke(
-    id,
-    dataSize
-  );
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
 }
 
-void QueuedSyncProductsComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
+                                                          FwDpIdType id,
+                                                          const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
-void QueuedSyncProductsComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedSyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
 #endif
@@ -4488,71 +2740,58 @@ void QueuedSyncProductsComponentBase ::
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::
-  dpRequest(
-      ContainerId::T containerId,
-      FwSizeType dataSize
-  )
-{
-  const FwDpIdType globalId = this->getIdBase() + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  this->productRequestOut_out(0, globalId, size);
+void QueuedSyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+    const FwDpIdType globalId = this->getIdBase() + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedSyncProductsComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  DpContainer container;
-  if (status == Fw::Success::SUCCESS) {
-    container = DpContainer(id, buffer, this->getIdBase());
-  }
-  // Convert global id to local id
-  const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(
-    id >= idBase,
-    static_cast<FwAssertArgType>(id),
-    static_cast<FwAssertArgType>(idBase)
-  );
-  const FwDpIdType localId = id - idBase;
-  // Switch on the local id
-  switch (localId) {
-    case ContainerId::Container1:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container1);
-      // Call the handler
-      this->dpRecv_Container1_handler(container, status.e);
-      break;
-    case ContainerId::Container2:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container2);
-      // Call the handler
-      this->dpRecv_Container2_handler(container, status.e);
-      break;
-    case ContainerId::Container3:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container3);
-      // Call the handler
-      this->dpRecv_Container3_handler(container, status.e);
-      break;
-    case ContainerId::Container4:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container4);
-      // Call the handler
-      this->dpRecv_Container4_handler(container, status.e);
-      break;
-    case ContainerId::Container5:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container5);
-      // Call the handler
-      this->dpRecv_Container5_handler(container, status.e);
-      break;
-    default:
-      FW_ASSERT(0);
-      break;
-  }
+void QueuedSyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                             FwDpIdType id,
+                                                             const Fw::Buffer& buffer,
+                                                             const Fw::Success& status) {
+    DpContainer container;
+    if (status == Fw::Success::SUCCESS) {
+        container = DpContainer(id, buffer, this->getIdBase());
+    }
+    // Convert global id to local id
+    const FwDpIdType idBase = this->getIdBase();
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    const FwDpIdType localId = id - idBase;
+    // Switch on the local id
+    switch (localId) {
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
+    }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedSyncProductsComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDSYNCPRODUCTS_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,783 +20,1216 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedSyncProductsComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+QueuedSyncProductsComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-QueuedSyncProductsComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_DataArrayRecord(
-    const QueuedSyncProducts_Data* array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+QueuedSyncProductsComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const QueuedSyncProducts_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_DataRecord(
-    const QueuedSyncProducts_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const QueuedSyncProducts_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_StringRecord(
-    const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                                  FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                                 FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::ActiveComponentBase::init(instance);
+void QueuedSyncProductsComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::ActiveComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -805,17 +1238,26 @@ void QueuedSyncProductsComponentBase ::init(FwSizeType queueDepth, FwEnumStoreTy
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedSyncProductsComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedSyncProductsComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedSyncProductsComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* QueuedSyncProductsComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -826,140 +1268,213 @@ Fw::InputDpResponsePort* QueuedSyncProductsComponentBase ::get_productRecvIn_Inp
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedSyncProductsComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedSyncProductsComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedSyncProductsComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedSyncProductsComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedSyncProductsComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedSyncProductsComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedSyncProductsComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedSyncProductsComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedSyncProductsComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedSyncProductsComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedSyncProductsComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedSyncProductsComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedSyncProductsComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -970,78 +1485,148 @@ Ports::InputTypedPort* QueuedSyncProductsComponentBase ::get_typedSync_InputPort
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1052,66 +1637,116 @@ void QueuedSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                      Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                            Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                          Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                     Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1122,72 +1757,134 @@ void QueuedSyncProductsComponentBase ::set_typedReturnOut_OutputPort(FwIndexType
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum,
-                                                                        Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum,
-                                                                     Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedSyncProductsComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedSyncProductsComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1198,24 +1895,46 @@ void QueuedSyncProductsComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1224,10 +1943,18 @@ void QueuedSyncProductsComponentBase ::set_typedOut_OutputPort(FwIndexType portN
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedSyncProductsComponentBase ::QueuedSyncProductsComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName) {}
+QueuedSyncProductsComponentBase ::
+  QueuedSyncProductsComponentBase(const char* compName) :
+    Fw::ActiveComponentBase(compName)
+{
 
-QueuedSyncProductsComponentBase ::~QueuedSyncProductsComponentBase() {}
+}
+
+QueuedSyncProductsComponentBase ::
+  ~QueuedSyncProductsComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1235,76 +1962,118 @@ QueuedSyncProductsComponentBase ::~QueuedSyncProductsComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSyncProductsComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedSyncProductsComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedSyncProductsComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1315,59 +2084,92 @@ bool QueuedSyncProductsComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedSyncProductsComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedSyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedSyncProductsComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1378,31 +2180,47 @@ bool QueuedSyncProductsComponentBase ::isConnected_typedReturnOut_OutputPort(FwI
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                         FwOpcodeType opCode,
-                                                         U32 cmdSeq,
-                                                         Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedSyncProductsComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void QueuedSyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                                 FwDpIdType id,
-                                                                 const Fw::Buffer& buffer,
-                                                                 const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->productRecvIn_handler(portNum, id, buffer, status);
+  // Call handler function
+  this->productRecvIn_handler(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1411,561 +2229,941 @@ void QueuedSyncProductsComponentBase ::productRecvIn_handlerBase(FwIndexType por
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedSyncProductsComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSyncProductsComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSyncProductsComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedSyncProductsComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedSyncProductsComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedSyncProductsComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedSyncProductsComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedSyncProductsComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSyncProductsComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedSyncProductsComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                              AliasPrim1 u32,
-                                                                              AliasPrim2 f32,
-                                                                              AliasBool b,
-                                                                              const Fw::StringBase& str2,
-                                                                              const AliasEnum& e,
-                                                                              const AliasArray& a,
-                                                                              const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedSyncProductsComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedSyncProductsComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                    AliasPrim1 u32,
-                                                                                    AliasPrim2 f32,
-                                                                                    AliasBool b,
-                                                                                    const Fw::StringBase& str2,
-                                                                                    const AliasEnum& e,
-                                                                                    const AliasArray& a,
-                                                                                    const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSyncProductsComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSyncProductsComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                    U32 u32,
-                                                                    F32 f32,
-                                                                    bool b,
-                                                                    const Fw::StringBase& str1,
-                                                                    const E& e,
-                                                                    const A& a,
-                                                                    const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSyncProductsComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                           U32 u32,
-                                                                           F32 f32,
-                                                                           bool b,
-                                                                           const Fw::StringBase& str1,
-                                                                           const E& e,
-                                                                           const A& a,
-                                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSyncProductsComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedSyncProductsComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedSyncProductsComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedSyncProductsComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedSyncProductsComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedSyncProductsComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedSyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1976,63 +3174,85 @@ void QueuedSyncProductsComponentBase ::typedSync_handlerBase(FwIndexType portNum
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    // Default: no-op
+void QueuedSyncProductsComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedSyncProductsComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Default: no-op
+void QueuedSyncProductsComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Default: no-op
+void QueuedSyncProductsComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                          U32 u32,
-                                                                          F32 f32,
-                                                                          bool b,
-                                                                          const Fw::StringBase& str1,
-                                                                          const E& e,
-                                                                          const A& a,
-                                                                          const S& s) {
-    // Default: no-op
+void QueuedSyncProductsComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedSyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                         U32 u32,
-                                                                         F32 f32,
-                                                                         bool b,
-                                                                         const Fw::StringBase& str1,
-                                                                         const E& e,
-                                                                         const A& a,
-                                                                         const S& s) {
-    // Default: no-op
+void QueuedSyncProductsComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2041,103 +3261,209 @@ void QueuedSyncProductsComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndex
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedSyncProductsComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedSyncProductsComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedSyncProductsComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSyncProductsComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedSyncProductsComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                         AliasPrim1 u32,
-                                                         AliasPrim2 f32,
-                                                         AliasBool b,
-                                                         const Fw::StringBase& str2,
-                                                         const AliasEnum& e,
-                                                         const AliasArray& a,
-                                                         const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedSyncProductsComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                     AliasPrim1 u32,
-                                                                     AliasPrim2 f32,
-                                                                     AliasBool b,
-                                                                     const Fw::StringBase& str2,
-                                                                     const AliasEnum& e,
-                                                                     const AliasArray& a,
-                                                                     const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedSyncProductsComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedSyncProductsComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedSyncProductsComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSyncProductsComponentBase ::typedOut_out(FwIndexType portNum,
-                                                    U32 u32,
-                                                    F32 f32,
-                                                    bool b,
-                                                    const Fw::StringBase& str1,
-                                                    const E& e,
-                                                    const A& a,
-                                                    const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedSyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str2,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedSyncProductsComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2146,39 +3472,47 @@ F32 QueuedSyncProductsComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void QueuedSyncProductsComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedSyncProductsComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedSyncProductsComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2188,516 +3522,887 @@ Fw::Time QueuedSyncProductsComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedSyncProductsComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedSyncProductsComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedSyncProductsComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::BLOCKING,
+    _priority
+  );
+  FW_ASSERT(
+    _msgStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(_msgStatus)
+  );
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+  // Reset to beginning of buffer
+  _msg.resetDeser();
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-    if (_msgType == QUEUEDSYNCPRODUCTS_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+  if (_msgType == QUEUEDSYNCPRODUCTS_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    FwOpcodeType opCode,
-                                                    U32 cmdSeq,
-                                                    Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedSyncProductsComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void QueuedSyncProductsComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            FwDpIdType id,
-                                                            const Fw::Buffer& buffer,
-                                                            const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void QueuedSyncProductsComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              AliasPrim1 u32,
-                                                              AliasPrim2 f32,
-                                                              AliasBool b,
-                                                              const Fw::StringBase& str2,
-                                                              const AliasEnum& e,
-                                                              const AliasArray& a,
-                                                              const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedSyncProductsComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                                FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSyncProductsComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedSyncProductsComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedSyncProductsComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSyncProductsComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedSyncProductsComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedSyncProductsComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedSyncProductsComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedSyncProductsComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                           FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedSyncProductsComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedSyncProductsComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedSyncProductsComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                AliasPrim1 u32,
-                                                                AliasPrim2 f32,
-                                                                AliasBool b,
-                                                                const Fw::StringBase& str2,
-                                                                const AliasEnum& e,
-                                                                const AliasArray& a,
-                                                                const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedSyncProductsComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                         FwIndexType portNum,
-                                                                         AliasPrim1 u32,
-                                                                         AliasPrim2 f32,
-                                                                         AliasBool b,
-                                                                         const Fw::StringBase& str2,
-                                                                         const AliasEnum& e,
-                                                                         const AliasArray& a,
-                                                                         const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedSyncProductsComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedSyncProductsComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                               FwIndexType portNum,
-                                                                               AliasPrim1 u32,
-                                                                               AliasPrim2 f32,
-                                                                               AliasBool b,
-                                                                               const Fw::StringBase& str2,
-                                                                               const AliasEnum& e,
-                                                                               const AliasArray& a,
-                                                                               const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedSyncProductsComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSyncProductsComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                         FwIndexType portNum,
-                                                         U32 u32,
-                                                         F32 f32,
-                                                         bool b,
-                                                         const Fw::StringBase& str1,
-                                                         const E& e,
-                                                         const A& a,
-                                                         const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSyncProductsComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                               FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str1,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSyncProductsComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                      FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSyncProductsComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                     FwIndexType portNum,
-                                                                     U32 u32,
-                                                                     F32 f32,
-                                                                     bool b,
-                                                                     const Fw::StringBase& str1,
-                                                                     const E& e,
-                                                                     const A& a,
-                                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSyncProductsComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedSyncProductsComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                                FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str2,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedSyncProductsComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedSyncProductsComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str2,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedSyncProductsComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedSyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    FW_ASSERT(callComp);
-    QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedSyncProductsComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2706,32 +4411,68 @@ void QueuedSyncProductsComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::productRequestOut_out(FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  productRequestOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+  FW_ASSERT(
+    this->m_productRequestOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productRequestOut_OutputPort[portNum].invoke(
+    id,
+    dataSize
+  );
 }
 
-void QueuedSyncProductsComponentBase ::productSendOut_out(FwIndexType portNum,
-                                                          FwDpIdType id,
-                                                          const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
-void QueuedSyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedSyncProductsComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
 #endif
@@ -2740,58 +4481,71 @@ void QueuedSyncProductsComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::T
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedSyncProductsComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
-    const FwDpIdType globalId = this->getIdBase() + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    this->productRequestOut_out(0, globalId, size);
+void QueuedSyncProductsComponentBase ::
+  dpRequest(
+      ContainerId::T containerId,
+      FwSizeType dataSize
+  )
+{
+  const FwDpIdType globalId = this->getIdBase() + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedSyncProductsComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                             FwDpIdType id,
-                                                             const Fw::Buffer& buffer,
-                                                             const Fw::Success& status) {
-    DpContainer container;
-    if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
-    }
-    // Convert global id to local id
-    const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
-    const FwDpIdType localId = id - idBase;
-    // Switch on the local id
-    switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
-    }
+void QueuedSyncProductsComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  DpContainer container;
+  if (status == Fw::Success::SUCCESS) {
+    container = DpContainer(id, buffer, this->getIdBase());
+  }
+  // Convert global id to local id
+  const FwDpIdType idBase = this->getIdBase();
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
+  const FwDpIdType localId = id - idBase;
+  // Switch on the local id
+  switch (localId) {
+    case ContainerId::Container1:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container1);
+      // Call the handler
+      this->dpRecv_Container1_handler(container, status.e);
+      break;
+    case ContainerId::Container2:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container2);
+      // Call the handler
+      this->dpRecv_Container2_handler(container, status.e);
+      break;
+    case ContainerId::Container3:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container3);
+      // Call the handler
+      this->dpRecv_Container3_handler(container, status.e);
+      break;
+    case ContainerId::Container4:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container4);
+      // Call the handler
+      this->dpRecv_Container4_handler(container, status.e);
+      break;
+    case ContainerId::Container5:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container5);
+      // Call the handler
+      this->dpRecv_Container5_handler(container, status.e);
+      break;
+    default:
+      FW_ASSERT(0);
+      break;
+  }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedTelemetryComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDTELEMETRY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,933 +20,575 @@ namespace {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-  };
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedTelemetryComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -955,15 +597,10 @@ void QueuedTelemetryComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedTelemetryComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedTelemetryComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -974,213 +611,140 @@ Fw::InputCmdPort* QueuedTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedTelemetryComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedTelemetryComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedTelemetryComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedTelemetryComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedTelemetryComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedTelemetryComponentBase ::get_typedAliasReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedTelemetryComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedTelemetryComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1191,120 +755,62 @@ Ports::InputTypedPort* QueuedTelemetryComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTelemetryComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedTelemetryComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1315,116 +821,66 @@ void QueuedTelemetryComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
+                                                                   Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                         Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
+                                                                 Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                       Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_typedAliasReturnStringOut_OutputPort(
+    FwIndexType portNum,
+    Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
+                                                                  Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1435,106 +891,55 @@ void QueuedTelemetryComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTelemetryComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedTelemetryComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1545,46 +950,24 @@ void QueuedTelemetryComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1593,18 +976,9 @@ void QueuedTelemetryComponentBase ::
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedTelemetryComponentBase ::
-  QueuedTelemetryComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
+QueuedTelemetryComponentBase ::QueuedTelemetryComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
 
-}
-
-QueuedTelemetryComponentBase ::
-  ~QueuedTelemetryComponentBase()
-{
-
-}
+QueuedTelemetryComponentBase ::~QueuedTelemetryComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1612,96 +986,62 @@ QueuedTelemetryComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1712,92 +1052,59 @@ bool QueuedTelemetryComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTelemetryComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1808,24 +1115,19 @@ bool QueuedTelemetryComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedTelemetryComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                      FwOpcodeType opCode,
+                                                      U32 cmdSeq,
+                                                      Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
-
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        default:
+            // Unknown opcode: ignore it
+            break;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1834,941 +1136,561 @@ void QueuedTelemetryComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                                AliasPrim1 u32,
+                                                                AliasPrim2 f32,
+                                                                AliasBool b,
+                                                                const Fw::StringBase& str2,
+                                                                const AliasEnum& e,
+                                                                const AliasArray& a,
+                                                                const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTelemetryComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTelemetryComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTelemetryComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedTelemetryComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedTelemetryComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedTelemetryComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedTelemetryComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTelemetryComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTelemetryComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedTelemetryComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedTelemetryComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                           AliasPrim1 u32,
+                                                                           AliasPrim2 f32,
+                                                                           AliasBool b,
+                                                                           const Fw::StringBase& str2,
+                                                                           const AliasEnum& e,
+                                                                           const AliasArray& a,
+                                                                           const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTelemetryComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                                 AliasPrim1 u32,
+                                                                                 AliasPrim2 f32,
+                                                                                 AliasBool b,
+                                                                                 const Fw::StringBase& str2,
+                                                                                 const AliasEnum& e,
+                                                                                 const AliasArray& a,
+                                                                                 const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                        U32 u32,
+                                                                        F32 f32,
+                                                                        bool b,
+                                                                        const Fw::StringBase& str1,
+                                                                        const E& e,
+                                                                        const A& a,
+                                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTelemetryComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedTelemetryComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedTelemetryComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedTelemetryComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedTelemetryComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                               U32 u32,
+                                                               F32 f32,
+                                                               bool b,
+                                                               const Fw::StringBase& str2,
+                                                               const E& e,
+                                                               const A& a,
+                                                               const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTelemetryComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -2779,85 +1701,63 @@ void QueuedTelemetryComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedTelemetryComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                               AliasPrim1 u32,
+                                                               AliasPrim2 f32,
+                                                               AliasBool b,
+                                                               const Fw::StringBase& str2,
+                                                               const AliasEnum& e,
+                                                               const AliasArray& a,
+                                                               const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedTelemetryComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTelemetryComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str1,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTelemetryComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                                U32 u32,
+                                                                F32 f32,
+                                                                bool b,
+                                                                const Fw::StringBase& str1,
+                                                                const E& e,
+                                                                const A& a,
+                                                                const S& s) {
+    // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTelemetryComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                       U32 u32,
+                                                                       F32 f32,
+                                                                       bool b,
+                                                                       const Fw::StringBase& str1,
+                                                                       const E& e,
+                                                                       const A& a,
+                                                                       const S& s) {
+    // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTelemetryComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                      U32 u32,
+                                                                      F32 f32,
+                                                                      bool b,
+                                                                      const Fw::StringBase& str1,
+                                                                      const E& e,
+                                                                      const A& a,
+                                                                      const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2866,209 +1766,103 @@ void QueuedTelemetryComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedTelemetryComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedTelemetryComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTelemetryComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedTelemetryComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                      AliasPrim1 u32,
+                                                      AliasPrim2 f32,
+                                                      AliasBool b,
+                                                      const Fw::StringBase& str2,
+                                                      const AliasEnum& e,
+                                                      const AliasArray& a,
+                                                      const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedTelemetryComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedTelemetryComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                                  AliasPrim1 u32,
+                                                                  AliasPrim2 f32,
+                                                                  AliasBool b,
+                                                                  const Fw::StringBase& str2,
+                                                                  const AliasEnum& e,
+                                                                  const AliasArray& a,
+                                                                  const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTelemetryComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                        AliasPrim1 u32,
+                                                                        AliasPrim2 f32,
+                                                                        AliasBool b,
+                                                                        const Fw::StringBase& str2,
+                                                                        const AliasEnum& e,
+                                                                        const AliasArray& a,
+                                                                        const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedTelemetryComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::typedOut_out(FwIndexType portNum,
+                                                 U32 u32,
+                                                 F32 f32,
+                                                 bool b,
+                                                 const Fw::StringBase& str1,
+                                                 const E& e,
+                                                 const A& a,
+                                                 const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedTelemetryComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedTelemetryComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str2,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -3077,364 +1871,196 @@ F32 QueuedTelemetryComponentBase ::
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  tlmWrite(
-      FwChanIdType id,
-      Fw::TlmBuffer& _tlmBuff,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    if (
-      this->isConnected_timeGetOut_OutputPort(0) &&
-      (_tlmTime ==  Fw::ZERO_TIME)
-    ) {
-      this->timeGetOut_out(0, _tlmTime);
+void QueuedTelemetryComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
+            this->timeGetOut_out(0, _tlmTime);
+        }
+
+        FwChanIdType _id;
+        _id = this->getIdBase() + id;
+
+        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
     }
-
-    FwChanIdType _id;
-    _id = this->getIdBase() + id;
-
-    this->tlmOut_out(
-      0,
-      _id,
-      _tlmTime,
-      _tlmBuff
-    );
-  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelU32Format(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-    this->tlmWrite(
-      CHANNELID_CHANNELU32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelF32Format(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelStringFormat(
-      const Fw::StringBase& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serializeTo(
-      _tlmBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRINGFORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelEnum(
-      const E& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUM,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelArrayFreq(
-      const A& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELARRAYFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelStructFreq(
-      const S& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRUCTFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelU32Limits(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelF32Limits(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelF64(
-      F64 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF64,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelU32OnChange(
-      U32 arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelU32OnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelU32OnChange) {
-      return;
+        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
     }
-    else {
-      this->m_last_ChannelU32OnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelU32OnChange = false;
-    this->m_last_ChannelU32OnChange = arg;
-  }
-
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32ONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
 }
 
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelEnumOnChange(
-      const E& arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelEnumOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelEnumOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelEnumOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelEnumOnChange = false;
-    this->m_last_ChannelEnumOnChange = arg;
-  }
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUMONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
+    }
 }
 
-void QueuedTelemetryComponentBase ::
-  tlmWrite_ChannelBoolOnChange(
-      bool arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelBoolOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelBoolOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelBoolOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelBoolOnChange = false;
-    this->m_last_ChannelBoolOnChange = arg;
-  }
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat =
+            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
+                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
+    }
+}
 
-    this->tlmWrite(
-      CHANNELID_CHANNELBOOLONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelU32OnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelU32OnChange) {
+            return;
+        } else {
+            this->m_last_ChannelU32OnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelU32OnChange = false;
+        this->m_last_ChannelU32OnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelEnumOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelEnumOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelEnumOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelEnumOnChange = false;
+        this->m_last_ChannelEnumOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTelemetryComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelBoolOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelBoolOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelBoolOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelBoolOnChange = false;
+        this->m_last_ChannelBoolOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedTelemetryComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedTelemetryComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -3444,892 +2070,526 @@ Fw::Time QueuedTelemetryComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedTelemetryComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedTelemetryComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedTelemetryComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDTELEMETRY_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      break;
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+    if (_msgType == QUEUEDTELEMETRY_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    switch (_msgType) {
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedTelemetryComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                                 FwIndexType portNum,
+                                                 FwOpcodeType opCode,
+                                                 U32 cmdSeq,
+                                                 Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                           FwIndexType portNum,
+                                                           AliasPrim1 u32,
+                                                           AliasPrim2 f32,
+                                                           AliasBool b,
+                                                           const Fw::StringBase& str2,
+                                                           const AliasEnum& e,
+                                                           const AliasArray& a,
+                                                           const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTelemetryComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                             FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedTelemetryComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedTelemetryComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTelemetryComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedTelemetryComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTelemetryComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedTelemetryComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTelemetryComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedTelemetryComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedTelemetryComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedTelemetryComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                      FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedTelemetryComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedTelemetryComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                            FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                            FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                                  FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedTelemetryComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedTelemetryComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str2,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedTelemetryComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedTelemetryComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                          FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedTelemetryComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTelemetryComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4338,48 +2598,22 @@ void QueuedTelemetryComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
-void QueuedTelemetryComponentBase ::
-  tlmOut_out(
-      FwIndexType portNum,
-      FwChanIdType id,
-      Fw::Time& timeTag,
-      Fw::TlmBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTelemetryComponentBase ::tlmOut_out(FwIndexType portNum,
+                                               FwChanIdType id,
+                                               Fw::Time& timeTag,
+                                               Fw::TlmBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_tlmOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_tlmOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    val
-  );
+    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -50,9 +50,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedTelemetryComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDTELEMETRY_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     ALIASTYPEDASYNC_ALIASTYPED,
     NOARGSASYNC_NOARGS,
@@ -20,575 +20,926 @@ enum MsgTypeEnum {
     TYPEDASYNCASSERT_TYPED,
     TYPEDASYNCBLOCKPRIORITY_TYPED,
     TYPEDASYNCDROPPRIORITY_TYPED,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncAssertPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncBlockPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
-};
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedTelemetryComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -597,10 +948,15 @@ void QueuedTelemetryComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType 
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedTelemetryComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedTelemetryComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
 #endif
@@ -611,140 +967,213 @@ Fw::InputCmdPort* QueuedTelemetryComponentBase ::get_cmdIn_InputPort(FwIndexType
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedTelemetryComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedTelemetryComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedTelemetryComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedTelemetryComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedTelemetryComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedTelemetryComponentBase ::get_typedAliasReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedTelemetryComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedTelemetryComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedTelemetryComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -755,62 +1184,120 @@ Ports::InputTypedPort* QueuedTelemetryComponentBase ::get_typedSync_InputPort(Fw
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -821,66 +1308,116 @@ void QueuedTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, F
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum,
-                                                                   Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                         Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum,
-                                                                 Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                       Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_typedAliasReturnStringOut_OutputPort(
-    FwIndexType portNum,
-    Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum,
-                                                                  Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -891,55 +1428,106 @@ void QueuedTelemetryComponentBase ::set_typedReturnOut_OutputPort(FwIndexType po
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTelemetryComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedTelemetryComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -950,24 +1538,46 @@ void QueuedTelemetryComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, F
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -976,9 +1586,18 @@ void QueuedTelemetryComponentBase ::set_typedOut_OutputPort(FwIndexType portNum,
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedTelemetryComponentBase ::QueuedTelemetryComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {}
+QueuedTelemetryComponentBase ::
+  QueuedTelemetryComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
 
-QueuedTelemetryComponentBase ::~QueuedTelemetryComponentBase() {}
+}
+
+QueuedTelemetryComponentBase ::
+  ~QueuedTelemetryComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -986,62 +1605,96 @@ QueuedTelemetryComponentBase ::~QueuedTelemetryComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTelemetryComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedTelemetryComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedTelemetryComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1052,59 +1705,92 @@ bool QueuedTelemetryComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType po
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTelemetryComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTelemetryComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTelemetryComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1115,19 +1801,24 @@ bool QueuedTelemetryComponentBase ::isConnected_typedReturnOut_OutputPort(FwInde
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                      FwOpcodeType opCode,
-                                                      U32 cmdSeq,
-                                                      Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedTelemetryComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        default:
-            // Unknown opcode: ignore it
-            break;
-    }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -1136,561 +1827,941 @@ void QueuedTelemetryComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                                AliasPrim1 u32,
-                                                                AliasPrim2 f32,
-                                                                AliasBool b,
-                                                                const Fw::StringBase& str2,
-                                                                const AliasEnum& e,
-                                                                const AliasArray& a,
-                                                                const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedTelemetryComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTelemetryComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTelemetryComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTelemetryComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedTelemetryComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedTelemetryComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedTelemetryComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedTelemetryComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedTelemetryComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTelemetryComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTelemetryComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedTelemetryComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedTelemetryComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                           AliasPrim1 u32,
-                                                                           AliasPrim2 f32,
-                                                                           AliasBool b,
-                                                                           const Fw::StringBase& str2,
-                                                                           const AliasEnum& e,
-                                                                           const AliasArray& a,
-                                                                           const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedTelemetryComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedTelemetryComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                                 AliasPrim1 u32,
-                                                                                 AliasPrim2 f32,
-                                                                                 AliasBool b,
-                                                                                 const Fw::StringBase& str2,
-                                                                                 const AliasEnum& e,
-                                                                                 const AliasArray& a,
-                                                                                 const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTelemetryComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTelemetryComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTelemetryComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTelemetryComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                        U32 u32,
-                                                                        F32 f32,
-                                                                        bool b,
-                                                                        const Fw::StringBase& str1,
-                                                                        const E& e,
-                                                                        const A& a,
-                                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTelemetryComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTelemetryComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedTelemetryComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedTelemetryComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedTelemetryComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                               U32 u32,
-                                                               F32 f32,
-                                                               bool b,
-                                                               const Fw::StringBase& str2,
-                                                               const E& e,
-                                                               const A& a,
-                                                               const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedTelemetryComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTelemetryComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -1701,63 +2772,85 @@ void QueuedTelemetryComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                               AliasPrim1 u32,
-                                                               AliasPrim2 f32,
-                                                               AliasBool b,
-                                                               const Fw::StringBase& str2,
-                                                               const AliasEnum& e,
-                                                               const AliasArray& a,
-                                                               const AliasStruct& s) {
-    // Default: no-op
+void QueuedTelemetryComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedTelemetryComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str1,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Default: no-op
+void QueuedTelemetryComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                                U32 u32,
-                                                                F32 f32,
-                                                                bool b,
-                                                                const Fw::StringBase& str1,
-                                                                const E& e,
-                                                                const A& a,
-                                                                const S& s) {
-    // Default: no-op
+void QueuedTelemetryComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                       U32 u32,
-                                                                       F32 f32,
-                                                                       bool b,
-                                                                       const Fw::StringBase& str1,
-                                                                       const E& e,
-                                                                       const A& a,
-                                                                       const S& s) {
-    // Default: no-op
+void QueuedTelemetryComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTelemetryComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                      U32 u32,
-                                                                      F32 f32,
-                                                                      bool b,
-                                                                      const Fw::StringBase& str1,
-                                                                      const E& e,
-                                                                      const A& a,
-                                                                      const S& s) {
-    // Default: no-op
+void QueuedTelemetryComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1766,103 +2859,209 @@ void QueuedTelemetryComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexTyp
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedTelemetryComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedTelemetryComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedTelemetryComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTelemetryComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedTelemetryComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                      AliasPrim1 u32,
-                                                      AliasPrim2 f32,
-                                                      AliasBool b,
-                                                      const Fw::StringBase& str2,
-                                                      const AliasEnum& e,
-                                                      const AliasArray& a,
-                                                      const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedTelemetryComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                                  AliasPrim1 u32,
-                                                                  AliasPrim2 f32,
-                                                                  AliasBool b,
-                                                                  const Fw::StringBase& str2,
-                                                                  const AliasEnum& e,
-                                                                  const AliasArray& a,
-                                                                  const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedTelemetryComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedTelemetryComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                        AliasPrim1 u32,
-                                                                        AliasPrim2 f32,
-                                                                        AliasBool b,
-                                                                        const Fw::StringBase& str2,
-                                                                        const AliasEnum& e,
-                                                                        const AliasArray& a,
-                                                                        const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTelemetryComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTelemetryComponentBase ::typedOut_out(FwIndexType portNum,
-                                                 U32 u32,
-                                                 F32 f32,
-                                                 bool b,
-                                                 const Fw::StringBase& str1,
-                                                 const E& e,
-                                                 const A& a,
-                                                 const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedTelemetryComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str2,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedTelemetryComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -1871,196 +3070,364 @@ F32 QueuedTelemetryComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
-            this->timeGetOut_out(0, _tlmTime);
-        }
-
-        FwChanIdType _id;
-        _id = this->getIdBase() + id;
-
-        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
+void QueuedTelemetryComponentBase ::
+  tlmWrite(
+      FwChanIdType id,
+      Fw::TlmBuffer& _tlmBuff,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    if (
+      this->isConnected_timeGetOut_OutputPort(0) &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->timeGetOut_out(0, _tlmTime);
     }
+
+    FwChanIdType _id;
+    _id = this->getIdBase() + id;
+
+    this->tlmOut_out(
+      0,
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelU32Format(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelF32Format(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat =
-            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
-                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelStringFormat(
+      const Fw::StringBase& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = arg.serializeTo(
+      _tlmBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRINGFORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelEnum(
+      const E& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELENUM,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelArrayFreq(
+      const A& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELARRAYFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelStructFreq(
+      const S& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRUCTFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelU32Limits(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelF32Limits(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelF64(
+      F64 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF64,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelU32OnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelU32OnChange) {
-            return;
-        } else {
-            this->m_last_ChannelU32OnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelU32OnChange = false;
-        this->m_last_ChannelU32OnChange = arg;
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelU32OnChange(
+      U32 arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelU32OnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelU32OnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelU32OnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelU32OnChange = false;
+    this->m_last_ChannelU32OnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELU32ONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelEnumOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelEnumOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelEnumOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelEnumOnChange = false;
-        this->m_last_ChannelEnumOnChange = arg;
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelEnumOnChange(
+      const E& arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelEnumOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelEnumOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelEnumOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelEnumOnChange = false;
+    this->m_last_ChannelEnumOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELENUMONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTelemetryComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelBoolOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelBoolOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelBoolOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelBoolOnChange = false;
-        this->m_last_ChannelBoolOnChange = arg;
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELBOOLONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedTelemetryComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedTelemetryComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -2070,526 +3437,892 @@ Fw::Time QueuedTelemetryComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedTelemetryComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedTelemetryComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedTelemetryComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDTELEMETRY_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-    if (_msgType == QUEUEDTELEMETRY_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    switch (_msgType) {
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
 
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                                 FwIndexType portNum,
-                                                 FwOpcodeType opCode,
-                                                 U32 cmdSeq,
-                                                 Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedTelemetryComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                           FwIndexType portNum,
-                                                           AliasPrim1 u32,
-                                                           AliasPrim2 f32,
-                                                           AliasBool b,
-                                                           const Fw::StringBase& str2,
-                                                           const AliasEnum& e,
-                                                           const AliasArray& a,
-                                                           const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedTelemetryComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                             FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTelemetryComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedTelemetryComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedTelemetryComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTelemetryComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedTelemetryComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTelemetryComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedTelemetryComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedTelemetryComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTelemetryComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedTelemetryComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedTelemetryComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedTelemetryComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                      FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedTelemetryComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedTelemetryComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                            FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedTelemetryComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTelemetryComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTelemetryComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                            FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTelemetryComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTelemetryComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                                  FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTelemetryComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedTelemetryComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str2,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedTelemetryComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedTelemetryComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                          FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedTelemetryComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTelemetryComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTelemetryComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2598,22 +4331,48 @@ void QueuedTelemetryComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* c
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTelemetryComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
-void QueuedTelemetryComponentBase ::tlmOut_out(FwIndexType portNum,
-                                               FwChanIdType id,
-                                               Fw::Time& timeTag,
-                                               Fw::TlmBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTelemetryComponentBase ::
+  tlmOut_out(
+      FwIndexType portNum,
+      FwChanIdType id,
+      Fw::Time& timeTag,
+      Fw::TlmBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
+  FW_ASSERT(
+    this->m_tlmOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_tlmOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    val
+  );
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedTestComponentAc.hpp"
 
 namespace {
-  enum MsgTypeEnum {
+enum MsgTypeEnum {
     QUEUEDTEST_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
     ALIASTYPEDASYNC_ALIASTYPED,
@@ -32,11 +32,11 @@ namespace {
     INT_IF_INTERNALPRIORITYDROP,
     INT_IF_INTERNALSTRING,
     INT_IF_INTERNALSTRUCT,
-  };
+};
 
-  // Get the max size by constructing a union of the async input, command, and
-  // internal port serialization sizes
-  union BuffUnion {
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -45,1234 +45,779 @@ namespace {
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
     // Size of internalArray argument list
-    BYTE internalArrayIntIfSize[
-      A::SERIALIZED_SIZE
-    ];
+    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
     // Size of internalEnum argument list
-    BYTE internalEnumIntIfSize[
-      E::SERIALIZED_SIZE
-    ];
+    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
     // Size of internalPrimitive argument list
-    BYTE internalPrimitiveIntIfSize[
-      sizeof(U32) +
-      sizeof(F32) +
-      sizeof(U8)
-    ];
+    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
     // Size of internalString argument list
-    BYTE internalStringIntIfSize[
-      Fw::InternalInterfaceString::SERIALIZED_SIZE +
-      Fw::InternalInterfaceString::SERIALIZED_SIZE
-    ];
+    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
+                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
     // Size of internalStruct argument list
-    BYTE internalStructIntIfSize[
-      S::SERIALIZED_SIZE
-    ];
-  };
+    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
+};
 
-  // Define a message buffer class large enough to handle all the
-  // asynchronous inputs to the component
-  class ComponentIpcSerializableBuffer :
-    public Fw::LinearBufferBase
-  {
-
-    public:
-
-      enum {
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-      };
+    };
 
-      Fw::Serializable::SizeType getCapacity() const {
-        return sizeof(m_buff);
-      }
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
+    }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
-
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
-
-    private:
-      // Should be the max of all the input ports serialized sizes...
-      U8 m_buff[SERIALIZATION_SIZE];
-
-  };
-}
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedTestComponentBase::DpContainer ::
-  DpContainer(
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      FwDpIdType baseId
-  ) :
-    Fw::DpContainer(id, buffer),
-    m_baseId(baseId)
-{
+QueuedTestComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
+    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
 
-}
+QueuedTestComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
 
-QueuedTestComponentBase::DpContainer ::
-  DpContainer() :
-    Fw::DpContainer(),
-    m_baseId(0)
-{
-
-}
-
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
-  serializeRecord_DataArrayRecord(
-      const QueuedTest_Data* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    sizeDelta += array[i].serializedSize();
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_DataArrayRecord(const QueuedTest_Data* array,
+                                                                                           FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        sizeDelta += array[i].serializedSize();
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
-  serializeRecord_DataRecord(const QueuedTest_Data& elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedSize();
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_DataRecord(const QueuedTest_Data& elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
-  serializeRecord_StringArrayRecord(
-      const Fw::StringBase** array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType);
-  for (FwSizeType i = 0; i < size; i++) {
-    const Fw::StringBase *const sbPtr = array[i];
-    FW_ASSERT(sbPtr != nullptr);
-    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
-  }
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
+    const Fw::StringBase** array,
+    FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
     for (FwSizeType i = 0; i < size; i++) {
-      const Fw::StringBase *const sbPtr = array[i];
-      FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        const Fw::StringBase* const sbPtr = array[i];
+        FW_ASSERT(sbPtr != nullptr);
+        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
-  serializeRecord_StringRecord(const Fw::StringBase& elt)
-{
-  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    elt.serializedTruncatedSize(stringSize);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serializeTo(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
-}
-
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
-  serializeRecord_U32ArrayRecord(
-      const U32* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U32);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serializeFrom(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            const Fw::StringBase* const sbPtr = array[i];
+            FW_ASSERT(sbPtr != nullptr);
+            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
     }
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+    return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
-  serializeRecord_U32Record(U32 elt)
-{
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(U32);
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_StringRecord(const Fw::StringBase& elt) {
+    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = elt.serializeTo(this->m_dataBuffer, stringSize);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
-  serializeRecord_U8ArrayRecord(
-      const U8* array,
-      FwSizeType size
-  )
-{
-  FW_ASSERT(array != nullptr);
-  // Compute the size delta
-  const FwSizeType sizeDelta =
-    sizeof(FwDpIdType) +
-    sizeof(FwSizeStoreType) +
-    size * sizeof(U8);
-  // Serialize the elements if they will fit
-  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serializeFrom(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    this->m_dataSize += sizeDelta;
-  }
-  else {
-    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-  }
-  return status;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
+                                                                                          FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        for (FwSizeType i = 0; i < size; i++) {
+            status = this->m_dataBuffer.serializeFrom(array[i]);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        }
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(elt);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
+}
+
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
+                                                                                         FwSizeType size) {
+    FW_ASSERT(array != nullptr);
+    // Compute the size delta
+    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
+    // Serialize the elements if they will fit
+    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+        status = this->m_dataBuffer.serializeFrom(id);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeSize(size);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        this->m_dataSize += sizeDelta;
+    } else {
+        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+    }
+    return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  init(
-      FwSizeType queueDepth,
-      FwEnumStoreType instance
-  )
-{
-  // Initialize base class
-  Fw::QueuedComponentBase::init(instance);
+void QueuedTestComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+    // Initialize base class
+    Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port cmdIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
-    port++
-  ) {
-    this->m_cmdIn_InputPort[port].init();
-    this->m_cmdIn_InputPort[port].addCallComp(
-      this,
-      m_p_cmdIn_in
-    );
-    this->m_cmdIn_InputPort[port].setPortNum(port);
+    // Connect input port cmdIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
+        this->m_cmdIn_InputPort[port].init();
+        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
+        this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port productRecvIn
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
-    port++
-  ) {
-    this->m_productRecvIn_InputPort[port].init();
-    this->m_productRecvIn_InputPort[port].addCallComp(
-      this,
-      m_p_productRecvIn_in
-    );
-    this->m_productRecvIn_InputPort[port].setPortNum(port);
+    // Connect input port productRecvIn
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
+        this->m_productRecvIn_InputPort[port].init();
+        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
+        this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port aliasTypedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
-    port++
-  ) {
-    this->m_aliasTypedAsync_InputPort[port].init();
-    this->m_aliasTypedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_aliasTypedAsync_in
-    );
-    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
+    // Connect input port aliasTypedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
+        this->m_aliasTypedAsync_InputPort[port].init();
+        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
+        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAliasStringReturnSync_in
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsAsync_InputPort[port].init();
-    this->m_noArgsAsync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsAsync_in
-    );
-    this->m_noArgsAsync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
+        this->m_noArgsAsync_InputPort[port].init();
+        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
+        this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsGuarded_InputPort[port].init();
-    this->m_noArgsGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsGuarded_in
-    );
-    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
+        this->m_noArgsGuarded_InputPort[port].init();
+        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
+        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnGuarded_InputPort[port].init();
-    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnGuarded_in
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
+        this->m_noArgsReturnGuarded_InputPort[port].init();
+        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
+        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnSync_InputPort[port].init();
-    this->m_noArgsReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsReturnSync_in
-    );
-    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
+        this->m_noArgsReturnSync_InputPort[port].init();
+        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
+        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnSync_InputPort[port].init();
-    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsStringReturnSync_in
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+         port++) {
+        this->m_noArgsStringReturnSync_InputPort[port].init();
+        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
+        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port noArgsSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
-    port++
-  ) {
-    this->m_noArgsSync_InputPort[port].init();
-    this->m_noArgsSync_InputPort[port].addCallComp(
-      this,
-      m_p_noArgsSync_in
-    );
-    this->m_noArgsSync_InputPort[port].setPortNum(port);
+    // Connect input port noArgsSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
+        this->m_noArgsSync_InputPort[port].init();
+        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
+        this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasGuarded_InputPort[port].init();
-    this->m_typedAliasGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasGuarded_in
-    );
-    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
+        this->m_typedAliasGuarded_InputPort[port].init();
+        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
+        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnSync_InputPort[port].init();
-    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasReturnSync_in
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasReturnSync_InputPort[port].init();
+        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
+        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAliasStringReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedAliasStringReturnSync_InputPort[port].init();
-    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAliasStringReturnSync_in
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedAliasStringReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+         port++) {
+        this->m_typedAliasStringReturnSync_InputPort[port].init();
+        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
+        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
-    port++
-  ) {
-    this->m_typedAsync_InputPort[port].init();
-    this->m_typedAsync_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsync_in
-    );
-    this->m_typedAsync_InputPort[port].setPortNum(port);
+    // Connect input port typedAsync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
+        this->m_typedAsync_InputPort[port].init();
+        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
+        this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncAssert
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncAssert_InputPort[port].init();
-    this->m_typedAsyncAssert_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncAssert_in
-    );
-    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncAssert
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
+        this->m_typedAsyncAssert_InputPort[port].init();
+        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
+        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncBlockPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncBlockPriority_InputPort[port].init();
-    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncBlockPriority_in
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncBlockPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncBlockPriority_InputPort[port].init();
+        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
+        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedAsyncDropPriority
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-    port++
-  ) {
-    this->m_typedAsyncDropPriority_InputPort[port].init();
-    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
-      this,
-      m_p_typedAsyncDropPriority_in
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+    // Connect input port typedAsyncDropPriority
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+         port++) {
+        this->m_typedAsyncDropPriority_InputPort[port].init();
+        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
+        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedGuarded_InputPort[port].init();
-    this->m_typedGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedGuarded_in
-    );
-    this->m_typedGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
+        this->m_typedGuarded_InputPort[port].init();
+        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
+        this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnGuarded
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnGuarded_InputPort[port].init();
-    this->m_typedReturnGuarded_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnGuarded_in
-    );
-    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnGuarded
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
+        this->m_typedReturnGuarded_InputPort[port].init();
+        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
+        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedReturnSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
-    port++
-  ) {
-    this->m_typedReturnSync_InputPort[port].init();
-    this->m_typedReturnSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedReturnSync_in
-    );
-    this->m_typedReturnSync_InputPort[port].setPortNum(port);
+    // Connect input port typedReturnSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
+        this->m_typedReturnSync_InputPort[port].init();
+        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
+        this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect input port typedSync
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
-    port++
-  ) {
-    this->m_typedSync_InputPort[port].init();
-    this->m_typedSync_InputPort[port].addCallComp(
-      this,
-      m_p_typedSync_in
-    );
-    this->m_typedSync_InputPort[port].setPortNum(port);
+    // Connect input port typedSync
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
+        this->m_typedSync_InputPort[port].init();
+        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
+        this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdRegOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdRegOut_OutputPort[port].init();
+    // Connect output port cmdRegOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
+        this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port cmdResponseOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
-    port++
-  ) {
-    this->m_cmdResponseOut_OutputPort[port].init();
+    // Connect output port cmdResponseOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
+        this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port eventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
-    port++
-  ) {
-    this->m_eventOut_OutputPort[port].init();
+    // Connect output port eventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
+        this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmGetOut_OutputPort[port].init();
+    // Connect output port prmGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
+        this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port prmSetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
-    port++
-  ) {
-    this->m_prmSetOut_OutputPort[port].init();
+    // Connect output port prmSetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
+        this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productRequestOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
-    port++
-  ) {
-    this->m_productRequestOut_OutputPort[port].init();
+    // Connect output port productRequestOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
+        this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port productSendOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
-    port++
-  ) {
-    this->m_productSendOut_OutputPort[port].init();
+    // Connect output port productSendOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
+        this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-  // Connect output port textEventOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
-    port++
-  ) {
-    this->m_textEventOut_OutputPort[port].init();
+    // Connect output port textEventOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
+        this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port timeGetOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
-    port++
-  ) {
-    this->m_timeGetOut_OutputPort[port].init();
+    // Connect output port timeGetOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
+        this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port tlmOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
-    port++
-  ) {
-    this->m_tlmOut_OutputPort[port].init();
+    // Connect output port tlmOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
+        this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsOut_OutputPort[port].init();
+    // Connect output port noArgsOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
+        this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsReturnOut_OutputPort[port].init();
+    // Connect output port noArgsReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
+        this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port noArgsStringReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_noArgsStringReturnOut_OutputPort[port].init();
+    // Connect output port noArgsStringReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+         port++) {
+        this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasOut_OutputPort[port].init();
+    // Connect output port typedAliasOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
+        this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedAliasReturnStringOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedAliasReturnStringOut_OutputPort[port].init();
+    // Connect output port typedAliasReturnStringOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+         port++) {
+        this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
+                        port);
+        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedOut_OutputPort[port].init();
+    // Connect output port typedOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
+        this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-  // Connect output port typedReturnOut
-  for (
-    FwIndexType port = 0;
-    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
-    port++
-  ) {
-    this->m_typedReturnOut_OutputPort[port].init();
+    // Connect output port typedReturnOut
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
+        this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    Fw::ObjectName portName;
-    portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
-      this->m_objName.toChar(),
-      port
-    );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-  }
+    }
 #endif
 
-  // Create the queue
-  Os::Queue::Status qStat = this->createQueue(
-    queueDepth,
-    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-  );
-  FW_ASSERT(
-    Os::Queue::Status::OP_OK == qStat,
-    static_cast<FwAssertArgType>(qStat)
-  );
+    // Create the queue
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -1281,26 +826,17 @@ void QueuedTestComponentBase ::
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedTestComponentBase ::
-  get_cmdIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputCmdPort* QueuedTestComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_cmdIn_InputPort[portNum];
+    return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedTestComponentBase ::
-  get_productRecvIn_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::InputDpResponsePort* QueuedTestComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_productRecvIn_InputPort[portNum];
+    return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -1311,213 +847,139 @@ Fw::InputDpResponsePort* QueuedTestComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedTestComponentBase ::
-  get_aliasTypedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedTestComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_aliasTypedAsync_InputPort[portNum];
+    return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedTestComponentBase ::
-  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsAliasStringReturnPort* QueuedTestComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTestComponentBase ::
-  get_noArgsAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedTestComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsAsync_InputPort[portNum];
+    return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTestComponentBase ::
-  get_noArgsGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedTestComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsGuarded_InputPort[portNum];
+    return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
-  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnGuarded_InputPort[portNum];
+    return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
-  get_noArgsReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsReturnSync_InputPort[portNum];
+    return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedTestComponentBase ::
-  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsStringReturnPort* QueuedTestComponentBase ::get_noArgsStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsStringReturnSync_InputPort[portNum];
+    return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTestComponentBase ::
-  get_noArgsSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputNoArgsPort* QueuedTestComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_noArgsSync_InputPort[portNum];
+    return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedTestComponentBase ::
-  get_typedAliasGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedPort* QueuedTestComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasGuarded_InputPort[portNum];
+    return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedTestComponentBase ::
-  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnPort* QueuedTestComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasReturnSync_InputPort[portNum];
+    return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedTestComponentBase ::
-  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputAliasTypedReturnStringPort* QueuedTestComponentBase ::get_typedAliasStringReturnSync_InputPort(
+    FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::
-  get_typedAsync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsync_InputPort[portNum];
+    return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::
-  get_typedAsyncAssert_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncAssert_InputPort[portNum];
+    return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::
-  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::
-  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedAsyncDropPriority_InputPort[portNum];
+    return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::
-  get_typedGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTestComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedGuarded_InputPort[portNum];
+    return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTestComponentBase ::
-  get_typedReturnGuarded_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnGuarded_InputPort[portNum];
+    return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTestComponentBase ::
-  get_typedReturnSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedReturnSync_InputPort[portNum];
+    return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::
-  get_typedSync_InputPort(FwIndexType portNum)
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Ports::InputTypedPort* QueuedTestComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return &this->m_typedSync_InputPort[portNum];
+    return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -1528,148 +990,76 @@ Ports::InputTypedPort* QueuedTestComponentBase ::
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdRegPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputCmdResponsePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].addCallPort(port);
+    this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_prmGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmGetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputPrmSetPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpRequestPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputDpRequestPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputDpSendPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTestComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputLogTextPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedTestComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTimePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputTlmPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1680,116 +1070,62 @@ void QueuedTestComponentBase ::
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_noArgsReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_noArgsStringReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputNoArgsStringReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
+                                                                    Ports::InputNoArgsStringReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_typedAliasReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
+                                                                  Ports::InputAliasTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_typedAliasReturnStringOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputAliasTypedReturnStringPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_typedAliasReturnStringOut_OutputPort(FwIndexType portNum,
+                                                                        Ports::InputAliasTypedReturnStringPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_typedReturnOut_OutputPort(
-      FwIndexType portNum,
-      Ports::InputTypedReturnPort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1800,134 +1136,69 @@ void QueuedTestComponentBase ::
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  set_cmdRegOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_cmdResponseOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_eventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_prmSetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_productRequestOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_productSendOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTestComponentBase ::
-  set_textEventOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedTestComponentBase ::
-  set_timeGetOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_tlmOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1938,46 +1209,24 @@ void QueuedTestComponentBase ::
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  set_noArgsOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_typedAliasOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::
-  set_typedOut_OutputPort(
-      FwIndexType portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1986,586 +1235,368 @@ void QueuedTestComponentBase ::
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  regCommands()
-{
-  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedTestComponentBase ::regCommands() {
+    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_ASYNC
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
 
-  this->cmdRegOut_out(
-    0,
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
-  );
+    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  loadParameters()
-{
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedTestComponentBase ::loadParameters() {
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-  FwPrmIdType _id{};
-  Fw::ParamBuffer _paramBuffer;
+    FwPrmIdType _id{};
+    Fw::ParamBuffer _paramBuffer;
 
-  _id = _baseId + PARAMID_PARAMU32;
+    _id = _baseId + PARAMID_PARAMU32;
 
-  // Get serialized parameter ParamU32
-  this->m_param_ParamU32_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamU32
+    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64;
+    _id = _baseId + PARAMID_PARAMF64;
 
-  // Get serialized parameter ParamF64
-  this->m_param_ParamF64_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamF64
+    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter
+    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRING;
+    _id = _baseId + PARAMID_PARAMSTRING;
 
-  // Get serialized parameter ParamString
-  this->m_param_ParamString_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamString
+    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
-  }
-  else {
-    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamString = Fw::String("default");
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMENUM;
-
-  // Get serialized parameter ParamEnum
-  this->m_param_ParamEnum_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamString = Fw::String("default");
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAY;
+    _id = _baseId + PARAMID_PARAMENUM;
 
-  // Get serialized parameter ParamArray
-  this->m_param_ParamArray_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnum
+    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    // Deserialize parameter
+    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
+        }
     }
-  }
-  else {
-    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-    this->m_ParamArray = A({1, 2, 3});
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCT;
+    _id = _baseId + PARAMID_PARAMARRAY;
 
-  // Get serialized parameter ParamStruct
-  this->m_param_ParamStruct_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamArray
+    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
     }
-  }
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+        this->m_ParamArray = A({1, 2, 3});
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMI32EXT;
+    _id = _baseId + PARAMID_PARAMSTRUCT;
 
-  // Get serialized parameter ParamI32Ext
-  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStruct
+    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMI32EXT,
-    this->m_param_ParamI32Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter
+    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMF64EXT;
+    _id = _baseId + PARAMID_PARAMI32EXT;
 
-  // Get serialized parameter ParamF64Ext
-  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamI32Ext
+    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMF64EXT,
-    this->m_param_ParamF64Ext_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  _id = _baseId + PARAMID_PARAMSTRINGEXT;
-
-  // Get serialized parameter ParamStringExt
-  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-    Fw::String _val = Fw::String("external default");
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMF64EXT;
+
+    // Get serialized parameter ParamF64Ext
+    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMSTRINGEXT,
-      this->m_param_ParamStringExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMENUMEXT;
+    _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
-  // Get serialized parameter ParamEnumExt
-  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamStringExt
+    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMENUMEXT,
-    this->m_param_ParamEnumExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-  }
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+        Fw::String _val = Fw::String("external default");
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
+                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMARRAYEXT;
+    _id = _baseId + PARAMID_PARAMENUMEXT;
 
-  // Get serialized parameter ParamArrayExt
-  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
+    // Get serialized parameter ParamEnumExt
+    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
 
-  this->m_paramLock.lock();
+    this->m_paramLock.lock();
 
-  // Deserialize parameter or use default value
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
+                                                     _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
     }
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-    A _val = A({1, 2, 3});
-    _paramBuffer.resetSer();
-    _stat = _paramBuffer.serializeFrom(_val);
-    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+    // Get serialized parameter ParamArrayExt
+    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter or use default value
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+        }
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+        A _val = A({1, 2, 3});
+        _paramBuffer.resetSer();
+        _stat = _paramBuffer.serializeFrom(_val);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
+                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
+        if (_stat != Fw::FW_SERIALIZE_OK) {
+            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        }
+    }
+
+    this->m_paramLock.unlock();
+
+    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+    // Get serialized parameter ParamStructExt
+    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+
+    this->m_paramLock.lock();
+
+    // Deserialize parameter
     FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(
-      _baseId,
-      PARAMID_PARAMARRAYEXT,
-      this->m_param_ParamArrayExt_valid,
-      _paramBuffer
-    );
+    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
+                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
     }
-  }
 
-  this->m_paramLock.unlock();
+    this->m_paramLock.unlock();
 
-  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-  // Get serialized parameter ParamStructExt
-  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
-    0,
-    _id,
-    _paramBuffer
-  );
-
-  this->m_paramLock.lock();
-
-  // Deserialize parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  _stat = this->paramDelegatePtr->deserializeParam(
-    _baseId,
-    PARAMID_PARAMSTRUCTEXT,
-    this->m_param_ParamStructExt_valid,
-    _paramBuffer
-  );
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-  }
-
-  this->m_paramLock.unlock();
-
-  // Call notifier
-  this->parametersLoaded();
+    // Call notifier
+    this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedTestComponentBase ::
-  QueuedTestComponentBase(const char* compName) :
-    Fw::QueuedComponentBase(compName)
-{
-  this->m_EventActivityLowThrottledThrottle = 0;
-  this->m_EventFatalThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledThrottle = 0;
-  this->m_EventWarningLowThrottledIntervalThrottle = 0;
+QueuedTestComponentBase ::QueuedTestComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {
+    this->m_EventActivityLowThrottledThrottle = 0;
+    this->m_EventFatalThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledThrottle = 0;
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-QueuedTestComponentBase ::
-  ~QueuedTestComponentBase()
-{
-
-}
+QueuedTestComponentBase ::~QueuedTestComponentBase() {}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -2573,118 +1604,76 @@ QueuedTestComponentBase ::
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTestComponentBase ::
-  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_eventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_eventOut_OutputPort[portNum].isConnected();
+    return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmGetOut_OutputPort[portNum].isConnected();
+    return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_prmSetOut_OutputPort[portNum].isConnected();
+    return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productRequestOut_OutputPort[portNum].isConnected();
+    return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_productSendOut_OutputPort[portNum].isConnected();
+    return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedTestComponentBase ::
-  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_textEventOut_OutputPort[portNum].isConnected();
+    return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedTestComponentBase ::
-  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_timeGetOut_OutputPort[portNum].isConnected();
+    return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_tlmOut_OutputPort[portNum].isConnected();
+    return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2695,92 +1684,59 @@ bool QueuedTestComponentBase ::
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTestComponentBase ::
-  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_typedOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedOut_OutputPort[portNum].isConnected();
+    return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::
-  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+bool QueuedTestComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -2791,487 +1747,287 @@ bool QueuedTestComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  cmdIn_handlerBase(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedTestComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
+                                                 FwOpcodeType opCode,
+                                                 U32 cmdSeq,
+                                                 Fw::CmdArgBuffer& args) {
+    const U32 idBase = this->getIdBase();
+    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-  const U32 idBase = this->getIdBase();
-  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+    // Select base class function based on opcode
+    switch (opCode - idBase) {
+        case OPCODE_CMD_SYNC: {
+            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
 
-  // Select base class function based on opcode
-  switch (opCode - idBase) {
-    case OPCODE_CMD_SYNC: {
-      this->CMD_SYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
+        case OPCODE_CMD_SYNC_PRIMITIVE: {
+            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRING: {
+            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ENUM: {
+            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_ARRAY: {
+            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_SYNC_STRUCT: {
+            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED: {
+            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_PRIMITIVE: {
+            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRING: {
+            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ENUM: {
+            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_ARRAY: {
+            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_GUARDED_STRUCT: {
+            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_ASYNC: {
+            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PRIORITY: {
+            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY: {
+            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_DROP: {
+            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
+            break;
+        }
+
+        case OPCODE_PARAMU32_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMU32_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRING_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamString();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUM_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAY_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMI32EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMI32EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMF64EXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRINGEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMENUMEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMARRAYEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SET: {
+            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+
+        case OPCODE_PARAMSTRUCTEXT_SAVE: {
+            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+            this->cmdResponse_out(opCode, cmdSeq, _cstat);
+            break;
+        }
+        default:
+            // Unknown opcode: ignore it
+            break;
     }
-
-    case OPCODE_CMD_SYNC_PRIMITIVE: {
-      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRING: {
-      this->CMD_SYNC_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ENUM: {
-      this->CMD_SYNC_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_ARRAY: {
-      this->CMD_SYNC_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_SYNC_STRUCT: {
-      this->CMD_SYNC_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED: {
-      this->CMD_GUARDED_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_PRIMITIVE: {
-      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRING: {
-      this->CMD_GUARDED_STRING_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ENUM: {
-      this->CMD_GUARDED_ENUM_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_ARRAY: {
-      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_GUARDED_STRUCT: {
-      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_ASYNC: {
-      this->CMD_ASYNC_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PRIORITY: {
-      this->CMD_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY: {
-      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_DROP: {
-      this->CMD_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-        opCode,
-        cmdSeq,
-        args
-      );
-      break;
-    }
-
-    case OPCODE_PARAMU32_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMU32_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRING_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamString();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUM_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAY_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMI32EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMI32EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMF64EXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRINGEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMENUMEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMARRAYEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SET: {
-      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-
-    case OPCODE_PARAMSTRUCTEXT_SAVE: {
-      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-      this->cmdResponse_out(
-        opCode,
-        cmdSeq,
-        _cstat
-      );
-      break;
-    }
-    default:
-      // Unknown opcode: ignore it
-      break;
-  }
 }
 
-void QueuedTestComponentBase ::
-  productRecvIn_handlerBase(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
+                                                         FwDpIdType id,
+                                                         const Fw::Buffer& buffer,
+                                                         const Fw::Success& status) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  productRecvIn_preMsgHook(
-    portNum,
-    id,
-    buffer,
-    status
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    productRecvIn_preMsgHook(portNum, id, buffer, status);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument id
-  _status = msg.serializeFrom(id);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument id
+    _status = msg.serializeFrom(id);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument buffer
-  _status = msg.serializeFrom(buffer);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument buffer
+    _status = msg.serializeFrom(buffer);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument status
-  _status = msg.serializeFrom(status);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument status
+    _status = msg.serializeFrom(status);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -3280,941 +2036,561 @@ void QueuedTestComponentBase ::
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  aliasTypedAsync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
+                                                           AliasPrim1 u32,
+                                                           AliasPrim2 f32,
+                                                           AliasBool b,
+                                                           const Fw::StringBase& str2,
+                                                           const AliasEnum& e,
+                                                           const AliasArray& a,
+                                                           const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  aliasTypedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str2
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str2
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-Fw::String QueuedTestComponentBase ::
-  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTestComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTestComponentBase ::
-  noArgsAsync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  noArgsAsync_preMsgHook(portNum);
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    noArgsAsync_preMsgHook(portNum);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  noArgsGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->noArgsGuarded_handler(portNum);
+    // Call handler function
+    this->noArgsGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-U32 QueuedTestComponentBase ::
-  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedTestComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->noArgsReturnGuarded_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnGuarded_handler(portNum);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-U32 QueuedTestComponentBase ::
-  noArgsReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedTestComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  U32 retVal;
+    U32 retVal;
 
-  // Call handler function
-  retVal = this->noArgsReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedTestComponentBase ::
-  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTestComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->noArgsStringReturnSync_handler(portNum);
+    // Call handler function
+    retVal = this->noArgsStringReturnSync_handler(portNum);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTestComponentBase ::
-  noArgsSync_handlerBase(FwIndexType portNum)
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->noArgsSync_handler(portNum);
+    // Call handler function
+    this->noArgsSync_handler(portNum);
 }
 
-void QueuedTestComponentBase ::
-  typedAliasGuarded_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedAliasGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-AliasPrim2 QueuedTestComponentBase ::
-  typedAliasReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedTestComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
+                                                                      AliasPrim1 u32,
+                                                                      AliasPrim2 f32,
+                                                                      AliasBool b,
+                                                                      const Fw::StringBase& str2,
+                                                                      const AliasEnum& e,
+                                                                      const AliasArray& a,
+                                                                      const AliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  AliasPrim2 retVal;
+    AliasPrim2 retVal;
 
-  // Call handler function
-  retVal = this->typedAliasReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-Fw::String QueuedTestComponentBase ::
-  typedAliasStringReturnSync_handlerBase(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTestComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
+                                                                            AliasPrim1 u32,
+                                                                            AliasPrim2 f32,
+                                                                            AliasBool b,
+                                                                            const Fw::StringBase& str2,
+                                                                            const AliasEnum& e,
+                                                                            const AliasArray& a,
+                                                                            const AnotherAliasStruct& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  Fw::String retVal;
+    Fw::String retVal;
 
-  // Call handler function
-  retVal = this->typedAliasStringReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTestComponentBase ::
-  typedAsync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
+                                                      U32 u32,
+                                                      F32 f32,
+                                                      bool b,
+                                                      const Fw::StringBase& str1,
+                                                      const E& e,
+                                                      const A& a,
+                                                      const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsync_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  typedAsyncAssert_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
+                                                            U32 u32,
+                                                            F32 f32,
+                                                            bool b,
+                                                            const Fw::StringBase& str1,
+                                                            const E& e,
+                                                            const A& a,
+                                                            const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncAssert_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  typedAsyncBlockPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
+                                                                   U32 u32,
+                                                                   F32 f32,
+                                                                   bool b,
+                                                                   const Fw::StringBase& str1,
+                                                                   const E& e,
+                                                                   const A& a,
+                                                                   const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncBlockPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  typedAsyncDropPriority_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Call pre-message hook
-  typedAsyncDropPriority_preMsgHook(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Call pre-message hook
+    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize message ID
-  _status = msg.serializeFrom(
-    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
-  );
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize port number
-  _status = msg.serializeFrom(portNum);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize port number
+    _status = msg.serializeFrom(portNum);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument u32
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument u32
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument f32
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument f32
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument b
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument b
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument str1
-  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument str1
+    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument e
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument e
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument a
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument a
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Serialize argument s
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize argument s
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  typedGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str1,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  this->typedGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 }
 
-F32 QueuedTestComponentBase ::
-  typedReturnGuarded_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedTestComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str2,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Lock guard mutex before calling
-  this->lock();
+    // Lock guard mutex before calling
+    this->lock();
 
-  // Call handler function
-  retVal = this->typedReturnGuarded_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  // Unlock guard mutex
-  this->unLock();
+    // Unlock guard mutex
+    this->unLock();
 
-  return retVal;
+    return retVal;
 }
 
-F32 QueuedTestComponentBase ::
-  typedReturnSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedTestComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
+                                                          U32 u32,
+                                                          F32 f32,
+                                                          bool b,
+                                                          const Fw::StringBase& str2,
+                                                          const E& e,
+                                                          const A& a,
+                                                          const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  F32 retVal;
+    F32 retVal;
 
-  // Call handler function
-  retVal = this->typedReturnSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
 
-  return retVal;
+    return retVal;
 }
 
-void QueuedTestComponentBase ::
-  typedSync_handlerBase(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Make sure port number is valid
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedSync_handlerBase(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    // Make sure port number is valid
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  // Call handler function
-  this->typedSync_handler(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    // Call handler function
+    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
 }
 
 // ----------------------------------------------------------------------
@@ -4225,15 +2601,11 @@ void QueuedTestComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
+void QueuedTestComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
+                                                        FwDpIdType id,
+                                                        const Fw::Buffer& buffer,
+                                                        const Fw::Success& status) {
+    // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -4244,85 +2616,63 @@ void QueuedTestComponentBase ::
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  aliasTypedAsync_preMsgHook(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  // Default: no-op
+void QueuedTestComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
+                                                          AliasPrim1 u32,
+                                                          AliasPrim2 f32,
+                                                          AliasBool b,
+                                                          const Fw::StringBase& str2,
+                                                          const AliasEnum& e,
+                                                          const AliasArray& a,
+                                                          const AliasStruct& s) {
+    // Default: no-op
 }
 
-void QueuedTestComponentBase ::
-  noArgsAsync_preMsgHook(FwIndexType portNum)
-{
-  // Default: no-op
+void QueuedTestComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
+    // Default: no-op
 }
 
-void QueuedTestComponentBase ::
-  typedAsync_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTestComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str1,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    // Default: no-op
 }
 
-void QueuedTestComponentBase ::
-  typedAsyncAssert_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTestComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
+                                                           U32 u32,
+                                                           F32 f32,
+                                                           bool b,
+                                                           const Fw::StringBase& str1,
+                                                           const E& e,
+                                                           const A& a,
+                                                           const S& s) {
+    // Default: no-op
 }
 
-void QueuedTestComponentBase ::
-  typedAsyncBlockPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTestComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
+                                                                  U32 u32,
+                                                                  F32 f32,
+                                                                  bool b,
+                                                                  const Fw::StringBase& str1,
+                                                                  const E& e,
+                                                                  const A& a,
+                                                                  const S& s) {
+    // Default: no-op
 }
 
-void QueuedTestComponentBase ::
-  typedAsyncDropPriority_preMsgHook(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  // Default: no-op
+void QueuedTestComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
+                                                                 U32 u32,
+                                                                 F32 f32,
+                                                                 bool b,
+                                                                 const Fw::StringBase& str1,
+                                                                 const E& e,
+                                                                 const A& a,
+                                                                 const S& s) {
+    // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -4331,209 +2681,103 @@ void QueuedTestComponentBase ::
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  noArgsOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::noArgsOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_noArgsOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedTestComponentBase ::
-  noArgsReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+U32 QueuedTestComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedTestComponentBase ::
-  noArgsStringReturnOut_out(FwIndexType portNum) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTestComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedTestComponentBase ::
-  typedAliasOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedAliasOut_out(FwIndexType portNum,
+                                                 AliasPrim1 u32,
+                                                 AliasPrim2 f32,
+                                                 AliasBool b,
+                                                 const Fw::StringBase& str2,
+                                                 const AliasEnum& e,
+                                                 const AliasArray& a,
+                                                 const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedAliasOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedTestComponentBase ::
-  typedAliasReturnOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+AliasPrim2 QueuedTestComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
+                                                             AliasPrim1 u32,
+                                                             AliasPrim2 f32,
+                                                             AliasBool b,
+                                                             const Fw::StringBase& str2,
+                                                             const AliasEnum& e,
+                                                             const AliasArray& a,
+                                                             const AliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedTestComponentBase ::
-  typedAliasReturnStringOut_out(
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::String QueuedTestComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
+                                                                   AliasPrim1 u32,
+                                                                   AliasPrim2 f32,
+                                                                   AliasBool b,
+                                                                   const Fw::StringBase& str2,
+                                                                   const AliasEnum& e,
+                                                                   const AliasArray& a,
+                                                                   const AnotherAliasStruct& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+              static_cast<FwAssertArgType>(portNum));
+    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
-void QueuedTestComponentBase ::
-  typedOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::typedOut_out(FwIndexType portNum,
+                                            U32 u32,
+                                            F32 f32,
+                                            bool b,
+                                            const Fw::StringBase& str1,
+                                            const E& e,
+                                            const A& a,
+                                            const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_typedOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedTestComponentBase ::
-  typedReturnOut_out(
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+F32 QueuedTestComponentBase ::typedReturnOut_out(FwIndexType portNum,
+                                                 U32 u32,
+                                                 F32 f32,
+                                                 bool b,
+                                                 const Fw::StringBase& str2,
+                                                 const E& e,
+                                                 const A& a,
+                                                 const S& s) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_typedReturnOut_OutputPort[portNum].invoke(
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
 }
 
 #endif
@@ -4542,264 +2786,162 @@ F32 QueuedTestComponentBase ::
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  internalArray_internalInterfaceInvoke(const A& a)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(a);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(a);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  internalEnum_internalInterfaceInvoke(const E& e)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(e);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(e);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  internalPrimitive_internalInterfaceInvoke(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(u32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(u32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(f32);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(f32);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(b);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(b);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  internalPriorityDrop_internalInterfaceInvoke()
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  internalString_internalInterfaceInvoke(
-      const Fw::InternalInterfaceString& str1,
-      const Fw::InternalInterfaceString& str2
-  )
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
+                                                                      const Fw::InternalInterfaceString& str2) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(str1);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(str1);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(str2);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(str2);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  internalStruct_internalInterfaceInvoke(const S& s)
-{
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize the message ID
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize the message ID
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Fake port number to make message dequeue work
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(s);
-  FW_ASSERT(
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(s);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  cmdResponse_out(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdResponse response
-  )
-{
-  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedTestComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
+    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -4808,965 +2950,613 @@ void QueuedTestComponentBase ::
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  CMD_SYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedTestComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void QueuedTestComponentBase ::
-  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 }
 
-void QueuedTestComponentBase ::
-  CMD_SYNC_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 }
 
-void QueuedTestComponentBase ::
-  CMD_SYNC_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
 }
 
-void QueuedTestComponentBase ::
-  CMD_SYNC_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
 }
 
-void QueuedTestComponentBase ::
-  CMD_SYNC_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->CMD_SYNC_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
 }
 
-void QueuedTestComponentBase ::
-  CMD_GUARDED_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
+void QueuedTestComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedTestComponentBase ::
-  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
+                                                                    U32 cmdSeq,
+                                                                    Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  U32 u32;
-  _status = args.deserializeTo(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    U32 u32;
+    _status = args.deserializeTo(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  F32 f32;
-  _status = args.deserializeTo(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    F32 f32;
+    _status = args.deserializeTo(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  bool b;
-  _status = args.deserializeTo(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    bool b;
+    _status = args.deserializeTo(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
-    opCode, cmdSeq,
-    u32,
-    f32,
-    b
-  );
+    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedTestComponentBase ::
-  CMD_GUARDED_STRING_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  Fw::CmdStringArg str1;
-  _status = args.deserializeTo(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str1;
+    _status = args.deserializeTo(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
-  Fw::CmdStringArg str2;
-  _status = args.deserializeTo(str2);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    Fw::CmdStringArg str2;
+    _status = args.deserializeTo(str2);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRING_cmdHandler(
-    opCode, cmdSeq,
-    str1,
-    str2
-  );
+    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedTestComponentBase ::
-  CMD_GUARDED_ENUM_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
+                                                               U32 cmdSeq,
+                                                               Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  E e;
-  _status = args.deserializeTo(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    E e;
+    _status = args.deserializeTo(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ENUM_cmdHandler(
-    opCode, cmdSeq,
-    e
-  );
+    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedTestComponentBase ::
-  CMD_GUARDED_ARRAY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                U32 cmdSeq,
+                                                                Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  A a;
-  _status = args.deserializeTo(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    A a;
+    _status = args.deserializeTo(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_ARRAY_cmdHandler(
-    opCode, cmdSeq,
-    a
-  );
+    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedTestComponentBase ::
-  CMD_GUARDED_STRUCT_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Deserialize the arguments
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
+                                                                 U32 cmdSeq,
+                                                                 Fw::CmdArgBuffer& args) {
+    // Deserialize the arguments
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Reset the buffer
-  args.resetDeser();
+    // Reset the buffer
+    args.resetDeser();
 
-  S s;
-  _status = args.deserializeTo(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    S s;
+    _status = args.deserializeTo(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 
 #if FW_CMD_CHECK_RESIDUAL
-  // Make sure there was no data left over.
-  // That means the argument buffer size was incorrect.
-  if (args.getDeserializeSizeLeft() != 0) {
-    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-      this->cmdResponseOut_out(
-        0,
-        opCode,
-        cmdSeq,
-        Fw::CmdResponse::FORMAT_ERROR
-      );
+    // Make sure there was no data left over.
+    // That means the argument buffer size was incorrect.
+    if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        return;
     }
-    return;
-  }
 #endif
 
-  this->lock();
+    this->lock();
 
-  this->CMD_GUARDED_STRUCT_cmdHandler(
-    opCode, cmdSeq,
-    s
-  );
+    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
 
-  this->unLock();
+    this->unLock();
 }
 
-void QueuedTestComponentBase ::
-  CMD_ASYNC_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
+void QueuedTestComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  CMD_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+void QueuedTestComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  CMD_PARAMS_PRIORITY_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
+                                                                  U32 cmdSeq,
+                                                                  Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  CMD_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+void QueuedTestComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
-void QueuedTestComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  // Call pre-message hook
-  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
+                                                                       U32 cmdSeq,
+                                                                       Fw::CmdArgBuffer& args) {
+    // Call pre-message hook
+    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
 
-  // Defer deserializing arguments to the message dispatcher
-  // to avoid deserializing and reserializing just for IPC
-  ComponentIpcSerializableBuffer msg;
-  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Defer deserializing arguments to the message dispatcher
+    // to avoid deserializing and reserializing just for IPC
+    ComponentIpcSerializableBuffer msg;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-  // Serialize for IPC
-  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    // Serialize for IPC
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Fake port number to make message dequeue work
-  FwIndexType port = 0;
+    // Fake port number to make message dequeue work
+    FwIndexType port = 0;
 
-  _status = msg.serializeFrom(port);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(port);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(opCode);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(opCode);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(cmdSeq);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(cmdSeq);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  _status = msg.serializeFrom(args);
-  FW_ASSERT (
-    _status == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_status)
-  );
+    _status = msg.serializeFrom(args);
+    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Send message
-  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+    // Send message
+    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
 
-  if (qStatus == Os::Queue::Status::FULL) {
-    this->incNumMsgDropped();
-    return;
-  }
+    if (qStatus == Os::Queue::Status::FULL) {
+        this->incNumMsgDropped();
+        return;
+    }
 
-  FW_ASSERT(
-    qStatus == Os::Queue::OP_OK,
-    static_cast<FwAssertArgType>(qStatus)
-  );
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
 }
 
 // ----------------------------------------------------------------------
@@ -5777,782 +3567,507 @@ void QueuedTestComponentBase ::
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  CMD_ASYNC_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedTestComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedTestComponentBase ::
-  CMD_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedTestComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedTestComponentBase ::
-  CMD_PARAMS_PRIORITY_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedTestComponentBase ::
-  CMD_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedTestComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
-void QueuedTestComponentBase ::
-  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
-      FwOpcodeType opCode,
-      U32 cmdSeq
-  )
-{
-  // Defaults to no-op; can be overridden
-  (void) opCode;
-  (void) cmdSeq;
+void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
+    // Defaults to no-op; can be overridden
+    (void)opCode;
+    (void)cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  log_ACTIVITY_HI_EventActivityHigh() const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
+void QueuedTestComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
 
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logBuff
-    );
-  }
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
+    }
 
-  // Emit the event on the text log port
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity High occurred";
+        const char* _formatString = "(%s) %s: Event Activity High occurred";
 #else
-    const char* _formatString =
-      "%s: Event Activity High occurred";
+        const char* _formatString = "%s: Event Activity High occurred";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventActivityHigh "
-    );
+                          "EventActivityHigh ");
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_HI,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
+    }
 #endif
 }
 
-void QueuedTestComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled(
-      U32 u32,
-      F32 f32,
-      bool b
-  )
-{
-  // Check throttle value
-  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventActivityLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(3));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(u32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(F32))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(f32);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(sizeof(U8))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(b);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#else
-    const char* _formatString =
-      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventActivityLowThrottled ",
-      u32,
-      static_cast<F64>(f32),
-      b
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::ACTIVITY_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedTestComponentBase ::
-  log_COMMAND_EventCommand(
-      const Fw::StringBase& str1,
-      const Fw::StringBase& str2
-  ) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(2));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    _status = str1.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = str2.serializeTo(
-      _logBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-    const char* _formatString =
-      "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventCommand ",
-      str1.toChar(),
-      str2.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::COMMAND,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedTestComponentBase ::
-  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(E::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(e);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-    Fw::String eStr;
-    e.toString(eStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventDiagnostic ",
-      eStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::DIAGNOSTIC,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedTestComponentBase ::
-  log_FATAL_EventFatalThrottled(const A& a)
-{
-  // Check throttle value
-  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventFatalThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serializeFrom(static_cast<U8>(4));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    _status = _logBuff.serializeFrom(static_cast<U32>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(A::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(a);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Fatal occurred with argument: %s";
-#endif
-
-    Fw::String aStr;
-    a.toString(aStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventFatalThrottled ",
-      aStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::FATAL,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedTestComponentBase ::
-  log_WARNING_HI_EventWarningHigh(const S& s) const
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(1));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-    // Serialize the argument size
-    _status = _logBuff.serializeFrom(
-      static_cast<U8>(S::SERIALIZED_SIZE)
-    );
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-    _status = _logBuff.serializeFrom(s);
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-    const char* _formatString =
-      "%s: Event Warning High occurred with argument: %s";
-#endif
-
-    Fw::String sStr;
-    s.toString(sStr);
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningHigh ",
-      sStr.toChar()
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_HI,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedTestComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled()
-{
-  // Check throttle value
-  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-    return;
-  }
-  else {
-    this->m_EventWarningLowThrottledThrottle++;
-  }
-
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
-#endif
-
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
-
-  // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
-#else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
-#endif
-
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
-#if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
-#endif
-      "EventWarningLowThrottled "
-    );
-
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
-#endif
-}
-
-void QueuedTestComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval()
-{
-  // Get the time
-  Fw::Time _logTime;
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    this->timeGetOut_out(0, _logTime);
-  }
-
-  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-  // Check throttle value & throttle timeout
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
-    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-      // The counter has overflowed, check if time interval has passed
-      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
-        // Reset the count
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
-      } else {
-        // Throttle the event
+void QueuedTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
+    // Check throttle value
+    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
         return;
-      }
+    } else {
+        this->m_EventActivityLowThrottledThrottle++;
     }
 
-    // Reset the throttle time if needed
-    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-      // This is the first event, reset the throttle time
-      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
     }
 
-    // Increment the count
-    this->m_EventWarningLowThrottledIntervalThrottle++;
-  }
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
-  // Emit the event on the log port
-  if (this->isConnected_eventOut_OutputPort(0)) {
-    Fw::LogBuffer _logBuff;
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
 #if FW_AMPCS_COMPATIBLE
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-    // Serialize the number of arguments
-    _status = _logBuff.serializeFrom(static_cast<U8>(0));
-    FW_ASSERT(
-      _status == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_status)
-    );
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(3));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 #endif
 
-    this->eventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logBuff
-    );
-  }
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(u32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-  // Emit the event on the text log port
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(f32);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(b);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-  if (this->isConnected_textEventOut_OutputPort(0)) {
+    if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-    const char* _formatString =
-      "(%s) %s: Event Warning Low occurred";
+        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #else
-    const char* _formatString =
-      "%s: Event Warning Low occurred";
+        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
 #endif
 
-    Fw::TextLogString _logString;
-    _logString.format(
-      _formatString,
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName.toChar(),
+                          this->m_objName.toChar(),
 #endif
-      "EventWarningLowThrottledInterval "
-    );
+                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
 
-    this->textEventOut_out(
-      0,
-      _id,
-      _logTime,
-      Fw::LogSeverity::WARNING_LO,
-      _logString
-    );
-  }
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
+    }
+#endif
+}
+
+void QueuedTestComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1, const Fw::StringBase& str2) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(2));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
+                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventCommand ", str1.toChar(), str2.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
+    }
+#endif
+}
+
+void QueuedTestComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(e);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+        Fw::String eStr;
+        e.toString(eStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventDiagnostic ", eStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
+    }
+#endif
+}
+
+void QueuedTestComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
+    // Check throttle value
+    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventFatalThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+        _status = _logBuff.serializeFrom(static_cast<U8>(4));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        _status = _logBuff.serializeFrom(static_cast<U32>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(a);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
+#endif
+
+        Fw::String aStr;
+        a.toString(aStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventFatalThrottled ", aStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
+    }
+#endif
+}
+
+void QueuedTestComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(1));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+        // Serialize the argument size
+        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+        _status = _logBuff.serializeFrom(s);
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
+#endif
+
+        Fw::String sStr;
+        s.toString(sStr);
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningHigh ", sStr.toChar());
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
+    }
+#endif
+}
+
+void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
+    // Check throttle value
+    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+        return;
+    } else {
+        this->m_EventWarningLowThrottledThrottle++;
+    }
+
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottled ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
+#endif
+}
+
+void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
+    // Get the time
+    Fw::Time _logTime;
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        this->timeGetOut_out(0, _logTime);
+    }
+
+    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+    // Check throttle value & throttle timeout
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+            // The counter has overflowed, check if time interval has passed
+            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
+                Fw::TimeInterval(10, 0)) {
+                // Reset the count
+                this->m_EventWarningLowThrottledIntervalThrottle = 0;
+            } else {
+                // Throttle the event
+                return;
+            }
+        }
+
+        // Reset the throttle time if needed
+        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+            // This is the first event, reset the throttle time
+            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
+        }
+
+        // Increment the count
+        this->m_EventWarningLowThrottledIntervalThrottle++;
+    }
+
+    // Emit the event on the log port
+    if (this->isConnected_eventOut_OutputPort(0)) {
+        Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+        // Serialize the number of arguments
+        _status = _logBuff.serializeFrom(static_cast<U8>(0));
+        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+#endif
+
+        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
+    }
+
+    // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+    if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+        const char* _formatString = "(%s) %s: Event Warning Low occurred";
+#else
+        const char* _formatString = "%s: Event Warning Low occurred";
+#endif
+
+        Fw::TextLogString _logString;
+        _logString.format(_formatString,
+#if FW_OBJECT_NAMES == 1
+                          this->m_objName.toChar(),
+#endif
+                          "EventWarningLowThrottledInterval ");
+
+        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
+    }
 #endif
 }
 
@@ -6560,692 +4075,463 @@ void QueuedTestComponentBase ::
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventActivityLowThrottledThrottle = 0;
-}
-
-void QueuedTestComponentBase ::
-  log_FATAL_EventFatalThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventFatalThrottledThrottle = 0;
-}
-
-void QueuedTestComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
-{
-  // Reset throttle counter
-  this->m_EventWarningLowThrottledThrottle = 0;
-}
-
-void QueuedTestComponentBase ::
-  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
-{
-  {
-    Os::ScopeLock scopedLock(this->m_eventLock);
-
+void QueuedTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
     // Reset throttle counter
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    this->m_EventActivityLowThrottledThrottle = 0;
+}
 
-    // Reset the throttle time
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-  }
+void QueuedTestComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventFatalThrottledThrottle = 0;
+}
+
+void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledThrottle = 0;
+}
+
+void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
+    {
+        Os::ScopeLock scopedLock(this->m_eventLock);
+
+        // Reset throttle counter
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+
+        // Reset the throttle time
+        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  tlmWrite(
-      FwChanIdType id,
-      Fw::TlmBuffer& _tlmBuff,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    if (
-      this->isConnected_timeGetOut_OutputPort(0) &&
-      (_tlmTime ==  Fw::ZERO_TIME)
-    ) {
-      this->timeGetOut_out(0, _tlmTime);
+void QueuedTestComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
+            this->timeGetOut_out(0, _tlmTime);
+        }
+
+        FwChanIdType _id;
+        _id = this->getIdBase() + id;
+
+        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
     }
-
-    FwChanIdType _id;
-    _id = this->getIdBase() + id;
-
-    this->tlmOut_out(
-      0,
-      _id,
-      _tlmTime,
-      _tlmBuff
-    );
-  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelU32Format(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+void QueuedTestComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-    this->tlmWrite(
-      CHANNELID_CHANNELU32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelF32Format(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32FORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelStringFormat(
-      const Fw::StringBase& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serializeTo(
-      _tlmBuff,
-      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
-    );
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRINGFORMAT,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelEnum(
-      const E& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUM,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelArrayFreq(
-      const A& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELARRAYFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelStructFreq(
-      const S& arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELSTRUCTFREQ,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelU32Limits(
-      U32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelF32Limits(
-      F32 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF32LIMITS,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelF64(
-      F64 arg,
-      Fw::Time _tlmTime
-  ) const
-{
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELF64,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
-}
-
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelU32OnChange(
-      U32 arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelU32OnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelU32OnChange) {
-      return;
+        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
     }
-    else {
-      this->m_last_ChannelU32OnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelU32OnChange = false;
-    this->m_last_ChannelU32OnChange = arg;
-  }
-
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELU32ONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
 }
 
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelEnumOnChange(
-      const E& arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelEnumOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelEnumOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelEnumOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelEnumOnChange = false;
-    this->m_last_ChannelEnumOnChange = arg;
-  }
+void QueuedTestComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
-
-    this->tlmWrite(
-      CHANNELID_CHANNELENUMONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
+    }
 }
 
-void QueuedTestComponentBase ::
-  tlmWrite_ChannelBoolOnChange(
-      bool arg,
-      Fw::Time _tlmTime
-  )
-{
-  // Check to see if it is the first time
-  if (not this->m_first_update_ChannelBoolOnChange) {
-    // Check to see if value has changed. If not, don't write it.
-    if (arg == this->m_last_ChannelBoolOnChange) {
-      return;
-    }
-    else {
-      this->m_last_ChannelBoolOnChange = arg;
-    }
-  }
-  else {
-    this->m_first_update_ChannelBoolOnChange = false;
-    this->m_last_ChannelBoolOnChange = arg;
-  }
+void QueuedTestComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat =
+            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
+                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
 
-  if (this->isConnected_tlmOut_OutputPort(0)) {
-    Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-    FW_ASSERT(
-      _stat == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_stat)
-    );
+        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
+    }
+}
 
-    this->tlmWrite(
-      CHANNELID_CHANNELBOOLONCHANGE,
-      _tlmBuff,
-      _tlmTime
-    );
-  }
+void QueuedTestComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelU32OnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelU32OnChange) {
+            return;
+        } else {
+            this->m_last_ChannelU32OnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelU32OnChange = false;
+        this->m_last_ChannelU32OnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelEnumOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelEnumOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelEnumOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelEnumOnChange = false;
+        this->m_last_ChannelEnumOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    }
+}
+
+void QueuedTestComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelBoolOnChange) {
+        // Check to see if value has changed. If not, don't write it.
+        if (arg == this->m_last_ChannelBoolOnChange) {
+            return;
+        } else {
+            this->m_last_ChannelBoolOnChange = arg;
+        }
+    } else {
+        this->m_first_update_ChannelBoolOnChange = false;
+        this->m_last_ChannelBoolOnChange = arg;
+    }
+
+    if (this->isConnected_tlmOut_OutputPort(0)) {
+        Fw::TlmBuffer _tlmBuff;
+        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+
+        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    }
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  parameterUpdated(FwPrmIdType id)
-{
-  // Do nothing by default
+void QueuedTestComponentBase ::parameterUpdated(FwPrmIdType id) {
+    // Do nothing by default
 }
 
-void QueuedTestComponentBase ::
-  parametersLoaded()
-{
-  // Do nothing by default
+void QueuedTestComponentBase ::parametersLoaded() {
+    // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 QueuedTestComponentBase ::
-  paramGet_ParamU32(Fw::ParamValid& valid)
-{
-  U32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamU32_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamU32;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-F64 QueuedTestComponentBase ::
-  paramGet_ParamF64(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamF64;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-Fw::ParamString QueuedTestComponentBase ::
-  paramGet_ParamString(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamString_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamString;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-E QueuedTestComponentBase ::
-  paramGet_ParamEnum(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnum_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamEnum;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-A QueuedTestComponentBase ::
-  paramGet_ParamArray(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArray_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamArray;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-S QueuedTestComponentBase ::
-  paramGet_ParamStruct(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStruct_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    _local = this->m_ParamStruct;
-  }
-  this->m_paramLock.unlock();
-  return _local;
-}
-
-I32 QueuedTestComponentBase ::
-  paramGet_ParamI32Ext(Fw::ParamValid& valid)
-{
-  I32 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamI32Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+U32 QueuedTestComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
+    U32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamU32_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamU32;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-F64 QueuedTestComponentBase ::
-  paramGet_ParamF64Ext(Fw::ParamValid& valid)
-{
-  F64 _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamF64Ext_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+F64 QueuedTestComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamF64;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-Fw::ParamString QueuedTestComponentBase ::
-  paramGet_ParamStringExt(Fw::ParamValid& valid)
-{
-  Fw::ParamString _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStringExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+Fw::ParamString QueuedTestComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamString_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamString;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-E QueuedTestComponentBase ::
-  paramGet_ParamEnumExt(Fw::ParamValid& valid)
-{
-  E _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamEnumExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+E QueuedTestComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnum_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamEnum;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-A QueuedTestComponentBase ::
-  paramGet_ParamArrayExt(Fw::ParamValid& valid)
-{
-  A _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamArrayExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+A QueuedTestComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArray_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamArray;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
 }
 
-S QueuedTestComponentBase ::
-  paramGet_ParamStructExt(Fw::ParamValid& valid)
-{
-  S _local{};
-  this->m_paramLock.lock();
-  valid = this->m_param_ParamStructExt_valid;
-  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-    Fw::ParamBuffer _paramBuffer;
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(this->getIdBase()),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-    if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _paramBuffer.deserializeTo(_local);
-      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-    } else {
-      valid = Fw::ParamValid::INVALID;
+S QueuedTestComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStruct_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        _local = this->m_ParamStruct;
     }
-  }
-  this->m_paramLock.unlock();
-  return _local;
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+I32 QueuedTestComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
+    I32 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamI32Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+F64 QueuedTestComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
+    F64 _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamF64Ext_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+Fw::ParamString QueuedTestComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
+    Fw::ParamString _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStringExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+E QueuedTestComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
+    E _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamEnumExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+A QueuedTestComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
+    A _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamArrayExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
+}
+
+S QueuedTestComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
+    S _local{};
+    this->m_paramLock.lock();
+    valid = this->m_param_ParamStructExt_valid;
+    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+        Fw::ParamBuffer _paramBuffer;
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
+                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
+        if (_stat == Fw::FW_SERIALIZE_OK) {
+            _stat = _paramBuffer.deserializeTo(_local);
+            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+        } else {
+            valid = Fw::ParamValid::INVALID;
+        }
+    }
+    this->m_paramLock.unlock();
+    return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
-{
-  FW_ASSERT(paramExternalDelegatePtr != nullptr);
-  this->paramDelegatePtr = paramExternalDelegatePtr;
+void QueuedTestComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
+    FW_ASSERT(paramExternalDelegatePtr != nullptr);
+    this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  dpSend(
-      DpContainer& container,
-      Fw::Time timeTag
-  )
-{
-  // Update the time tag
-  if (timeTag == Fw::ZERO_TIME) {
-    // Get the time from the time port
-    timeTag = this->getTime();
-  }
-  container.setTimeTag(timeTag);
-  // Serialize the header into the packet
-  container.serializeHeader();
-  // Update the size of the buffer according to the data size
-  const FwSizeType packetSize = container.getPacketSize();
-  Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-      static_cast<FwAssertArgType>(buffer.getSize()));
-  buffer.setSize(static_cast<U32>(packetSize));
-  // Invalidate the buffer in the container, so it can't be reused
-  container.invalidateBuffer();
-  // Send the buffer
-  this->productSendOut_out(0, container.getId(), buffer);
+void QueuedTestComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
+    // Update the time tag
+    if (timeTag == Fw::ZERO_TIME) {
+        // Get the time from the time port
+        timeTag = this->getTime();
+    }
+    container.setTimeTag(timeTag);
+    // Serialize the header into the packet
+    container.serializeHeader();
+    // Update the size of the buffer according to the data size
+    const FwSizeType packetSize = container.getPacketSize();
+    Fw::Buffer buffer = container.getBuffer();
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+              static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
+    // Invalidate the buffer in the container, so it can't be reused
+    container.invalidateBuffer();
+    // Send the buffer
+    this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedTestComponentBase ::
-  getTime() const
-{
-  if (this->isConnected_timeGetOut_OutputPort(0)) {
-    Fw::Time _time;
-    this->timeGetOut_out(0, _time);
-    return _time;
-  }
-  else {
-    return Fw::Time(TimeBase::TB_NONE, 0, 0);
-  }
+Fw::Time QueuedTestComponentBase ::getTime() const {
+    if (this->isConnected_timeGetOut_OutputPort(0)) {
+        Fw::Time _time;
+        this->timeGetOut_out(0, _time);
+        return _time;
+    } else {
+        return Fw::Time(TimeBase::TB_NONE, 0, 0);
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -7255,1393 +4541,890 @@ Fw::Time QueuedTestComponentBase ::
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  lock()
-{
-  this->m_guardedPortMutex.lock();
+void QueuedTestComponentBase ::lock() {
+    this->m_guardedPortMutex.lock();
 }
 
-void QueuedTestComponentBase ::
-  unLock()
-{
-  this->m_guardedPortMutex.unLock();
+void QueuedTestComponentBase ::unLock() {
+    this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
-  doDispatch()
-{
-  ComponentIpcSerializableBuffer _msg;
-  FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::doDispatch() {
+    ComponentIpcSerializableBuffer _msg;
+    FwQueuePriorityType _priority = 0;
 
-  Os::Queue::Status _msgStatus = this->m_queue.receive(
-    _msg,
-    Os::Queue::NONBLOCKING,
-    _priority
-  );
-  if (Os::Queue::Status::EMPTY == _msgStatus) {
-    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-  }
-  else {
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
-  }
-
-  // Reset to beginning of buffer
-  _msg.resetDeser();
-
-  FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
-
-  if (_msgType == QUEUEDTEST_COMPONENT_EXIT) {
-    return MSG_DISPATCH_EXIT;
-  }
-
-  FwIndexType portNum = 0;
-  _deserStatus = _msg.deserializeTo(portNum);
-  FW_ASSERT(
-    _deserStatus == Fw::FW_SERIALIZE_OK,
-    static_cast<FwAssertArgType>(_deserStatus)
-  );
-
-  switch (_msgType) {
-    // Handle async input port productRecvIn
-    case PRODUCTRECVIN_DPRESPONSE: {
-      // Deserialize argument id
-      FwDpIdType id;
-      _deserStatus = _msg.deserializeTo(id);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument buffer
-      Fw::Buffer buffer;
-      _deserStatus = _msg.deserializeTo(buffer);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument status
-      Fw::Success status;
-      _deserStatus = _msg.deserializeTo(status);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->productRecvIn_handler(
-        portNum,
-        id,
-        buffer,
-        status
-      );
-
-      break;
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    if (Os::Queue::Status::EMPTY == _msgStatus) {
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
-    // Handle async input port aliasTypedAsync
-    case ALIASTYPEDASYNC_ALIASTYPED: {
-      // Deserialize argument u32
-      AliasPrim1 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    // Reset to beginning of buffer
+    _msg.resetDeser();
 
-      // Deserialize argument f32
-      AliasPrim2 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    FwEnumStoreType _desMsg = 0;
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument b
-      AliasBool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
-      // Deserialize argument str2
-      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserializeTo(str2);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      AliasEnum e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      AliasArray a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      AliasStruct s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->aliasTypedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str2,
-        e,
-        a,
-        s
-      );
-
-      break;
+    if (_msgType == QUEUEDTEST_COMPONENT_EXIT) {
+        return MSG_DISPATCH_EXIT;
     }
 
-    // Handle async input port noArgsAsync
-    case NOARGSASYNC_NOARGS: {
-      // Call handler function
-      this->noArgsAsync_handler(portNum);
+    FwIndexType portNum = 0;
+    _deserStatus = _msg.deserializeTo(portNum);
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      break;
-    }
+    switch (_msgType) {
+        // Handle async input port productRecvIn
+        case PRODUCTRECVIN_DPRESPONSE: {
+            // Deserialize argument id
+            FwDpIdType id;
+            _deserStatus = _msg.deserializeTo(id);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-    // Handle async input port typedAsync
-    case TYPEDASYNC_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument buffer
+            Fw::Buffer buffer;
+            _deserStatus = _msg.deserializeTo(buffer);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
+            // Deserialize argument status
+            Fw::Success status;
+            _deserStatus = _msg.deserializeTo(status);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->productRecvIn_handler(portNum, id, buffer, status);
 
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsync_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncAssert
-    case TYPEDASYNCASSERT_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncAssert_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncBlockPriority
-    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncBlockPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle async input port typedAsyncDropPriority
-    case TYPEDASYNCDROPPRIORITY_TYPED: {
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument f32
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument b
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument str1
-      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserializeTo(str1);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument e
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument a
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize argument s
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-      FW_ASSERT(
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-      // Call handler function
-      this->typedAsyncDropPriority_handler(
-        portNum,
-        u32,
-        f32,
-        b,
-        str1,
-        e,
-        a,
-        s
-      );
-
-      break;
-    }
-
-    // Handle command CMD_ASYNC
-    case CMD_CMD_ASYNC: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle async input port aliasTypedAsync
+        case ALIASTYPEDASYNC_ALIASTYPED: {
+            // Deserialize argument u32
+            AliasPrim1 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            AliasPrim2 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            AliasBool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str2
+            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+            _deserStatus = _msg.deserializeTo(str2);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            AliasEnum e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            AliasArray a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            AliasStruct s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port noArgsAsync
+        case NOARGSASYNC_NOARGS: {
+            // Call handler function
+            this->noArgsAsync_handler(portNum);
+
+            break;
+        }
+
+        // Handle async input port typedAsync
+        case TYPEDASYNC_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncAssert
+        case TYPEDASYNCASSERT_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncBlockPriority
+        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle async input port typedAsyncDropPriority
+        case TYPEDASYNCDROPPRIORITY_TYPED: {
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument f32
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument b
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument str1
+            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+            _deserStatus = _msg.deserializeTo(str1);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument e
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument a
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize argument s
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+            // Call handler function
+            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
+
+            break;
+        }
+
+        // Handle command CMD_ASYNC
+        case CMD_CMD_ASYNC: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PRIORITY
-    case CMD_CMD_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_PRIORITY
+        case CMD_CMD_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY
-    case CMD_CMD_PARAMS_PRIORITY: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY
+        case CMD_CMD_PARAMS_PRIORITY: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
-    }
-
-    // Handle command CMD_DROP
-    case CMD_CMD_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+
+        // Handle command CMD_DROP
+        case CMD_CMD_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+            // Call handler function
+            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
 
-      break;
-    }
-
-    // Handle command CMD_PARAMS_PRIORITY_DROP
-    case CMD_CMD_PARAMS_PRIORITY_DROP: {
-      // Deserialize opcode
-      FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserializeTo(_opCode);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command sequence
-      U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserializeTo(_cmdSeq);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Deserialize command argument buffer
-      Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserializeTo(args);
-      FW_ASSERT (
-        _deserStatus == Fw::FW_SERIALIZE_OK,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Reset buffer
-      args.resetDeser();
-
-      // Deserialize argument u32
-      U32 u32;
-      _deserStatus = args.deserializeTo(u32);
-      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(
-              _opCode,
-              _cmdSeq,
-              Fw::CmdResponse::FORMAT_ERROR
-          );
+            break;
         }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
 
-      // Make sure there was no data left over.
-      // That means the argument buffer size was incorrect.
+        // Handle command CMD_PARAMS_PRIORITY_DROP
+        case CMD_CMD_PARAMS_PRIORITY_DROP: {
+            // Deserialize opcode
+            FwOpcodeType _opCode = 0;
+            _deserStatus = _msg.deserializeTo(_opCode);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command sequence
+            U32 _cmdSeq = 0;
+            _deserStatus = _msg.deserializeTo(_cmdSeq);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Deserialize command argument buffer
+            Fw::CmdArgBuffer args;
+            _deserStatus = _msg.deserializeTo(args);
+            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Reset buffer
+            args.resetDeser();
+
+            // Deserialize argument u32
+            U32 u32;
+            _deserStatus = args.deserializeTo(u32);
+            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
+
+            // Make sure there was no data left over.
+            // That means the argument buffer size was incorrect.
 #if FW_CMD_CHECK_RESIDUAL
-      if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        // Don't crash the task if bad arguments were passed from the ground
-        break;
-      }
+            if (args.getDeserializeSizeLeft() != 0) {
+                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+                }
+                // Don't crash the task if bad arguments were passed from the ground
+                break;
+            }
 #endif
 
-      // Call handler function
-      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
-        _opCode, _cmdSeq,
-        u32
-      );
+            // Call handler function
+            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
 
-      break;
+            break;
+        }
+
+        // Handle internal interface internalArray
+        case INT_IF_INTERNALARRAY: {
+            A a;
+            _deserStatus = _msg.deserializeTo(a);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalArray_internalInterfaceHandler(a);
+
+            break;
+        }
+
+        // Handle internal interface internalEnum
+        case INT_IF_INTERNALENUM: {
+            E e;
+            _deserStatus = _msg.deserializeTo(e);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalEnum_internalInterfaceHandler(e);
+
+            break;
+        }
+
+        // Handle internal interface internalPrimitive
+        case INT_IF_INTERNALPRIMITIVE: {
+            U32 u32;
+            _deserStatus = _msg.deserializeTo(u32);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            F32 f32;
+            _deserStatus = _msg.deserializeTo(f32);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            bool b;
+            _deserStatus = _msg.deserializeTo(b);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
+
+            break;
+        }
+
+        // Handle internal interface internalPriorityDrop
+        case INT_IF_INTERNALPRIORITYDROP: {
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalPriorityDrop_internalInterfaceHandler();
+
+            break;
+        }
+
+        // Handle internal interface internalString
+        case INT_IF_INTERNALSTRING: {
+            Fw::InternalInterfaceString str1;
+            _deserStatus = _msg.deserializeTo(str1);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            Fw::InternalInterfaceString str2;
+            _deserStatus = _msg.deserializeTo(str2);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalString_internalInterfaceHandler(str1, str2);
+
+            break;
+        }
+
+        // Handle internal interface internalStruct
+        case INT_IF_INTERNALSTRUCT: {
+            S s;
+            _deserStatus = _msg.deserializeTo(s);
+
+            // Internal interface should always deserialize
+            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
+
+            // Make sure there was no data left over.
+            // That means the buffer size was incorrect.
+            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
+
+            // Call handler function
+            this->internalStruct_internalInterfaceHandler(s);
+
+            break;
+        }
+
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
-    // Handle internal interface internalArray
-    case INT_IF_INTERNALARRAY: {
-      A a;
-      _deserStatus = _msg.deserializeTo(a);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalArray_internalInterfaceHandler(
-        a
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalEnum
-    case INT_IF_INTERNALENUM: {
-      E e;
-      _deserStatus = _msg.deserializeTo(e);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalEnum_internalInterfaceHandler(
-        e
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalPrimitive
-    case INT_IF_INTERNALPRIMITIVE: {
-      U32 u32;
-      _deserStatus = _msg.deserializeTo(u32);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      F32 f32;
-      _deserStatus = _msg.deserializeTo(f32);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      bool b;
-      _deserStatus = _msg.deserializeTo(b);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalPrimitive_internalInterfaceHandler(
-        u32,
-        f32,
-        b
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalPriorityDrop
-    case INT_IF_INTERNALPRIORITYDROP: {
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalPriorityDrop_internalInterfaceHandler();
-
-      break;
-    }
-
-    // Handle internal interface internalString
-    case INT_IF_INTERNALSTRING: {
-      Fw::InternalInterfaceString str1;
-      _deserStatus = _msg.deserializeTo(str1);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      Fw::InternalInterfaceString str2;
-      _deserStatus = _msg.deserializeTo(str2);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalString_internalInterfaceHandler(
-        str1,
-        str2
-      );
-
-      break;
-    }
-
-    // Handle internal interface internalStruct
-    case INT_IF_INTERNALSTRUCT: {
-      S s;
-      _deserStatus = _msg.deserializeTo(s);
-
-      // Internal interface should always deserialize
-      FW_ASSERT(
-        Fw::FW_SERIALIZE_OK == _deserStatus,
-        static_cast<FwAssertArgType>(_deserStatus)
-      );
-
-      // Make sure there was no data left over.
-      // That means the buffer size was incorrect.
-      FW_ASSERT(
-        _msg.getDeserializeSizeLeft() == 0,
-        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
-      );
-
-      // Call handler function
-      this->internalStruct_internalInterfaceHandler(
-        s
-      );
-
-      break;
-    }
-
-    default:
-      return MSG_DISPATCH_ERROR;
-  }
-
-  return MSG_DISPATCH_OK;
+    return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
-  dispatchCurrentMessages()
-{
-  // Dispatch all current messages unless ERROR or EXIT occur
-  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-  for (FwSizeType i = 0; i < currentMessageCount; i++) {
-    messageStatus = this->doDispatch();
-    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-      break;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::dispatchCurrentMessages() {
+    // Dispatch all current messages unless ERROR or EXIT occur
+    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+    for (FwSizeType i = 0; i < currentMessageCount; i++) {
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
-  }
-  return messageStatus;
+    return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  m_p_cmdIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      Fw::CmdArgBuffer& args
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->cmdIn_handlerBase(
-    portNum,
-    opCode,
-    cmdSeq,
-    args
-  );
+void QueuedTestComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
+                                            FwIndexType portNum,
+                                            FwOpcodeType opCode,
+                                            U32 cmdSeq,
+                                            Fw::CmdArgBuffer& args) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
 }
 
-void QueuedTestComponentBase ::
-  m_p_productRecvIn_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->productRecvIn_handlerBase(
-    portNum,
-    id,
-    buffer,
-    status
-  );
+void QueuedTestComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
+                                                    FwIndexType portNum,
+                                                    FwDpIdType id,
+                                                    const Fw::Buffer& buffer,
+                                                    const Fw::Success& status) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  m_p_aliasTypedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->aliasTypedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                      FwIndexType portNum,
+                                                      AliasPrim1 u32,
+                                                      AliasPrim2 f32,
+                                                      AliasBool b,
+                                                      const Fw::StringBase& str2,
+                                                      const AliasEnum& e,
+                                                      const AliasArray& a,
+                                                      const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedTestComponentBase ::
-  m_p_noArgsAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTestComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                        FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::
-  m_p_noArgsAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedTestComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::
-  m_p_noArgsGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedTestComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTestComponentBase ::
-  m_p_noArgsReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedTestComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTestComponentBase ::
-  m_p_noArgsReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedTestComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedTestComponentBase ::
-  m_p_noArgsStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTestComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                   FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::
-  m_p_noArgsSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->noArgsSync_handlerBase(portNum);
+void QueuedTestComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::
-  m_p_typedAliasGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->typedAliasGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        AliasPrim1 u32,
+                                                        AliasPrim2 f32,
+                                                        AliasBool b,
+                                                        const Fw::StringBase& str2,
+                                                        const AliasEnum& e,
+                                                        const AliasArray& a,
+                                                        const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-AliasPrim2 QueuedTestComponentBase ::
-  m_p_typedAliasReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->typedAliasReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+AliasPrim2 QueuedTestComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                 FwIndexType portNum,
+                                                                 AliasPrim1 u32,
+                                                                 AliasPrim2 f32,
+                                                                 AliasBool b,
+                                                                 const Fw::StringBase& str2,
+                                                                 const AliasEnum& e,
+                                                                 const AliasArray& a,
+                                                                 const AliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-Fw::String QueuedTestComponentBase ::
-  m_p_typedAliasStringReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      AliasPrim1 u32,
-      AliasPrim2 f32,
-      AliasBool b,
-      const Fw::StringBase& str2,
-      const AliasEnum& e,
-      const AliasArray& a,
-      const AnotherAliasStruct& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->typedAliasStringReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+Fw::String QueuedTestComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                                       FwIndexType portNum,
+                                                                       AliasPrim1 u32,
+                                                                       AliasPrim2 f32,
+                                                                       AliasBool b,
+                                                                       const Fw::StringBase& str2,
+                                                                       const AliasEnum& e,
+                                                                       const AliasArray& a,
+                                                                       const AnotherAliasStruct& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedTestComponentBase ::
-  m_p_typedAsync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->typedAsync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
+                                                 FwIndexType portNum,
+                                                 U32 u32,
+                                                 F32 f32,
+                                                 bool b,
+                                                 const Fw::StringBase& str1,
+                                                 const E& e,
+                                                 const A& a,
+                                                 const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTestComponentBase ::
-  m_p_typedAsyncAssert_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->typedAsyncAssert_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
+                                                       FwIndexType portNum,
+                                                       U32 u32,
+                                                       F32 f32,
+                                                       bool b,
+                                                       const Fw::StringBase& str1,
+                                                       const E& e,
+                                                       const A& a,
+                                                       const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTestComponentBase ::
-  m_p_typedAsyncBlockPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->typedAsyncBlockPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
+                                                              FwIndexType portNum,
+                                                              U32 u32,
+                                                              F32 f32,
+                                                              bool b,
+                                                              const Fw::StringBase& str1,
+                                                              const E& e,
+                                                              const A& a,
+                                                              const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTestComponentBase ::
-  m_p_typedAsyncDropPriority_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->typedAsyncDropPriority_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
+                                                             FwIndexType portNum,
+                                                             U32 u32,
+                                                             F32 f32,
+                                                             bool b,
+                                                             const Fw::StringBase& str1,
+                                                             const E& e,
+                                                             const A& a,
+                                                             const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-void QueuedTestComponentBase ::
-  m_p_typedGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->typedGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 u32,
+                                                   F32 f32,
+                                                   bool b,
+                                                   const Fw::StringBase& str1,
+                                                   const E& e,
+                                                   const A& a,
+                                                   const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
-F32 QueuedTestComponentBase ::
-  m_p_typedReturnGuarded_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->typedReturnGuarded_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedTestComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
+                                                        FwIndexType portNum,
+                                                        U32 u32,
+                                                        F32 f32,
+                                                        bool b,
+                                                        const Fw::StringBase& str2,
+                                                        const E& e,
+                                                        const A& a,
+                                                        const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-F32 QueuedTestComponentBase ::
-  m_p_typedReturnSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  return compPtr->typedReturnSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str2,
-    e,
-    a,
-    s
-  );
+F32 QueuedTestComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
+                                                     FwIndexType portNum,
+                                                     U32 u32,
+                                                     F32 f32,
+                                                     bool b,
+                                                     const Fw::StringBase& str2,
+                                                     const E& e,
+                                                     const A& a,
+                                                     const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
 }
 
-void QueuedTestComponentBase ::
-  m_p_typedSync_in(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const Fw::StringBase& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
-  FW_ASSERT(callComp);
-  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-  compPtr->typedSync_handlerBase(
-    portNum,
-    u32,
-    f32,
-    b,
-    str1,
-    e,
-    a,
-    s
-  );
+void QueuedTestComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
+                                                FwIndexType portNum,
+                                                U32 u32,
+                                                F32 f32,
+                                                bool b,
+                                                const Fw::StringBase& str1,
+                                                const E& e,
+                                                const A& a,
+                                                const S& s) {
+    FW_ASSERT(callComp);
+    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -8650,236 +5433,102 @@ void QueuedTestComponentBase ::
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  cmdRegOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdRegOut_OutputPort[portNum].invoke(
-    opCode
-  );
+    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
 }
 
-void QueuedTestComponentBase ::
-  cmdResponseOut_out(
-      FwIndexType portNum,
-      FwOpcodeType opCode,
-      U32 cmdSeq,
-      const Fw::CmdResponse& response
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::cmdResponseOut_out(FwIndexType portNum,
+                                                  FwOpcodeType opCode,
+                                                  U32 cmdSeq,
+                                                  const Fw::CmdResponse& response) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_cmdResponseOut_OutputPort[portNum].invoke(
-    opCode,
-    cmdSeq,
-    response
-  );
+    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
 }
 
-void QueuedTestComponentBase ::
-  eventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::LogBuffer& args
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::eventOut_out(FwIndexType portNum,
+                                            FwEventIdType id,
+                                            Fw::Time& timeTag,
+                                            const Fw::LogSeverity& severity,
+                                            Fw::LogBuffer& args) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_eventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_eventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    args
-  );
+    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
 }
 
-Fw::ParamValid QueuedTestComponentBase ::
-  prmGetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+Fw::ParamValid QueuedTestComponentBase ::prmGetOut_out(FwIndexType portNum,
+                                                       FwPrmIdType id,
+                                                       Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  return this->m_prmGetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void QueuedTestComponentBase ::
-  prmSetOut_out(
-      FwIndexType portNum,
-      FwPrmIdType id,
-      Fw::ParamBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_prmSetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_prmSetOut_OutputPort[portNum].invoke(
-    id,
-    val
-  );
+    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
 }
 
-void QueuedTestComponentBase ::
-  productRequestOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      FwSizeType dataSize
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::productRequestOut_out(FwIndexType portNum, FwDpIdType id, FwSizeType dataSize) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productRequestOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productRequestOut_OutputPort[portNum].invoke(
-    id,
-    dataSize
-  );
+    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
 }
 
-void QueuedTestComponentBase ::
-  productSendOut_out(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::productSendOut_out(FwIndexType portNum, FwDpIdType id, const Fw::Buffer& buffer) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_productSendOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_productSendOut_OutputPort[portNum].invoke(
-    id,
-    buffer
-  );
+    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void QueuedTestComponentBase ::
-  textEventOut_out(
-      FwIndexType portNum,
-      FwEventIdType id,
-      Fw::Time& timeTag,
-      const Fw::LogSeverity& severity,
-      Fw::TextLogString& text
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::textEventOut_out(FwIndexType portNum,
+                                                FwEventIdType id,
+                                                Fw::Time& timeTag,
+                                                const Fw::LogSeverity& severity,
+                                                Fw::TextLogString& text) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_textEventOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_textEventOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    severity,
-    text
-  );
+    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
 }
 
 #endif
 
-void QueuedTestComponentBase ::
-  timeGetOut_out(
-      FwIndexType portNum,
-      Fw::Time& time
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+              static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_timeGetOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_timeGetOut_OutputPort[portNum].invoke(
-    time
-  );
+    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_timeGetOut_OutputPort[portNum].invoke(time);
 }
 
-void QueuedTestComponentBase ::
-  tlmOut_out(
-      FwIndexType portNum,
-      FwChanIdType id,
-      Fw::Time& timeTag,
-      Fw::TlmBuffer& val
-  ) const
-{
-  FW_ASSERT(
-    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
-    static_cast<FwAssertArgType>(portNum)
-  );
+void QueuedTestComponentBase ::tlmOut_out(FwIndexType portNum,
+                                          FwChanIdType id,
+                                          Fw::Time& timeTag,
+                                          Fw::TlmBuffer& val) const {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
 
-  FW_ASSERT(
-    this->m_tlmOut_OutputPort[portNum].isConnected(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-  this->m_tlmOut_OutputPort[portNum].invoke(
-    id,
-    timeTag,
-    val
-  );
+    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
+    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
 }
 
 #endif
@@ -8888,757 +5537,612 @@ void QueuedTestComponentBase ::
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamU32(Fw::SerialBufferBase& val)
-{
-  U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
+    U32 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamU32 = _localVal;
-  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamU32 = _localVal;
+    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMU32);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMU32);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamF64(Fw::SerialBufferBase& val)
-{
-  F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
+    F64 _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamF64 = _localVal;
-  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamF64 = _localVal;
+    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMF64);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMF64);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamString(Fw::SerialBufferBase& val)
-{
-  Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
+    Fw::ParamString _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamString = _localVal;
-  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamString = _localVal;
+    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamEnum(Fw::SerialBufferBase& val)
-{
-  E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
+    E _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamEnum = _localVal;
-  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamEnum = _localVal;
+    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMENUM);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamArray(Fw::SerialBufferBase& val)
-{
-  A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
+    A _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamArray = _localVal;
-  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamArray = _localVal;
+    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamStruct(Fw::SerialBufferBase& val)
-{
-  S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
+    S _localVal{};
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
 
-  // Assign value only if successfully deserialized
-  this->m_paramLock.lock();
-  this->m_ParamStruct = _localVal;
-  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-  this->m_paramLock.unlock();
+    // Assign value only if successfully deserialized
+    this->m_paramLock.lock();
+    this->m_ParamStruct = _localVal;
+    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  return Fw::CmdResponse::OK;
+    // Call notifier
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMI32EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMI32EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMF64EXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMF64EXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRINGEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMENUMEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMENUMEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMARRAYEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+    }
+    return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
-{
-  Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
+    Fw::CmdResponse _response{};
 
-  this->m_paramLock.lock();
-  // Update the external parameter
-  FW_ASSERT(this->paramDelegatePtr != nullptr);
-  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-    static_cast<FwPrmIdType>(this->getIdBase()),
-    PARAMID_PARAMSTRUCTEXT,
-    Fw::ParamValid::VALID,
-    val
-  );
-  // Set response and update component state
-  if (_stat == Fw::FW_SERIALIZE_OK) {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-    _response = Fw::CmdResponse::OK;
-  }
-  else {
-    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-    _response = Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  this->m_paramLock.unlock();
+    this->m_paramLock.lock();
+    // Update the external parameter
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
+    // Set response and update component state
+    if (_stat == Fw::FW_SERIALIZE_OK) {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+        _response = Fw::CmdResponse::OK;
+    } else {
+        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+        _response = Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    this->m_paramLock.unlock();
 
-  // Call notifier
-  if (_response == Fw::CmdResponse::OK) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-  }
-  return _response;
+    // Call notifier
+    if (_response == Fw::CmdResponse::OK) {
+        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    }
+    return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamU32()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamU32);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamU32() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamU32);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamF64()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamF64);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamF64() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamF64);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamString()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamString);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamString() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamString);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamEnum()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamEnum() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamArray()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamArray);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamArray() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamArray);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamStruct()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamStruct() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamI32Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMI32EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamI32Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamF64Ext()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMF64EXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamF64Ext() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat =
+            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamStringExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRINGEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamStringExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamEnumExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMENUMEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamEnumExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamArrayExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMARRAYEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamArrayExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::
-  paramSave_ParamStructExt()
-{
-  if (!this->isConnected_prmSetOut_OutputPort(0)) {
-    return Fw::CmdResponse::EXECUTION_ERROR;
-  }
-  Fw::ParamBuffer _paramBuffer;
-  const FwIdType idBase = this->getIdBase();
-  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-  // Serialize the parameter
-  this->m_paramLock.lock();
-  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->serializeParam(
-      static_cast<FwPrmIdType>(idBase),
-      PARAMID_PARAMSTRUCTEXT,
-      _paramBuffer
-    );
-  }
-  this->m_paramLock.unlock();
-  if (_stat != Fw::FW_SERIALIZE_OK) {
-    return Fw::CmdResponse::VALIDATION_ERROR;
-  }
-  // Save the parameter
-  this->prmSetOut_out(
-    0,
-    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
-    _paramBuffer
-  );
-  // Return the command response
-  return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamStructExt() {
+    if (!this->isConnected_prmSetOut_OutputPort(0)) {
+        return Fw::CmdResponse::EXECUTION_ERROR;
+    }
+    Fw::ParamBuffer _paramBuffer;
+    const FwIdType idBase = this->getIdBase();
+    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+    // Serialize the parameter
+    this->m_paramLock.lock();
+    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
+        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+        FW_ASSERT(this->paramDelegatePtr != nullptr);
+        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
+                                                       _paramBuffer);
+    }
+    this->m_paramLock.unlock();
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+        return Fw::CmdResponse::VALIDATION_ERROR;
+    }
+    // Save the parameter
+    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
+    // Return the command response
+    return Fw::CmdResponse::OK;
 }
 
 // ----------------------------------------------------------------------
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::
-  dpRequest(
-      ContainerId::T containerId,
-      FwSizeType dataSize
-  )
-{
-  const FwDpIdType globalId = this->getIdBase() + containerId;
-  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-  this->productRequestOut_out(0, globalId, size);
+void QueuedTestComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
+    const FwDpIdType globalId = this->getIdBase() + containerId;
+    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+    this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedTestComponentBase ::
-  productRecvIn_handler(
-      const FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  DpContainer container;
-  if (status == Fw::Success::SUCCESS) {
-    container = DpContainer(id, buffer, this->getIdBase());
-  }
-  // Convert global id to local id
-  const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(
-    id >= idBase,
-    static_cast<FwAssertArgType>(id),
-    static_cast<FwAssertArgType>(idBase)
-  );
-  const FwDpIdType localId = id - idBase;
-  // Switch on the local id
-  switch (localId) {
-    case ContainerId::Container1:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container1);
-      // Call the handler
-      this->dpRecv_Container1_handler(container, status.e);
-      break;
-    case ContainerId::Container2:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container2);
-      // Call the handler
-      this->dpRecv_Container2_handler(container, status.e);
-      break;
-    case ContainerId::Container3:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container3);
-      // Call the handler
-      this->dpRecv_Container3_handler(container, status.e);
-      break;
-    case ContainerId::Container4:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container4);
-      // Call the handler
-      this->dpRecv_Container4_handler(container, status.e);
-      break;
-    case ContainerId::Container5:
-      // Set the priority
-      container.setPriority(ContainerPriority::Container5);
-      // Call the handler
-      this->dpRecv_Container5_handler(container, status.e);
-      break;
-    default:
-      FW_ASSERT(0);
-      break;
-  }
+void QueuedTestComponentBase ::productRecvIn_handler(const FwIndexType portNum,
+                                                     FwDpIdType id,
+                                                     const Fw::Buffer& buffer,
+                                                     const Fw::Success& status) {
+    DpContainer container;
+    if (status == Fw::Success::SUCCESS) {
+        container = DpContainer(id, buffer, this->getIdBase());
+    }
+    // Convert global id to local id
+    const FwDpIdType idBase = this->getIdBase();
+    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
+    const FwDpIdType localId = id - idBase;
+    // Switch on the local id
+    switch (localId) {
+        case ContainerId::Container1:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container1);
+            // Call the handler
+            this->dpRecv_Container1_handler(container, status.e);
+            break;
+        case ContainerId::Container2:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container2);
+            // Call the handler
+            this->dpRecv_Container2_handler(container, status.e);
+            break;
+        case ContainerId::Container3:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container3);
+            // Call the handler
+            this->dpRecv_Container3_handler(container, status.e);
+            break;
+        case ContainerId::Container4:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container4);
+            // Call the handler
+            this->dpRecv_Container4_handler(container, status.e);
+            break;
+        case ContainerId::Container5:
+            // Set the priority
+            container.setPriority(ContainerPriority::Container5);
+            // Call the handler
+            this->dpRecv_Container5_handler(container, status.e);
+            break;
+        default:
+            FW_ASSERT(0);
+            break;
+    }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -12,7 +12,7 @@
 #include "QueuedTestComponentAc.hpp"
 
 namespace {
-enum MsgTypeEnum {
+  enum MsgTypeEnum {
     QUEUEDTEST_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
     PRODUCTRECVIN_DPRESPONSE,
     ALIASTYPEDASYNC_ALIASTYPED,
@@ -32,11 +32,11 @@ enum MsgTypeEnum {
     INT_IF_INTERNALPRIORITYDROP,
     INT_IF_INTERNALSTRING,
     INT_IF_INTERNALSTRUCT,
-};
+  };
 
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
+  // Get the max size by constructing a union of the async input, command, and
+  // internal port serialization sizes
+  union BuffUnion {
     BYTE productRecvInPortSize[Fw::DpResponsePortBuffer::CAPACITY];
     BYTE aliasTypedAsyncPortSize[Ports::AliasTypedPortBuffer::CAPACITY];
     BYTE typedAsyncPortSize[Ports::TypedPortBuffer::CAPACITY];
@@ -45,779 +45,1227 @@ union BuffUnion {
     BYTE typedAsyncDropPriorityPortSize[Ports::TypedPortBuffer::CAPACITY];
     BYTE cmdPortSize[Fw::CmdPortBuffer::CAPACITY];
     // Size of internalArray argument list
-    BYTE internalArrayIntIfSize[A::SERIALIZED_SIZE];
+    BYTE internalArrayIntIfSize[
+      A::SERIALIZED_SIZE
+    ];
     // Size of internalEnum argument list
-    BYTE internalEnumIntIfSize[E::SERIALIZED_SIZE];
+    BYTE internalEnumIntIfSize[
+      E::SERIALIZED_SIZE
+    ];
     // Size of internalPrimitive argument list
-    BYTE internalPrimitiveIntIfSize[sizeof(U32) + sizeof(F32) + sizeof(U8)];
+    BYTE internalPrimitiveIntIfSize[
+      sizeof(U32) +
+      sizeof(F32) +
+      sizeof(U8)
+    ];
     // Size of internalString argument list
-    BYTE internalStringIntIfSize[Fw::InternalInterfaceString::SERIALIZED_SIZE +
-                                 Fw::InternalInterfaceString::SERIALIZED_SIZE];
+    BYTE internalStringIntIfSize[
+      Fw::InternalInterfaceString::SERIALIZED_SIZE +
+      Fw::InternalInterfaceString::SERIALIZED_SIZE
+    ];
     // Size of internalStruct argument list
-    BYTE internalStructIntIfSize[S::SERIALIZED_SIZE];
-};
+    BYTE internalStructIntIfSize[
+      S::SERIALIZED_SIZE
+    ];
+  };
 
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
+  // Define a message buffer class large enough to handle all the
+  // asynchronous inputs to the component
+  class ComponentIpcSerializableBuffer :
+    public Fw::LinearBufferBase
+  {
+
+    public:
+
+      enum {
         // Offset into data in buffer: Size of message ID and port number
         DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
         // Max data size
         MAX_DATA_SIZE = sizeof(BuffUnion),
         // Max message size: Size of message id + size of port + max data size
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
+      };
 
-    ComponentIpcSerializableBuffer() {
+      ComponentIpcSerializableBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = sizeof(m_buff);
-    }
+      }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    private:
+      // Should be the max of all the input ports serialized sizes...
+      U8 m_buff[SERIALIZATION_SIZE];
+
+  };
+}
 
 // ----------------------------------------------------------------------
 // Types for data products
 // ----------------------------------------------------------------------
 
-QueuedTestComponentBase::DpContainer ::DpContainer(FwDpIdType id, const Fw::Buffer& buffer, FwDpIdType baseId)
-    : Fw::DpContainer(id, buffer), m_baseId(baseId) {}
+QueuedTestComponentBase::DpContainer ::
+  DpContainer(
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      FwDpIdType baseId
+  ) :
+    Fw::DpContainer(id, buffer),
+    m_baseId(baseId)
+{
 
-QueuedTestComponentBase::DpContainer ::DpContainer() : Fw::DpContainer(), m_baseId(0) {}
+}
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_DataArrayRecord(const QueuedTest_Data* array,
-                                                                                           FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+QueuedTestComponentBase::DpContainer ::
+  DpContainer() :
+    Fw::DpContainer(),
+    m_baseId(0)
+{
+
+}
+
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
+  serializeRecord_DataArrayRecord(
+      const QueuedTest_Data* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    sizeDelta += array[i].serializedSize();
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        sizeDelta += array[i].serializedSize();
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_DataRecord(const QueuedTest_Data& elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedSize();
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
+  serializeRecord_DataRecord(const QueuedTest_Data& elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedSize();
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_StringArrayRecord(
-    const Fw::StringBase** array,
-    FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType);
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
+  serializeRecord_StringArrayRecord(
+      const Fw::StringBase** array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType);
+  for (FwSizeType i = 0; i < size; i++) {
+    const Fw::StringBase *const sbPtr = array[i];
+    FW_ASSERT(sbPtr != nullptr);
+    sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+  }
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-        const Fw::StringBase* const sbPtr = array[i];
-        FW_ASSERT(sbPtr != nullptr);
-        sizeDelta += sbPtr->serializedTruncatedSize(stringSize);
+      const Fw::StringBase *const sbPtr = array[i];
+      FW_ASSERT(sbPtr != nullptr);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            const Fw::StringBase* const sbPtr = array[i];
-            FW_ASSERT(sbPtr != nullptr);
-            status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_StringRecord(const Fw::StringBase& elt) {
-    const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + elt.serializedTruncatedSize(stringSize);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = elt.serializeTo(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
+  serializeRecord_StringRecord(const Fw::StringBase& elt)
+{
+  const FwSizeType stringSize = static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE);
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    elt.serializedTruncatedSize(stringSize);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_U32ArrayRecord(const U32* array,
-                                                                                          FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U32);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        for (FwSizeType i = 0; i < size; i++) {
-            status = this->m_dataBuffer.serializeFrom(array[i]);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        }
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
+  serializeRecord_U32ArrayRecord(
+      const U32* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U32);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    for (FwSizeType i = 0; i < size; i++) {
+      status = this->m_dataBuffer.serializeFrom(array[i]);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
-    return status;
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_U32Record(U32 elt) {
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(U32);
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(elt);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
+  serializeRecord_U32Record(U32 elt)
+{
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(U32);
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if (this->m_dataBuffer.getSize() + sizeDelta <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(elt);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
-Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::serializeRecord_U8ArrayRecord(const U8* array,
-                                                                                         FwSizeType size) {
-    FW_ASSERT(array != nullptr);
-    // Compute the size delta
-    const FwSizeType sizeDelta = sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + size * sizeof(U8);
-    // Serialize the elements if they will fit
-    Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
-    if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
-        const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-        status = this->m_dataBuffer.serializeFrom(id);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeSize(size);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        this->m_dataSize += sizeDelta;
-    } else {
-        status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
-    }
-    return status;
+Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
+  serializeRecord_U8ArrayRecord(
+      const U8* array,
+      FwSizeType size
+  )
+{
+  FW_ASSERT(array != nullptr);
+  // Compute the size delta
+  const FwSizeType sizeDelta =
+    sizeof(FwDpIdType) +
+    sizeof(FwSizeStoreType) +
+    size * sizeof(U8);
+  // Serialize the elements if they will fit
+  Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
+  if ((this->m_dataBuffer.getSize() + sizeDelta) <= this->m_dataBuffer.getCapacity()) {
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
+    status = this->m_dataBuffer.serializeFrom(id);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeSize(size);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    this->m_dataSize += sizeDelta;
+  }
+  else {
+    status = Fw::FW_SERIALIZE_NO_ROOM_LEFT;
+  }
+  return status;
 }
 
 // ----------------------------------------------------------------------
 // Component initialization
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
-    // Initialize base class
-    Fw::QueuedComponentBase::init(instance);
+void QueuedTestComponentBase ::
+  init(
+      FwSizeType queueDepth,
+      FwEnumStoreType instance
+  )
+{
+  // Initialize base class
+  Fw::QueuedComponentBase::init(instance);
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port cmdIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts()); port++) {
-        this->m_cmdIn_InputPort[port].init();
-        this->m_cmdIn_InputPort[port].addCallComp(this, m_p_cmdIn_in);
-        this->m_cmdIn_InputPort[port].setPortNum(port);
+  // Connect input port cmdIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdIn_InputPorts());
+    port++
+  ) {
+    this->m_cmdIn_InputPort[port].init();
+    this->m_cmdIn_InputPort[port].addCallComp(
+      this,
+      m_p_cmdIn_in
+    );
+    this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port productRecvIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts()); port++) {
-        this->m_productRecvIn_InputPort[port].init();
-        this->m_productRecvIn_InputPort[port].addCallComp(this, m_p_productRecvIn_in);
-        this->m_productRecvIn_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRecvIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
-#endif
-
-#if !FW_DIRECT_PORT_CALLS
-    // Connect input port aliasTypedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts()); port++) {
-        this->m_aliasTypedAsync_InputPort[port].init();
-        this->m_aliasTypedAsync_InputPort[port].addCallComp(this, m_p_aliasTypedAsync_in);
-        this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
-
-#if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
-#endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsAliasStringReturnSync_InputPort[port].init();
-        this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsAliasStringReturnSync_in);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port productRecvIn
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRecvIn_InputPorts());
+    port++
+  ) {
+    this->m_productRecvIn_InputPort[port].init();
+    this->m_productRecvIn_InputPort[port].addCallComp(
+      this,
+      m_p_productRecvIn_in
+    );
+    this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts()); port++) {
-        this->m_noArgsAsync_InputPort[port].init();
-        this->m_noArgsAsync_InputPort[port].addCallComp(this, m_p_noArgsAsync_in);
-        this->m_noArgsAsync_InputPort[port].setPortNum(port);
+  // Connect input port aliasTypedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_aliasTypedAsync_InputPorts());
+    port++
+  ) {
+    this->m_aliasTypedAsync_InputPort[port].init();
+    this->m_aliasTypedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_aliasTypedAsync_in
+    );
+    this->m_aliasTypedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_aliasTypedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts()); port++) {
-        this->m_noArgsGuarded_InputPort[port].init();
-        this->m_noArgsGuarded_InputPort[port].addCallComp(this, m_p_noArgsGuarded_in);
-        this->m_noArgsGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAliasStringReturnSync_InputPort[port].init();
+    this->m_noArgsAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAliasStringReturnSync_in
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts()); port++) {
-        this->m_noArgsReturnGuarded_InputPort[port].init();
-        this->m_noArgsReturnGuarded_InputPort[port].addCallComp(this, m_p_noArgsReturnGuarded_in);
-        this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsAsync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsAsync_InputPort[port].init();
+    this->m_noArgsAsync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsAsync_in
+    );
+    this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts()); port++) {
-        this->m_noArgsReturnSync_InputPort[port].init();
-        this->m_noArgsReturnSync_InputPort[port].addCallComp(this, m_p_noArgsReturnSync_in);
-        this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsGuarded_InputPort[port].init();
+    this->m_noArgsGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsGuarded_in
+    );
+    this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
-         port++) {
-        this->m_noArgsStringReturnSync_InputPort[port].init();
-        this->m_noArgsStringReturnSync_InputPort[port].addCallComp(this, m_p_noArgsStringReturnSync_in);
-        this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnGuarded_InputPort[port].init();
+    this->m_noArgsReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnGuarded_in
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port noArgsSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts()); port++) {
-        this->m_noArgsSync_InputPort[port].init();
-        this->m_noArgsSync_InputPort[port].addCallComp(this, m_p_noArgsSync_in);
-        this->m_noArgsSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnSync_InputPort[port].init();
+    this->m_noArgsReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsReturnSync_in
+    );
+    this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts()); port++) {
-        this->m_typedAliasGuarded_InputPort[port].init();
-        this->m_typedAliasGuarded_InputPort[port].addCallComp(this, m_p_typedAliasGuarded_in);
-        this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
+  // Connect input port noArgsStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnSync_InputPort[port].init();
+    this->m_noArgsStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsStringReturnSync_in
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasReturnSync_InputPort[port].init();
-        this->m_typedAliasReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasReturnSync_in);
-        this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port noArgsSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsSync_InputPorts());
+    port++
+  ) {
+    this->m_noArgsSync_InputPort[port].init();
+    this->m_noArgsSync_InputPort[port].addCallComp(
+      this,
+      m_p_noArgsSync_in
+    );
+    this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAliasStringReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
-         port++) {
-        this->m_typedAliasStringReturnSync_InputPort[port].init();
-        this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(this, m_p_typedAliasStringReturnSync_in);
-        this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasGuarded_InputPort[port].init();
+    this->m_typedAliasGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasGuarded_in
+    );
+    this->m_typedAliasGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts()); port++) {
-        this->m_typedAsync_InputPort[port].init();
-        this->m_typedAsync_InputPort[port].addCallComp(this, m_p_typedAsync_in);
-        this->m_typedAsync_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnSync_InputPort[port].init();
+    this->m_typedAliasReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasReturnSync_in
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncAssert
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts()); port++) {
-        this->m_typedAsyncAssert_InputPort[port].init();
-        this->m_typedAsyncAssert_InputPort[port].addCallComp(this, m_p_typedAsyncAssert_in);
-        this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
+  // Connect input port typedAliasStringReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasStringReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedAliasStringReturnSync_InputPort[port].init();
+    this->m_typedAliasStringReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAliasStringReturnSync_in
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasStringReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncBlockPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncBlockPriority_InputPort[port].init();
-        this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(this, m_p_typedAsyncBlockPriority_in);
-        this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsync_InputPorts());
+    port++
+  ) {
+    this->m_typedAsync_InputPort[port].init();
+    this->m_typedAsync_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsync_in
+    );
+    this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedAsyncDropPriority
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
-         port++) {
-        this->m_typedAsyncDropPriority_InputPort[port].init();
-        this->m_typedAsyncDropPriority_InputPort[port].addCallComp(this, m_p_typedAsyncDropPriority_in);
-        this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncAssert
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncAssert_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncAssert_InputPort[port].init();
+    this->m_typedAsyncAssert_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncAssert_in
+    );
+    this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts()); port++) {
-        this->m_typedGuarded_InputPort[port].init();
-        this->m_typedGuarded_InputPort[port].addCallComp(this, m_p_typedGuarded_in);
-        this->m_typedGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncBlockPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncBlockPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncBlockPriority_InputPort[port].init();
+    this->m_typedAsyncBlockPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncBlockPriority_in
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnGuarded
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts()); port++) {
-        this->m_typedReturnGuarded_InputPort[port].init();
-        this->m_typedReturnGuarded_InputPort[port].addCallComp(this, m_p_typedReturnGuarded_in);
-        this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
+  // Connect input port typedAsyncDropPriority
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAsyncDropPriority_InputPorts());
+    port++
+  ) {
+    this->m_typedAsyncDropPriority_InputPort[port].init();
+    this->m_typedAsyncDropPriority_InputPort[port].addCallComp(
+      this,
+      m_p_typedAsyncDropPriority_in
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedReturnSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts()); port++) {
-        this->m_typedReturnSync_InputPort[port].init();
-        this->m_typedReturnSync_InputPort[port].addCallComp(this, m_p_typedReturnSync_in);
-        this->m_typedReturnSync_InputPort[port].setPortNum(port);
+  // Connect input port typedGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedGuarded_InputPort[port].init();
+    this->m_typedGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedGuarded_in
+    );
+    this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect input port typedSync
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts()); port++) {
-        this->m_typedSync_InputPort[port].init();
-        this->m_typedSync_InputPort[port].addCallComp(this, m_p_typedSync_in);
-        this->m_typedSync_InputPort[port].setPortNum(port);
+  // Connect input port typedReturnGuarded
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnGuarded_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnGuarded_InputPort[port].init();
+    this->m_typedReturnGuarded_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnGuarded_in
+    );
+    this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedSync_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedSync_InputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdRegOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts()); port++) {
-        this->m_cmdRegOut_OutputPort[port].init();
+  // Connect input port typedReturnSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnSync_InputPorts());
+    port++
+  ) {
+    this->m_typedReturnSync_InputPort[port].init();
+    this->m_typedReturnSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedReturnSync_in
+    );
+    this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port cmdResponseOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts()); port++) {
-        this->m_cmdResponseOut_OutputPort[port].init();
+  // Connect input port typedSync
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedSync_InputPorts());
+    port++
+  ) {
+    this->m_typedSync_InputPort[port].init();
+    this->m_typedSync_InputPort[port].addCallComp(
+      this,
+      m_p_typedSync_in
+    );
+    this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port eventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts()); port++) {
-        this->m_eventOut_OutputPort[port].init();
+  // Connect output port cmdRegOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdRegOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_eventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts()); port++) {
-        this->m_prmGetOut_OutputPort[port].init();
+  // Connect output port cmdResponseOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_cmdResponseOut_OutputPorts());
+    port++
+  ) {
+    this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port prmSetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts()); port++) {
-        this->m_prmSetOut_OutputPort[port].init();
+  // Connect output port eventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_eventOut_OutputPorts());
+    port++
+  ) {
+    this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productRequestOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts()); port++) {
-        this->m_productRequestOut_OutputPort[port].init();
+  // Connect output port prmGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port productSendOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts()); port++) {
-        this->m_productSendOut_OutputPort[port].init();
+  // Connect output port prmSetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_prmSetOut_OutputPorts());
+    port++
+  ) {
+    this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_productSendOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productRequestOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productRequestOut_OutputPorts());
+    port++
+  ) {
+    this->m_productRequestOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
+#endif
+
+#if !FW_DIRECT_PORT_CALLS
+  // Connect output port productSendOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_productSendOut_OutputPorts());
+    port++
+  ) {
+    this->m_productSendOut_OutputPort[port].init();
+
+#if FW_OBJECT_NAMES == 1
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
+#endif
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS && FW_ENABLE_TEXT_LOGGING
-    // Connect output port textEventOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts()); port++) {
-        this->m_textEventOut_OutputPort[port].init();
+  // Connect output port textEventOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_textEventOut_OutputPorts());
+    port++
+  ) {
+    this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_textEventOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port timeGetOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts()); port++) {
-        this->m_timeGetOut_OutputPort[port].init();
+  // Connect output port timeGetOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_timeGetOut_OutputPorts());
+    port++
+  ) {
+    this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port tlmOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts()); port++) {
-        this->m_tlmOut_OutputPort[port].init();
+  // Connect output port tlmOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_tlmOut_OutputPorts());
+    port++
+  ) {
+    this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_tlmOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts()); port++) {
-        this->m_noArgsOut_OutputPort[port].init();
+  // Connect output port noArgsOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts()); port++) {
-        this->m_noArgsReturnOut_OutputPort[port].init();
+  // Connect output port noArgsReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port noArgsStringReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
-         port++) {
-        this->m_noArgsStringReturnOut_OutputPort[port].init();
+  // Connect output port noArgsStringReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_noArgsStringReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_noArgsStringReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_noArgsStringReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts()); port++) {
-        this->m_typedAliasOut_OutputPort[port].init();
+  // Connect output port typedAliasOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedAliasReturnStringOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
-         port++) {
-        this->m_typedAliasReturnStringOut_OutputPort[port].init();
+  // Connect output port typedAliasReturnStringOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedAliasReturnStringOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedAliasReturnStringOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(),
-                        port);
-        this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedAliasReturnStringOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts()); port++) {
-        this->m_typedOut_OutputPort[port].init();
+  // Connect output port typedOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
 #if !FW_DIRECT_PORT_CALLS
-    // Connect output port typedReturnOut
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts()); port++) {
-        this->m_typedReturnOut_OutputPort[port].init();
+  // Connect output port typedReturnOut
+  for (
+    FwIndexType port = 0;
+    port < static_cast<FwIndexType>(this->getNum_typedReturnOut_OutputPorts());
+    port++
+  ) {
+    this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
+    Fw::ObjectName portName;
+    portName.format(
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
+      this->m_objName.toChar(),
+      port
+    );
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
-    }
+  }
 #endif
 
-    // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+  // Create the queue
+  Os::Queue::Status qStat = this->createQueue(
+    queueDepth,
+    static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+  );
+  FW_ASSERT(
+    Os::Queue::Status::OP_OK == qStat,
+    static_cast<FwAssertArgType>(qStat)
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -826,17 +1274,26 @@ void QueuedTestComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType insta
 // Getters for special input ports
 // ----------------------------------------------------------------------
 
-Fw::InputCmdPort* QueuedTestComponentBase ::get_cmdIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Fw::InputCmdPort* QueuedTestComponentBase ::
+  get_cmdIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_cmdIn_InputPort[portNum];
+  return &this->m_cmdIn_InputPort[portNum];
 }
 
-Fw::InputDpResponsePort* QueuedTestComponentBase ::get_productRecvIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::InputDpResponsePort* QueuedTestComponentBase ::
+  get_productRecvIn_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_productRecvIn_InputPort[portNum];
+  return &this->m_productRecvIn_InputPort[portNum];
 }
 
 #endif
@@ -847,139 +1304,213 @@ Fw::InputDpResponsePort* QueuedTestComponentBase ::get_productRecvIn_InputPort(F
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-Ports::InputAliasTypedPort* QueuedTestComponentBase ::get_aliasTypedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedTestComponentBase ::
+  get_aliasTypedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_aliasTypedAsync_InputPort[portNum];
+  return &this->m_aliasTypedAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsAliasStringReturnPort* QueuedTestComponentBase ::get_noArgsAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsAliasStringReturnPort* QueuedTestComponentBase ::
+  get_noArgsAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTestComponentBase ::get_noArgsAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
+  get_noArgsAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsAsync_InputPort[portNum];
+  return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTestComponentBase ::get_noArgsGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
+  get_noArgsGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsGuarded_InputPort[portNum];
+  return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::get_noArgsReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
+  get_noArgsReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnGuarded_InputPort[portNum];
+  return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::get_noArgsReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
+  get_noArgsReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsReturnSync_InputPort[portNum];
+  return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsStringReturnPort* QueuedTestComponentBase ::get_noArgsStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsStringReturnPort* QueuedTestComponentBase ::
+  get_noArgsStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsStringReturnSync_InputPort[portNum];
+  return &this->m_noArgsStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputNoArgsPort* QueuedTestComponentBase ::get_noArgsSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
+  get_noArgsSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_noArgsSync_InputPort[portNum];
+  return &this->m_noArgsSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedPort* QueuedTestComponentBase ::get_typedAliasGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedPort* QueuedTestComponentBase ::
+  get_typedAliasGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasGuarded_InputPort[portNum];
+  return &this->m_typedAliasGuarded_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnPort* QueuedTestComponentBase ::get_typedAliasReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnPort* QueuedTestComponentBase ::
+  get_typedAliasReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasReturnSync_InputPort[portNum];
+  return &this->m_typedAliasReturnSync_InputPort[portNum];
 }
 
-Ports::InputAliasTypedReturnStringPort* QueuedTestComponentBase ::get_typedAliasStringReturnSync_InputPort(
-    FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputAliasTypedReturnStringPort* QueuedTestComponentBase ::
+  get_typedAliasStringReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAliasStringReturnSync_InputPort[portNum];
+  return &this->m_typedAliasStringReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTestComponentBase ::
+  get_typedAsync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsync_InputPort[portNum];
+  return &this->m_typedAsync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsyncAssert_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTestComponentBase ::
+  get_typedAsyncAssert_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncAssert_InputPort[portNum];
+  return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsyncBlockPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTestComponentBase ::
+  get_typedAsyncBlockPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncBlockPriority_InputPort[portNum];
+  return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::get_typedAsyncDropPriority_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTestComponentBase ::
+  get_typedAsyncDropPriority_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedAsyncDropPriority_InputPort[portNum];
+  return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::get_typedGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTestComponentBase ::
+  get_typedGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedGuarded_InputPort[portNum];
+  return &this->m_typedGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTestComponentBase ::get_typedReturnGuarded_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::
+  get_typedReturnGuarded_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnGuarded_InputPort[portNum];
+  return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-Ports::InputTypedReturnPort* QueuedTestComponentBase ::get_typedReturnSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::
+  get_typedReturnSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedReturnSync_InputPort[portNum];
+  return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-Ports::InputTypedPort* QueuedTestComponentBase ::get_typedSync_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+Ports::InputTypedPort* QueuedTestComponentBase ::
+  get_typedSync_InputPort(FwIndexType portNum)
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return &this->m_typedSync_InputPort[portNum];
+  return &this->m_typedSync_InputPort[portNum];
 }
 
 #endif
@@ -990,76 +1521,148 @@ Ports::InputTypedPort* QueuedTestComponentBase ::get_typedSync_InputPort(FwIndex
 // Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputCmdRegPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdRegPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputCmdResponsePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputCmdResponsePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputLogPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].addCallPort(port);
+  this->m_eventOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_prmGetOut_OutputPort(FwIndexType portNum, Fw::InputPrmGetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_prmGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmGetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputPrmSetPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputPrmSetPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
+  this->m_prmSetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputDpRequestPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpRequestPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
+  this->m_productRequestOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputDpSendPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputDpSendPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].addCallPort(port);
+  this->m_productSendOut_OutputPort[portNum].addCallPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputLogTextPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputLogTextPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].addCallPort(port);
+  this->m_textEventOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
 
-void QueuedTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputTimePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTimePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
+  this->m_timeGetOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputTlmPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputTlmPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].addCallPort(port);
+  this->m_tlmOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1070,62 +1673,116 @@ void QueuedTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::In
 // Connect typed input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_noArgsReturnOut_OutputPort(FwIndexType portNum, Ports::InputNoArgsReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_noArgsReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_noArgsStringReturnOut_OutputPort(FwIndexType portNum,
-                                                                    Ports::InputNoArgsStringReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_noArgsStringReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputNoArgsStringReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_noArgsStringReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Ports::InputAliasTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_typedAliasReturnOut_OutputPort(FwIndexType portNum,
-                                                                  Ports::InputAliasTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_typedAliasReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_typedAliasReturnStringOut_OutputPort(FwIndexType portNum,
-                                                                        Ports::InputAliasTypedReturnStringPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_typedAliasReturnStringOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputAliasTypedReturnStringPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedAliasReturnStringOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Ports::InputTypedPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedOut_OutputPort[portNum].addCallPort(port);
 }
 
-void QueuedTestComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum, Ports::InputTypedReturnPort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_typedReturnOut_OutputPort(
+      FwIndexType portNum,
+      Ports::InputTypedReturnPort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
+  this->m_typedReturnOut_OutputPort[portNum].addCallPort(port);
 }
 
 #endif
@@ -1136,69 +1793,134 @@ void QueuedTestComponentBase ::set_typedReturnOut_OutputPort(FwIndexType portNum
 // Connect serial input ports to special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::set_cmdRegOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_cmdRegOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdRegOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_cmdResponseOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_cmdResponseOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_cmdResponseOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_eventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_eventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_eventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_prmSetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_prmSetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_prmSetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_productRequestOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_productRequestOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productRequestOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_productSendOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_productSendOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_productSendOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-void QueuedTestComponentBase ::set_textEventOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_textEventOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_textEventOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
 
-void QueuedTestComponentBase ::set_timeGetOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_timeGetOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_timeGetOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_tlmOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_tlmOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1209,24 +1931,46 @@ void QueuedTestComponentBase ::set_tlmOut_OutputPort(FwIndexType portNum, Fw::In
 // Connect serial input ports to typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::set_noArgsOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_noArgsOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_noArgsOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_typedAliasOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_typedAliasOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedAliasOut_OutputPort[portNum].registerSerialPort(port);
 }
 
-void QueuedTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::InputSerializePort* port) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  set_typedOut_OutputPort(
+      FwIndexType portNum,
+      Fw::InputSerializePort* port
+  )
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
+  this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif
@@ -1235,368 +1979,586 @@ void QueuedTestComponentBase ::set_typedOut_OutputPort(FwIndexType portNum, Fw::
 // Command registration
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::regCommands() {
-    FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
+void QueuedTestComponentBase ::
+  regCommands()
+{
+  FW_ASSERT(this->isConnected_cmdRegOut_OutputPort(0));
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_SYNC_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRING);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ENUM);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_ASYNC);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_ASYNC
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMU32_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMU32_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRING_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUM_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAY_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMI32EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMF64EXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+  );
 
-    this->cmdRegOut_out(0, this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE);
+  this->cmdRegOut_out(
+    0,
+    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+  );
 }
 
 // ----------------------------------------------------------------------
 // Parameter loading
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::loadParameters() {
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
-    const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
-    FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
+void QueuedTestComponentBase ::
+  loadParameters()
+{
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_OK;
+  const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
+  FW_ASSERT(this->isConnected_prmGetOut_OutputPort(0));
 
-    FwPrmIdType _id{};
-    Fw::ParamBuffer _paramBuffer;
+  FwPrmIdType _id{};
+  Fw::ParamBuffer _paramBuffer;
 
-    _id = _baseId + PARAMID_PARAMU32;
+  _id = _baseId + PARAMID_PARAMU32;
 
-    // Get serialized parameter ParamU32
-    this->m_param_ParamU32_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamU32
+  this->m_param_ParamU32_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMF64;
-
-    // Get serialized parameter ParamF64
-    this->m_param_ParamF64_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRING;
-
-    // Get serialized parameter ParamString
-    this->m_param_ParamString_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamString);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamString = Fw::String("default");
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMENUM;
-
-    // Get serialized parameter ParamEnum
-    this->m_param_ParamEnum_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMARRAY;
-
-    // Get serialized parameter ParamArray
-    this->m_param_ParamArray_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
-        this->m_ParamArray = A({1, 2, 3});
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCT;
-
-    // Get serialized parameter ParamStruct
-    this->m_param_ParamStruct_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-        _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMI32EXT;
-
-    // Get serialized parameter ParamI32Ext
-    this->m_param_ParamI32Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMF64EXT;
+  _id = _baseId + PARAMID_PARAMF64;
 
-    // Get serialized parameter ParamF64Ext
-    this->m_param_ParamF64Ext_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamF64
+  this->m_param_ParamF64_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMSTRINGEXT;
+  _id = _baseId + PARAMID_PARAMSTRING;
 
-    // Get serialized parameter ParamStringExt
-    this->m_param_ParamStringExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamString
+  this->m_param_ParamString_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
-        Fw::String _val = Fw::String("external default");
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRINGEXT,
-                                                         this->m_param_ParamStringExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMENUMEXT;
-
-    // Get serialized parameter ParamEnumExt
-    this->m_param_ParamEnumExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid,
-                                                     _paramBuffer);
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
     }
+  }
+  else {
+    this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamString = Fw::String("default");
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    _id = _baseId + PARAMID_PARAMARRAYEXT;
+  _id = _baseId + PARAMID_PARAMENUM;
 
-    // Get serialized parameter ParamArrayExt
-    this->m_param_ParamArrayExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
+  // Get serialized parameter ParamEnum
+  this->m_param_ParamEnum_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
 
-    this->m_paramLock.lock();
+  this->m_paramLock.lock();
 
-    // Deserialize parameter or use default value
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-        }
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
-    }
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
-        A _val = A({1, 2, 3});
-        _paramBuffer.resetSer();
-        _stat = _paramBuffer.serializeFrom(_val);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMARRAYEXT,
-                                                         this->m_param_ParamArrayExt_valid, _paramBuffer);
-        if (_stat != Fw::FW_SERIALIZE_OK) {
-            this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        }
-    }
-
-    this->m_paramLock.unlock();
-
-    _id = _baseId + PARAMID_PARAMSTRUCTEXT;
-
-    // Get serialized parameter ParamStructExt
-    this->m_param_ParamStructExt_valid = this->prmGetOut_out(0, _id, _paramBuffer);
-
-    this->m_paramLock.lock();
-
-    // Deserialize parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    _stat = this->paramDelegatePtr->deserializeParam(_baseId, PARAMID_PARAMSTRUCTEXT,
-                                                     this->m_param_ParamStructExt_valid, _paramBuffer);
+  // Deserialize parameter
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+      this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
+  }
 
-    this->m_paramLock.unlock();
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parametersLoaded();
+  _id = _baseId + PARAMID_PARAMARRAY;
+
+  // Get serialized parameter ParamArray
+  this->m_param_ParamArray_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamArray);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT) {
+    this->m_ParamArray = A({1, 2, 3});
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRUCT;
+
+  // Get serialized parameter ParamStruct
+  this->m_param_ParamStruct_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    _stat = _paramBuffer.deserializeTo(this->m_ParamStruct);
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMI32EXT;
+
+  // Get serialized parameter ParamI32Ext
+  this->m_param_ParamI32Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMI32EXT,
+    this->m_param_ParamI32Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMF64EXT;
+
+  // Get serialized parameter ParamF64Ext
+  this->m_param_ParamF64Ext_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMF64EXT,
+    this->m_param_ParamF64Ext_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRINGEXT;
+
+  // Get serialized parameter ParamStringExt
+  this->m_param_ParamStringExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT) {
+    Fw::String _val = Fw::String("external default");
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMSTRINGEXT,
+      this->m_param_ParamStringExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMENUMEXT;
+
+  // Get serialized parameter ParamEnumExt
+  this->m_param_ParamEnumExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMENUMEXT,
+    this->m_param_ParamEnumExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMARRAYEXT;
+
+  // Get serialized parameter ParamArrayExt
+  this->m_param_ParamArrayExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter or use default value
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+    }
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::DEFAULT;
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT) {
+    A _val = A({1, 2, 3});
+    _paramBuffer.resetSer();
+    _stat = _paramBuffer.serializeFrom(_val);
+    FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->deserializeParam(
+      _baseId,
+      PARAMID_PARAMARRAYEXT,
+      this->m_param_ParamArrayExt_valid,
+      _paramBuffer
+    );
+    if (_stat != Fw::FW_SERIALIZE_OK) {
+      this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    }
+  }
+
+  this->m_paramLock.unlock();
+
+  _id = _baseId + PARAMID_PARAMSTRUCTEXT;
+
+  // Get serialized parameter ParamStructExt
+  this->m_param_ParamStructExt_valid = this->prmGetOut_out(
+    0,
+    _id,
+    _paramBuffer
+  );
+
+  this->m_paramLock.lock();
+
+  // Deserialize parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  _stat = this->paramDelegatePtr->deserializeParam(
+    _baseId,
+    PARAMID_PARAMSTRUCTEXT,
+    this->m_param_ParamStructExt_valid,
+    _paramBuffer
+  );
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+  }
+
+  this->m_paramLock.unlock();
+
+  // Call notifier
+  this->parametersLoaded();
 }
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-QueuedTestComponentBase ::QueuedTestComponentBase(const char* compName) : Fw::QueuedComponentBase(compName) {
-    this->m_EventActivityLowThrottledThrottle = 0;
-    this->m_EventFatalThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledThrottle = 0;
-    this->m_EventWarningLowThrottledIntervalThrottle = 0;
+QueuedTestComponentBase ::
+  QueuedTestComponentBase(const char* compName) :
+    Fw::QueuedComponentBase(compName)
+{
+  this->m_EventActivityLowThrottledThrottle = 0;
+  this->m_EventFatalThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledThrottle = 0;
+  this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
+  this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time();
 }
 
-QueuedTestComponentBase ::~QueuedTestComponentBase() {}
+QueuedTestComponentBase ::
+  ~QueuedTestComponentBase()
+{
+
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
@@ -1604,76 +2566,118 @@ QueuedTestComponentBase ::~QueuedTestComponentBase() {}
 // Connection status queries for special output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTestComponentBase ::isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_cmdRegOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdRegOut_OutputPort[portNum].isConnected();
+  return this->m_cmdRegOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_cmdResponseOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
+  return this->m_cmdResponseOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_eventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_eventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_eventOut_OutputPort[portNum].isConnected();
+  return this->m_eventOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_prmGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_prmGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmGetOut_OutputPort[portNum].isConnected();
+  return this->m_prmGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_prmSetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_prmSetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_prmSetOut_OutputPort[portNum].isConnected();
+  return this->m_prmSetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_productRequestOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_productRequestOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productRequestOut_OutputPort[portNum].isConnected();
+  return this->m_productRequestOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_productSendOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_productSendOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_productSendOut_OutputPort[portNum].isConnected();
+  return this->m_productSendOut_OutputPort[portNum].isConnected();
 }
 
 #if FW_ENABLE_TEXT_LOGGING == 1
 
-bool QueuedTestComponentBase ::isConnected_textEventOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_textEventOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_textEventOut_OutputPort[portNum].isConnected();
+  return this->m_textEventOut_OutputPort[portNum].isConnected();
 }
 
 #endif
 
-bool QueuedTestComponentBase ::isConnected_timeGetOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_timeGetOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_timeGetOut_OutputPort[portNum].isConnected();
+  return this->m_timeGetOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_tlmOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_tlmOut_OutputPort[portNum].isConnected();
+  return this->m_tlmOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1684,59 +2688,92 @@ bool QueuedTestComponentBase ::isConnected_tlmOut_OutputPort(FwIndexType portNum
 // Connection status queries for typed output ports
 // ----------------------------------------------------------------------
 
-bool QueuedTestComponentBase ::isConnected_noArgsOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_noArgsOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_noArgsReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_noArgsStringReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_typedAliasOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_typedAliasReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_typedAliasReturnStringOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_typedOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_typedOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedOut_OutputPort[portNum].isConnected();
+  return this->m_typedOut_OutputPort[portNum].isConnected();
 }
 
-bool QueuedTestComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+bool QueuedTestComponentBase ::
+  isConnected_typedReturnOut_OutputPort(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    return this->m_typedReturnOut_OutputPort[portNum].isConnected();
+  return this->m_typedReturnOut_OutputPort[portNum].isConnected();
 }
 
 #endif
@@ -1747,287 +2784,487 @@ bool QueuedTestComponentBase ::isConnected_typedReturnOut_OutputPort(FwIndexType
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::cmdIn_handlerBase(FwIndexType portNum,
-                                                 FwOpcodeType opCode,
-                                                 U32 cmdSeq,
-                                                 Fw::CmdArgBuffer& args) {
-    const U32 idBase = this->getIdBase();
-    FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
+void QueuedTestComponentBase ::
+  cmdIn_handlerBase(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 
-    // Select base class function based on opcode
-    switch (opCode - idBase) {
-        case OPCODE_CMD_SYNC: {
-            this->CMD_SYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
+  const U32 idBase = this->getIdBase();
+  FW_ASSERT(opCode >= idBase, static_cast<FwAssertArgType>(opCode), static_cast<FwAssertArgType>(idBase));
 
-        case OPCODE_CMD_SYNC_PRIMITIVE: {
-            this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRING: {
-            this->CMD_SYNC_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ENUM: {
-            this->CMD_SYNC_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_ARRAY: {
-            this->CMD_SYNC_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_SYNC_STRUCT: {
-            this->CMD_SYNC_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED: {
-            this->CMD_GUARDED_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_PRIMITIVE: {
-            this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRING: {
-            this->CMD_GUARDED_STRING_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ENUM: {
-            this->CMD_GUARDED_ENUM_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_ARRAY: {
-            this->CMD_GUARDED_ARRAY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_GUARDED_STRUCT: {
-            this->CMD_GUARDED_STRUCT_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_ASYNC: {
-            this->CMD_ASYNC_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PRIORITY: {
-            this->CMD_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY: {
-            this->CMD_PARAMS_PRIORITY_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_DROP: {
-            this->CMD_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(opCode, cmdSeq, args);
-            break;
-        }
-
-        case OPCODE_PARAMU32_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMU32_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamU32();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRING_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamString();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUM_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAY_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArray();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMI32EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMI32EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMF64EXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRINGEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMENUMEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMARRAYEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SET: {
-            Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-
-        case OPCODE_PARAMSTRUCTEXT_SAVE: {
-            Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
-            this->cmdResponse_out(opCode, cmdSeq, _cstat);
-            break;
-        }
-        default:
-            // Unknown opcode: ignore it
-            break;
+  // Select base class function based on opcode
+  switch (opCode - idBase) {
+    case OPCODE_CMD_SYNC: {
+      this->CMD_SYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
     }
+
+    case OPCODE_CMD_SYNC_PRIMITIVE: {
+      this->CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRING: {
+      this->CMD_SYNC_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ENUM: {
+      this->CMD_SYNC_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_ARRAY: {
+      this->CMD_SYNC_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_SYNC_STRUCT: {
+      this->CMD_SYNC_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED: {
+      this->CMD_GUARDED_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_PRIMITIVE: {
+      this->CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRING: {
+      this->CMD_GUARDED_STRING_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ENUM: {
+      this->CMD_GUARDED_ENUM_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_ARRAY: {
+      this->CMD_GUARDED_ARRAY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_GUARDED_STRUCT: {
+      this->CMD_GUARDED_STRUCT_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_ASYNC: {
+      this->CMD_ASYNC_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PRIORITY: {
+      this->CMD_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY: {
+      this->CMD_PARAMS_PRIORITY_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_DROP: {
+      this->CMD_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_CMD_PARAMS_PRIORITY_DROP: {
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+        opCode,
+        cmdSeq,
+        args
+      );
+      break;
+    }
+
+    case OPCODE_PARAMU32_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamU32(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMU32_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamU32();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamString(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRING_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamString();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnum(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUM_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnum();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArray(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAY_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArray();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStruct(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStruct();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMI32EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamI32Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMI32EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamI32Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamF64Ext(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMF64EXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamF64Ext();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStringExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRINGEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStringExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamEnumExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMENUMEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamEnumExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamArrayExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMARRAYEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamArrayExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SET: {
+      Fw::CmdResponse _cstat = this->paramSet_ParamStructExt(args);
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+
+    case OPCODE_PARAMSTRUCTEXT_SAVE: {
+      Fw::CmdResponse _cstat = this->paramSave_ParamStructExt();
+      this->cmdResponse_out(
+        opCode,
+        cmdSeq,
+        _cstat
+      );
+      break;
+    }
+    default:
+      // Unknown opcode: ignore it
+      break;
+  }
 }
 
-void QueuedTestComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
-                                                         FwDpIdType id,
-                                                         const Fw::Buffer& buffer,
-                                                         const Fw::Success& status) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  productRecvIn_handlerBase(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRecvIn_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    productRecvIn_preMsgHook(portNum, id, buffer, status);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  productRecvIn_preMsgHook(
+    portNum,
+    id,
+    buffer,
+    status
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument id
-    _status = msg.serializeFrom(id);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument id
+  _status = msg.serializeFrom(id);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument buffer
-    _status = msg.serializeFrom(buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument buffer
+  _status = msg.serializeFrom(buffer);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument status
-    _status = msg.serializeFrom(status);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument status
+  _status = msg.serializeFrom(status);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2036,561 +3273,941 @@ void QueuedTestComponentBase ::productRecvIn_handlerBase(FwIndexType portNum,
 // Call these functions directly to bypass the corresponding ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::aliasTypedAsync_handlerBase(FwIndexType portNum,
-                                                           AliasPrim1 u32,
-                                                           AliasPrim2 f32,
-                                                           AliasBool b,
-                                                           const Fw::StringBase& str2,
-                                                           const AliasEnum& e,
-                                                           const AliasArray& a,
-                                                           const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  aliasTypedAsync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_aliasTypedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    aliasTypedAsync_preMsgHook(portNum, u32, f32, b, str2, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  aliasTypedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str2
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str2
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-Fw::String QueuedTestComponentBase ::noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTestComponentBase ::
+  noArgsAliasStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsAliasStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsAliasStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTestComponentBase ::noArgsAsync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  noArgsAsync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    noArgsAsync_preMsgHook(portNum);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  noArgsAsync_preMsgHook(portNum);
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::noArgsGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  noArgsGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->noArgsGuarded_handler(portNum);
+  // Call handler function
+  this->noArgsGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-U32 QueuedTestComponentBase ::noArgsReturnGuarded_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedTestComponentBase ::
+  noArgsReturnGuarded_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->noArgsReturnGuarded_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnGuarded_handler(portNum);
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-U32 QueuedTestComponentBase ::noArgsReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedTestComponentBase ::
+  noArgsReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    U32 retVal;
+  U32 retVal;
 
-    // Call handler function
-    retVal = this->noArgsReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedTestComponentBase ::noArgsStringReturnSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTestComponentBase ::
+  noArgsStringReturnSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->noArgsStringReturnSync_handler(portNum);
+  // Call handler function
+  retVal = this->noArgsStringReturnSync_handler(portNum);
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTestComponentBase ::noArgsSync_handlerBase(FwIndexType portNum) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  noArgsSync_handlerBase(FwIndexType portNum)
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->noArgsSync_handler(portNum);
+  // Call handler function
+  this->noArgsSync_handler(portNum);
 }
 
-void QueuedTestComponentBase ::typedAliasGuarded_handlerBase(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedAliasGuarded_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedAliasGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  this->typedAliasGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-AliasPrim2 QueuedTestComponentBase ::typedAliasReturnSync_handlerBase(FwIndexType portNum,
-                                                                      AliasPrim1 u32,
-                                                                      AliasPrim2 f32,
-                                                                      AliasBool b,
-                                                                      const Fw::StringBase& str2,
-                                                                      const AliasEnum& e,
-                                                                      const AliasArray& a,
-                                                                      const AliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedTestComponentBase ::
+  typedAliasReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    AliasPrim2 retVal;
+  AliasPrim2 retVal;
 
-    // Call handler function
-    retVal = this->typedAliasReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-Fw::String QueuedTestComponentBase ::typedAliasStringReturnSync_handlerBase(FwIndexType portNum,
-                                                                            AliasPrim1 u32,
-                                                                            AliasPrim2 f32,
-                                                                            AliasBool b,
-                                                                            const Fw::StringBase& str2,
-                                                                            const AliasEnum& e,
-                                                                            const AliasArray& a,
-                                                                            const AnotherAliasStruct& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTestComponentBase ::
+  typedAliasStringReturnSync_handlerBase(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasStringReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    Fw::String retVal;
+  Fw::String retVal;
 
-    // Call handler function
-    retVal = this->typedAliasStringReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedAliasStringReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTestComponentBase ::typedAsync_handlerBase(FwIndexType portNum,
-                                                      U32 u32,
-                                                      F32 f32,
-                                                      bool b,
-                                                      const Fw::StringBase& str1,
-                                                      const E& e,
-                                                      const A& a,
-                                                      const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedAsync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsync_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsync_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::typedAsyncAssert_handlerBase(FwIndexType portNum,
-                                                            U32 u32,
-                                                            F32 f32,
-                                                            bool b,
-                                                            const Fw::StringBase& str1,
-                                                            const E& e,
-                                                            const A& a,
-                                                            const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedAsyncAssert_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncAssert_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncAssert_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncAssert_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::typedAsyncBlockPriority_handlerBase(FwIndexType portNum,
-                                                                   U32 u32,
-                                                                   F32 f32,
-                                                                   bool b,
-                                                                   const Fw::StringBase& str1,
-                                                                   const E& e,
-                                                                   const A& a,
-                                                                   const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedAsyncBlockPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncBlockPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncBlockPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncBlockPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::typedAsyncDropPriority_handlerBase(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedAsyncDropPriority_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAsyncDropPriority_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call pre-message hook
-    typedAsyncDropPriority_preMsgHook(portNum, u32, f32, b, str1, e, a, s);
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Call pre-message hook
+  typedAsyncDropPriority_preMsgHook(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize message ID
+  _status = msg.serializeFrom(
+    static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
+  );
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize port number
-    _status = msg.serializeFrom(portNum);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize port number
+  _status = msg.serializeFrom(portNum);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument u32
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument u32
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument f32
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument f32
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument b
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument b
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument str1
-    _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument str1
+  _status = str1.serializeTo(msg, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument e
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument e
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument a
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument a
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Serialize argument s
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize argument s
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::typedGuarded_handlerBase(FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str1,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    this->typedGuarded_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 }
 
-F32 QueuedTestComponentBase ::typedReturnGuarded_handlerBase(FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str2,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedTestComponentBase ::
+  typedReturnGuarded_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnGuarded_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Lock guard mutex before calling
-    this->lock();
+  // Lock guard mutex before calling
+  this->lock();
 
-    // Call handler function
-    retVal = this->typedReturnGuarded_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnGuarded_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    // Unlock guard mutex
-    this->unLock();
+  // Unlock guard mutex
+  this->unLock();
 
-    return retVal;
+  return retVal;
 }
 
-F32 QueuedTestComponentBase ::typedReturnSync_handlerBase(FwIndexType portNum,
-                                                          U32 u32,
-                                                          F32 f32,
-                                                          bool b,
-                                                          const Fw::StringBase& str2,
-                                                          const E& e,
-                                                          const A& a,
-                                                          const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedTestComponentBase ::
+  typedReturnSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    F32 retVal;
+  F32 retVal;
 
-    // Call handler function
-    retVal = this->typedReturnSync_handler(portNum, u32, f32, b, str2, e, a, s);
+  // Call handler function
+  retVal = this->typedReturnSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 
-    return retVal;
+  return retVal;
 }
 
-void QueuedTestComponentBase ::typedSync_handlerBase(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedSync_handlerBase(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Make sure port number is valid
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedSync_InputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    // Call handler function
-    this->typedSync_handler(portNum, u32, f32, b, str1, e, a, s);
+  // Call handler function
+  this->typedSync_handler(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -2601,11 +4218,15 @@ void QueuedTestComponentBase ::typedSync_handlerBase(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
-                                                        FwDpIdType id,
-                                                        const Fw::Buffer& buffer,
-                                                        const Fw::Success& status) {
-    // Default: no-op
+void QueuedTestComponentBase ::
+  productRecvIn_preMsgHook(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  // Default: no-op
 }
 
 // ----------------------------------------------------------------------
@@ -2616,63 +4237,85 @@ void QueuedTestComponentBase ::productRecvIn_preMsgHook(FwIndexType portNum,
 // override them to provide specific pre-message behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::aliasTypedAsync_preMsgHook(FwIndexType portNum,
-                                                          AliasPrim1 u32,
-                                                          AliasPrim2 f32,
-                                                          AliasBool b,
-                                                          const Fw::StringBase& str2,
-                                                          const AliasEnum& e,
-                                                          const AliasArray& a,
-                                                          const AliasStruct& s) {
-    // Default: no-op
+void QueuedTestComponentBase ::
+  aliasTypedAsync_preMsgHook(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTestComponentBase ::noArgsAsync_preMsgHook(FwIndexType portNum) {
-    // Default: no-op
+void QueuedTestComponentBase ::
+  noArgsAsync_preMsgHook(FwIndexType portNum)
+{
+  // Default: no-op
 }
 
-void QueuedTestComponentBase ::typedAsync_preMsgHook(FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str1,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    // Default: no-op
+void QueuedTestComponentBase ::
+  typedAsync_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTestComponentBase ::typedAsyncAssert_preMsgHook(FwIndexType portNum,
-                                                           U32 u32,
-                                                           F32 f32,
-                                                           bool b,
-                                                           const Fw::StringBase& str1,
-                                                           const E& e,
-                                                           const A& a,
-                                                           const S& s) {
-    // Default: no-op
+void QueuedTestComponentBase ::
+  typedAsyncAssert_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTestComponentBase ::typedAsyncBlockPriority_preMsgHook(FwIndexType portNum,
-                                                                  U32 u32,
-                                                                  F32 f32,
-                                                                  bool b,
-                                                                  const Fw::StringBase& str1,
-                                                                  const E& e,
-                                                                  const A& a,
-                                                                  const S& s) {
-    // Default: no-op
+void QueuedTestComponentBase ::
+  typedAsyncBlockPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
-void QueuedTestComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType portNum,
-                                                                 U32 u32,
-                                                                 F32 f32,
-                                                                 bool b,
-                                                                 const Fw::StringBase& str1,
-                                                                 const E& e,
-                                                                 const A& a,
-                                                                 const S& s) {
-    // Default: no-op
+void QueuedTestComponentBase ::
+  typedAsyncDropPriority_preMsgHook(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  // Default: no-op
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -2681,103 +4324,209 @@ void QueuedTestComponentBase ::typedAsyncDropPriority_preMsgHook(FwIndexType por
 // Invocation functions for typed output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::noArgsOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  noArgsOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_noArgsOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_noArgsOut_OutputPort[portNum].invoke();
 }
 
-U32 QueuedTestComponentBase ::noArgsReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+U32 QueuedTestComponentBase ::
+  noArgsReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsReturnOut_OutputPort[portNum].invoke();
 }
 
-Fw::String QueuedTestComponentBase ::noArgsStringReturnOut_out(FwIndexType portNum) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTestComponentBase ::
+  noArgsStringReturnOut_out(FwIndexType portNum) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_noArgsStringReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
+  FW_ASSERT(
+    this->m_noArgsStringReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_noArgsStringReturnOut_OutputPort[portNum].invoke();
 }
 
-void QueuedTestComponentBase ::typedAliasOut_out(FwIndexType portNum,
-                                                 AliasPrim1 u32,
-                                                 AliasPrim2 f32,
-                                                 AliasBool b,
-                                                 const Fw::StringBase& str2,
-                                                 const AliasEnum& e,
-                                                 const AliasArray& a,
-                                                 const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedAliasOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedAliasOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedAliasOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedTestComponentBase ::typedAliasReturnOut_out(FwIndexType portNum,
-                                                             AliasPrim1 u32,
-                                                             AliasPrim2 f32,
-                                                             AliasBool b,
-                                                             const Fw::StringBase& str2,
-                                                             const AliasEnum& e,
-                                                             const AliasArray& a,
-                                                             const AliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+AliasPrim2 QueuedTestComponentBase ::
+  typedAliasReturnOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedTestComponentBase ::typedAliasReturnStringOut_out(FwIndexType portNum,
-                                                                   AliasPrim1 u32,
-                                                                   AliasPrim2 f32,
-                                                                   AliasBool b,
-                                                                   const Fw::StringBase& str2,
-                                                                   const AliasEnum& e,
-                                                                   const AliasArray& a,
-                                                                   const AnotherAliasStruct& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::String QueuedTestComponentBase ::
+  typedAliasReturnStringOut_out(
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedAliasReturnStringOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
-              static_cast<FwAssertArgType>(portNum));
-    return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedAliasReturnStringOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedAliasReturnStringOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::typedOut_out(FwIndexType portNum,
-                                            U32 u32,
-                                            F32 f32,
-                                            bool b,
-                                            const Fw::StringBase& str1,
-                                            const E& e,
-                                            const A& a,
-                                            const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  typedOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_typedOut_OutputPort[portNum].invoke(u32, f32, b, str1, e, a, s);
+  FW_ASSERT(
+    this->m_typedOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_typedOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedTestComponentBase ::typedReturnOut_out(FwIndexType portNum,
-                                                 U32 u32,
-                                                 F32 f32,
-                                                 bool b,
-                                                 const Fw::StringBase& str2,
-                                                 const E& e,
-                                                 const A& a,
-                                                 const S& s) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+F32 QueuedTestComponentBase ::
+  typedReturnOut_out(
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_typedReturnOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_typedReturnOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_typedReturnOut_OutputPort[portNum].invoke(u32, f32, b, str2, e, a, s);
+  FW_ASSERT(
+    this->m_typedReturnOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_typedReturnOut_OutputPort[portNum].invoke(
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
 #endif
@@ -2786,162 +4535,264 @@ F32 QueuedTestComponentBase ::typedReturnOut_out(FwIndexType portNum,
 // Internal interface base-class functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::internalArray_internalInterfaceInvoke(const A& a) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  internalArray_internalInterfaceInvoke(const A& a)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(a);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::internalEnum_internalInterfaceInvoke(const E& e) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  internalEnum_internalInterfaceInvoke(const E& e)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(e);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::internalPrimitive_internalInterfaceInvoke(U32 u32, F32 f32, bool b) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  internalPrimitive_internalInterfaceInvoke(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(u32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(f32);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(b);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 5, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::internalPriorityDrop_internalInterfaceInvoke() {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  internalPriorityDrop_internalInterfaceInvoke()
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::internalString_internalInterfaceInvoke(const Fw::InternalInterfaceString& str1,
-                                                                      const Fw::InternalInterfaceString& str2) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  internalString_internalInterfaceInvoke(
+      const Fw::InternalInterfaceString& str1,
+      const Fw::InternalInterfaceString& str2
+  )
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(str1);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(str1);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(str2);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(str2);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
-void QueuedTestComponentBase ::internalStruct_internalInterfaceInvoke(const S& s) {
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  internalStruct_internalInterfaceInvoke(const S& s)
+{
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize the message ID
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize the message ID
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Fake port number to make message dequeue work
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(s);
+  FW_ASSERT(
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
 // Command response
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdResponse response) {
-    FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
-    this->cmdResponseOut_out(0, opCode, cmdSeq, response);
+void QueuedTestComponentBase ::
+  cmdResponse_out(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdResponse response
+  )
+{
+  FW_ASSERT(this->isConnected_cmdResponseOut_OutputPort(0));
+  this->cmdResponseOut_out(0, opCode, cmdSeq, response);
 }
 
 // ----------------------------------------------------------------------
@@ -2950,613 +4801,965 @@ void QueuedTestComponentBase ::cmdResponse_out(FwOpcodeType opCode, U32 cmdSeq, 
 // Call these functions directly to bypass the command input port
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::CMD_SYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void QueuedTestComponentBase ::
+  CMD_SYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
+  this->CMD_SYNC_cmdHandler(opCode, cmdSeq);
 }
 
-void QueuedTestComponentBase ::CMD_SYNC_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_SYNC_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
+  this->CMD_SYNC_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 }
 
-void QueuedTestComponentBase ::CMD_SYNC_STRING_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_SYNC_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_SYNC_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 }
 
-void QueuedTestComponentBase ::CMD_SYNC_ENUM_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_SYNC_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_SYNC_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 }
 
-void QueuedTestComponentBase ::CMD_SYNC_ARRAY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_SYNC_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_SYNC_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 }
 
-void QueuedTestComponentBase ::CMD_SYNC_STRUCT_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_SYNC_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->CMD_SYNC_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_SYNC_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::CMD_GUARDED_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
+void QueuedTestComponentBase ::
+  CMD_GUARDED_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
+  this->CMD_GUARDED_cmdHandler(opCode, cmdSeq);
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedTestComponentBase ::CMD_GUARDED_PRIMITIVE_cmdHandlerBase(FwOpcodeType opCode,
-                                                                    U32 cmdSeq,
-                                                                    Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_GUARDED_PRIMITIVE_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    U32 u32;
-    _status = args.deserializeTo(u32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  U32 u32;
+  _status = args.deserializeTo(u32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    F32 f32;
-    _status = args.deserializeTo(f32);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  F32 f32;
+  _status = args.deserializeTo(f32);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    bool b;
-    _status = args.deserializeTo(b);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  bool b;
+  _status = args.deserializeTo(b);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
-
-#if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-#endif
-
-    this->lock();
-
-    this->CMD_GUARDED_PRIMITIVE_cmdHandler(opCode, cmdSeq, u32, f32, b);
-
-    this->unLock();
-}
-
-void QueuedTestComponentBase ::CMD_GUARDED_STRING_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Reset the buffer
-    args.resetDeser();
-
-    Fw::CmdStringArg str1;
-    _status = args.deserializeTo(str1);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
-
-    Fw::CmdStringArg str2;
-    _status = args.deserializeTo(str2);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
-    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRING_cmdHandler(opCode, cmdSeq, str1, str2);
+  this->CMD_GUARDED_PRIMITIVE_cmdHandler(
+    opCode, cmdSeq,
+    u32,
+    f32,
+    b
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedTestComponentBase ::CMD_GUARDED_ENUM_cmdHandlerBase(FwOpcodeType opCode,
-                                                               U32 cmdSeq,
-                                                               Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_GUARDED_STRING_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    E e;
-    _status = args.deserializeTo(e);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  Fw::CmdStringArg str1;
+  _status = args.deserializeTo(str1);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
+
+  Fw::CmdStringArg str2;
+  _status = args.deserializeTo(str2);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ENUM_cmdHandler(opCode, cmdSeq, e);
+  this->CMD_GUARDED_STRING_cmdHandler(
+    opCode, cmdSeq,
+    str1,
+    str2
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedTestComponentBase ::CMD_GUARDED_ARRAY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                U32 cmdSeq,
-                                                                Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_GUARDED_ENUM_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    A a;
-    _status = args.deserializeTo(a);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  E e;
+  _status = args.deserializeTo(e);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_ARRAY_cmdHandler(opCode, cmdSeq, a);
+  this->CMD_GUARDED_ENUM_cmdHandler(
+    opCode, cmdSeq,
+    e
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedTestComponentBase ::CMD_GUARDED_STRUCT_cmdHandlerBase(FwOpcodeType opCode,
-                                                                 U32 cmdSeq,
-                                                                 Fw::CmdArgBuffer& args) {
-    // Deserialize the arguments
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+void QueuedTestComponentBase ::
+  CMD_GUARDED_ARRAY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Reset the buffer
-    args.resetDeser();
+  // Reset the buffer
+  args.resetDeser();
 
-    S s;
-    _status = args.deserializeTo(s);
-    if (_status != Fw::FW_SERIALIZE_OK) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  A a;
+  _status = args.deserializeTo(a);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
 #if FW_CMD_CHECK_RESIDUAL
-    // Make sure there was no data left over.
-    // That means the argument buffer size was incorrect.
-    if (args.getDeserializeSizeLeft() != 0) {
-        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-            this->cmdResponseOut_out(0, opCode, cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-        }
-        return;
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 #endif
 
-    this->lock();
+  this->lock();
 
-    this->CMD_GUARDED_STRUCT_cmdHandler(opCode, cmdSeq, s);
+  this->CMD_GUARDED_ARRAY_cmdHandler(
+    opCode, cmdSeq,
+    a
+  );
 
-    this->unLock();
+  this->unLock();
 }
 
-void QueuedTestComponentBase ::CMD_ASYNC_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_ASYNC_preMsgHook(opCode, cmdSeq);
+void QueuedTestComponentBase ::
+  CMD_GUARDED_STRUCT_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Deserialize the arguments
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Reset the buffer
+  args.resetDeser();
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedTestComponentBase ::CMD_PRIORITY_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_cmdHandlerBase(FwOpcodeType opCode,
-                                                                  U32 cmdSeq,
-                                                                  Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
-
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
-
-void QueuedTestComponentBase ::CMD_DROP_cmdHandlerBase(FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_DROP_preMsgHook(opCode, cmdSeq);
-
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
-
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
-
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+  S s;
+  _status = args.deserializeTo(s);
+  if (_status != Fw::FW_SERIALIZE_OK) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
     }
+    return;
+  }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+#if FW_CMD_CHECK_RESIDUAL
+  // Make sure there was no data left over.
+  // That means the argument buffer size was incorrect.
+  if (args.getDeserializeSizeLeft() != 0) {
+    if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+      this->cmdResponseOut_out(
+        0,
+        opCode,
+        cmdSeq,
+        Fw::CmdResponse::FORMAT_ERROR
+      );
+    }
+    return;
+  }
+#endif
+
+  this->lock();
+
+  this->CMD_GUARDED_STRUCT_cmdHandler(
+    opCode, cmdSeq,
+    s
+  );
+
+  this->unLock();
 }
 
-void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeType opCode,
-                                                                       U32 cmdSeq,
-                                                                       Fw::CmdArgBuffer& args) {
-    // Call pre-message hook
-    this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode, cmdSeq);
+void QueuedTestComponentBase ::
+  CMD_ASYNC_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_ASYNC_preMsgHook(opCode,cmdSeq);
 
-    // Defer deserializing arguments to the message dispatcher
-    // to avoid deserializing and reserializing just for IPC
-    ComponentIpcSerializableBuffer msg;
-    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
-    // Serialize for IPC
-    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Fake port number to make message dequeue work
-    FwIndexType port = 0;
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
 
-    _status = msg.serializeFrom(port);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(opCode);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(cmdSeq);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    _status = msg.serializeFrom(args);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
 
-    // Send message
-    Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
-    Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
 
-    if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
-    }
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+void QueuedTestComponentBase ::
+  CMD_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 10, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedTestComponentBase ::
+  CMD_PARAMS_PRIORITY_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 20, _block);
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedTestComponentBase ::
+  CMD_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 0, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
+}
+
+void QueuedTestComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  // Call pre-message hook
+  this->CMD_PARAMS_PRIORITY_DROP_preMsgHook(opCode,cmdSeq);
+
+  // Defer deserializing arguments to the message dispatcher
+  // to avoid deserializing and reserializing just for IPC
+  ComponentIpcSerializableBuffer msg;
+  Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+  // Serialize for IPC
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Fake port number to make message dequeue work
+  FwIndexType port = 0;
+
+  _status = msg.serializeFrom(port);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(opCode);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(cmdSeq);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  _status = msg.serializeFrom(args);
+  FW_ASSERT (
+    _status == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_status)
+  );
+
+  // Send message
+  Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
+  Os::Queue::Status qStatus = this->m_queue.send(msg, 30, _block);
+
+  if (qStatus == Os::Queue::Status::FULL) {
+    this->incNumMsgDropped();
+    return;
+  }
+
+  FW_ASSERT(
+    qStatus == Os::Queue::OP_OK,
+    static_cast<FwAssertArgType>(qStatus)
+  );
 }
 
 // ----------------------------------------------------------------------
@@ -3567,507 +5770,782 @@ void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_cmdHandlerBase(FwOpcodeT
 // override them to provide specific pre-command behavior.
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::CMD_ASYNC_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedTestComponentBase ::
+  CMD_ASYNC_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedTestComponentBase ::CMD_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedTestComponentBase ::
+  CMD_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedTestComponentBase ::
+  CMD_PARAMS_PRIORITY_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedTestComponentBase ::CMD_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedTestComponentBase ::
+  CMD_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
-void QueuedTestComponentBase ::CMD_PARAMS_PRIORITY_DROP_preMsgHook(FwOpcodeType opCode, U32 cmdSeq) {
-    // Defaults to no-op; can be overridden
-    (void)opCode;
-    (void)cmdSeq;
+void QueuedTestComponentBase ::
+  CMD_PARAMS_PRIORITY_DROP_preMsgHook(
+      FwOpcodeType opCode,
+      U32 cmdSeq
+  )
+{
+  // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------
 // Event logging functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::log_ACTIVITY_HI_EventActivityHigh() const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
+void QueuedTestComponentBase ::
+  log_ACTIVITY_HI_EventActivityHigh() const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
 
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logBuff);
-    }
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logBuff
+    );
+  }
 
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity High occurred";
+    const char* _formatString =
+      "(%s) %s: Event Activity High occurred";
 #else
-        const char* _formatString = "%s: Event Activity High occurred";
+    const char* _formatString =
+      "%s: Event Activity High occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityHigh ");
+      "EventActivityHigh "
+    );
 
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_HI, _logString);
-    }
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_HI,
+      _logString
+    );
+  }
 #endif
 }
 
-void QueuedTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled(U32 u32, F32 f32, bool b) {
-    // Check throttle value
-    if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+void QueuedTestComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled(
+      U32 u32,
+      F32 f32,
+      bool b
+  )
+{
+  // Check throttle value
+  if (this->m_EventActivityLowThrottledThrottle >= EVENTID_EVENTACTIVITYLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventActivityLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(u32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(F32))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(f32);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(sizeof(U8))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(b);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#else
+    const char* _formatString =
+      "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventActivityLowThrottled ",
+      u32,
+      static_cast<F64>(f32),
+      b
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::ACTIVITY_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedTestComponentBase ::
+  log_COMMAND_EventCommand(
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
+  ) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    _status = str1.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = str2.serializeTo(
+      _logBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Command occurred with arguments: %s, %s";
+#else
+    const char* _formatString =
+      "%s: Event Command occurred with arguments: %s, %s";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventCommand ",
+      str1.toChar(),
+      str2.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::COMMAND,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedTestComponentBase ::
+  log_DIAGNOSTIC_EventDiagnostic(const E& e) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(E::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(e);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Diagnostic occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Diagnostic occurred with argument: %s";
+#endif
+
+    Fw::String eStr;
+    e.toString(eStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventDiagnostic ",
+      eStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::DIAGNOSTIC,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedTestComponentBase ::
+  log_FATAL_EventFatalThrottled(const A& a)
+{
+  // Check throttle value
+  if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventFatalThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(A::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(a);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Fatal occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Fatal occurred with argument: %s";
+#endif
+
+    Fw::String aStr;
+    a.toString(aStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventFatalThrottled ",
+      aStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::FATAL,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedTestComponentBase ::
+  log_WARNING_HI_EventWarningHigh(const S& s) const
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+#if FW_AMPCS_COMPATIBLE
+    // Serialize the argument size
+    _status = _logBuff.serializeFrom(
+      static_cast<U8>(S::SERIALIZED_SIZE)
+    );
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+    _status = _logBuff.serializeFrom(s);
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning High occurred with argument: %s";
+#else
+    const char* _formatString =
+      "%s: Event Warning High occurred with argument: %s";
+#endif
+
+    Fw::String sStr;
+    s.toString(sStr);
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningHigh ",
+      sStr.toChar()
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_HI,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedTestComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled()
+{
+  // Check throttle value
+  if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
+    return;
+  }
+  else {
+    this->m_EventWarningLowThrottledThrottle++;
+  }
+
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
+
+#if FW_AMPCS_COMPATIBLE
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
+#endif
+
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
+
+  // Emit the event on the text log port
+#if FW_ENABLE_TEXT_LOGGING
+  if (this->isConnected_textEventOut_OutputPort(0)) {
+#if FW_OBJECT_NAMES == 1
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
+#else
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
+#endif
+
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
+#if FW_OBJECT_NAMES == 1
+      this->m_objName.toChar(),
+#endif
+      "EventWarningLowThrottled "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
+#endif
+}
+
+void QueuedTestComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval()
+{
+  // Get the time
+  Fw::Time _logTime;
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    this->timeGetOut_out(0, _logTime);
+  }
+
+  const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
+
+  // Check throttle value & throttle timeout
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
+
+    if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
+      // The counter has overflowed, check if time interval has passed
+      if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >= Fw::TimeInterval(10, 0)) {
+        // Reset the count
+        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+      } else {
+        // Throttle the event
         return;
-    } else {
-        this->m_EventActivityLowThrottledThrottle++;
+      }
     }
 
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
+    // Reset the throttle time if needed
+    if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
+      // This is the first event, reset the throttle time
+      this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
     }
 
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+    // Increment the count
+    this->m_EventWarningLowThrottledIntervalThrottle++;
+  }
 
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(3));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
+  // Emit the event on the log port
+  if (this->isConnected_eventOut_OutputPort(0)) {
+    Fw::LogBuffer _logBuff;
 
 #if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
+    // Serialize the number of arguments
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
+    FW_ASSERT(
+      _status == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_status)
+    );
 #endif
-        _status = _logBuff.serializeFrom(u32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(F32)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(f32);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    this->eventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logBuff
+    );
+  }
 
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(sizeof(U8)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(b);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
+  // Emit the event on the text log port
 #if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
+  if (this->isConnected_textEventOut_OutputPort(0)) {
 #if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "(%s) %s: Event Warning Low occurred";
 #else
-        const char* _formatString = "%s: Event Activity Low occurred with arguments: %" PRIu32 ", %f, %d";
+    const char* _formatString =
+      "%s: Event Warning Low occurred";
 #endif
 
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
+    Fw::TextLogString _logString;
+    _logString.format(
+      _formatString,
 #if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
+      this->m_objName.toChar(),
 #endif
-                          "EventActivityLowThrottled ", u32, static_cast<F64>(f32), b);
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::ACTIVITY_LO, _logString);
-    }
-#endif
-}
-
-void QueuedTestComponentBase ::log_COMMAND_EventCommand(const Fw::StringBase& str1, const Fw::StringBase& str2) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(2));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        _status = str1.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE),
-                                                    static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = str2.serializeTo(_logBuff, FW_MIN(static_cast<FwSizeType>(FW_LOG_STRING_MAX_SIZE), 100));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Command occurred with arguments: %s, %s";
-#else
-        const char* _formatString = "%s: Event Command occurred with arguments: %s, %s";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventCommand ", str1.toChar(), str2.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::COMMAND, _logString);
-    }
-#endif
-}
-
-void QueuedTestComponentBase ::log_DIAGNOSTIC_EventDiagnostic(const E& e) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(E::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(e);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Diagnostic occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Diagnostic occurred with argument: %s";
-#endif
-
-        Fw::String eStr;
-        e.toString(eStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventDiagnostic ", eStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::DIAGNOSTIC, _logString);
-    }
-#endif
-}
-
-void QueuedTestComponentBase ::log_FATAL_EventFatalThrottled(const A& a) {
-    // Check throttle value
-    if (this->m_EventFatalThrottledThrottle >= EVENTID_EVENTFATALTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventFatalThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-        _status = _logBuff.serializeFrom(static_cast<U8>(4));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        _status = _logBuff.serializeFrom(static_cast<U32>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(A::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(a);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Fatal occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Fatal occurred with argument: %s";
-#endif
-
-        Fw::String aStr;
-        a.toString(aStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventFatalThrottled ", aStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::FATAL, _logString);
-    }
-#endif
-}
-
-void QueuedTestComponentBase ::log_WARNING_HI_EventWarningHigh(const S& s) const {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(1));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-#if FW_AMPCS_COMPATIBLE
-        // Serialize the argument size
-        _status = _logBuff.serializeFrom(static_cast<U8>(S::SERIALIZED_SIZE));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-        _status = _logBuff.serializeFrom(s);
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning High occurred with argument: %s";
-#else
-        const char* _formatString = "%s: Event Warning High occurred with argument: %s";
-#endif
-
-        Fw::String sStr;
-        s.toString(sStr);
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningHigh ", sStr.toChar());
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_HI, _logString);
-    }
-#endif
-}
-
-void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled() {
-    // Check throttle value
-    if (this->m_EventWarningLowThrottledThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLED_THROTTLE) {
-        return;
-    } else {
-        this->m_EventWarningLowThrottledThrottle++;
-    }
-
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottled ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
-#endif
-}
-
-void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval() {
-    // Get the time
-    Fw::Time _logTime;
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        this->timeGetOut_out(0, _logTime);
-    }
-
-    const FwEventIdType _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL;
-
-    // Check throttle value & throttle timeout
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
-
-        if (this->m_EventWarningLowThrottledIntervalThrottle >= EVENTID_EVENTWARNINGLOWTHROTTLEDINTERVAL_THROTTLE) {
-            // The counter has overflowed, check if time interval has passed
-            if (Fw::TimeInterval(this->m_EventWarningLowThrottledIntervalThrottleTime, _logTime) >=
-                Fw::TimeInterval(10, 0)) {
-                // Reset the count
-                this->m_EventWarningLowThrottledIntervalThrottle = 0;
-            } else {
-                // Throttle the event
-                return;
-            }
-        }
-
-        // Reset the throttle time if needed
-        if (this->m_EventWarningLowThrottledIntervalThrottle == 0) {
-            // This is the first event, reset the throttle time
-            this->m_EventWarningLowThrottledIntervalThrottleTime = _logTime;
-        }
-
-        // Increment the count
-        this->m_EventWarningLowThrottledIntervalThrottle++;
-    }
-
-    // Emit the event on the log port
-    if (this->isConnected_eventOut_OutputPort(0)) {
-        Fw::LogBuffer _logBuff;
-
-#if FW_AMPCS_COMPATIBLE
-        Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
-        // Serialize the number of arguments
-        _status = _logBuff.serializeFrom(static_cast<U8>(0));
-        FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-#endif
-
-        this->eventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logBuff);
-    }
-
-    // Emit the event on the text log port
-#if FW_ENABLE_TEXT_LOGGING
-    if (this->isConnected_textEventOut_OutputPort(0)) {
-#if FW_OBJECT_NAMES == 1
-        const char* _formatString = "(%s) %s: Event Warning Low occurred";
-#else
-        const char* _formatString = "%s: Event Warning Low occurred";
-#endif
-
-        Fw::TextLogString _logString;
-        _logString.format(_formatString,
-#if FW_OBJECT_NAMES == 1
-                          this->m_objName.toChar(),
-#endif
-                          "EventWarningLowThrottledInterval ");
-
-        this->textEventOut_out(0, _id, _logTime, Fw::LogSeverity::WARNING_LO, _logString);
-    }
+      "EventWarningLowThrottledInterval "
+    );
+
+    this->textEventOut_out(
+      0,
+      _id,
+      _logTime,
+      Fw::LogSeverity::WARNING_LO,
+      _logString
+    );
+  }
 #endif
 }
 
@@ -4075,463 +6553,692 @@ void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval()
 // Event throttle reset functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventActivityLowThrottledThrottle = 0;
+void QueuedTestComponentBase ::
+  log_ACTIVITY_LO_EventActivityLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventActivityLowThrottledThrottle = 0;
 }
 
-void QueuedTestComponentBase ::log_FATAL_EventFatalThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventFatalThrottledThrottle = 0;
+void QueuedTestComponentBase ::
+  log_FATAL_EventFatalThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventFatalThrottledThrottle = 0;
 }
 
-void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottled_ThrottleClear() {
-    // Reset throttle counter
-    this->m_EventWarningLowThrottledThrottle = 0;
+void QueuedTestComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottled_ThrottleClear()
+{
+  // Reset throttle counter
+  this->m_EventWarningLowThrottledThrottle = 0;
 }
 
-void QueuedTestComponentBase ::log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear() {
-    {
-        Os::ScopeLock scopedLock(this->m_eventLock);
+void QueuedTestComponentBase ::
+  log_WARNING_LO_EventWarningLowThrottledInterval_ThrottleClear()
+{
+  {
+    Os::ScopeLock scopedLock(this->m_eventLock);
 
-        // Reset throttle counter
-        this->m_EventWarningLowThrottledIntervalThrottle = 0;
+    // Reset throttle counter
+    this->m_EventWarningLowThrottledIntervalThrottle = 0;
 
-        // Reset the throttle time
-        this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
-    }
+    // Reset the throttle time
+    this->m_EventWarningLowThrottledIntervalThrottleTime = Fw::Time(0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry serialized write
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::tlmWrite(FwChanIdType id, Fw::TlmBuffer& _tlmBuff, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        if (this->isConnected_timeGetOut_OutputPort(0) && (_tlmTime == Fw::ZERO_TIME)) {
-            this->timeGetOut_out(0, _tlmTime);
-        }
-
-        FwChanIdType _id;
-        _id = this->getIdBase() + id;
-
-        this->tlmOut_out(0, _id, _tlmTime, _tlmBuff);
+void QueuedTestComponentBase ::
+  tlmWrite(
+      FwChanIdType id,
+      Fw::TlmBuffer& _tlmBuff,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    if (
+      this->isConnected_timeGetOut_OutputPort(0) &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->timeGetOut_out(0, _tlmTime);
     }
+
+    FwChanIdType _id;
+    _id = this->getIdBase() + id;
+
+    this->tlmOut_out(
+      0,
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Telemetry write functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::tlmWrite_ChannelU32Format(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelU32Format(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelF32Format(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelF32Format(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32FORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32FORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelStringFormat(const Fw::StringBase& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat =
-            arg.serializeTo(_tlmBuff, FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE),
-                                             static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)));
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelStringFormat(
+      const Fw::StringBase& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = arg.serializeTo(
+      _tlmBuff,
+      FW_MIN(static_cast<FwSizeType>(FW_TLM_STRING_MAX_SIZE), static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))
+    );
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRINGFORMAT, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRINGFORMAT,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelEnum(const E& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelEnum(
+      const E& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELENUM, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELENUM,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelArrayFreq(const A& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelArrayFreq(
+      const A& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELARRAYFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELARRAYFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelStructFreq(const S& arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelStructFreq(
+      const S& arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELSTRUCTFREQ, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELSTRUCTFREQ,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelU32Limits(U32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelU32Limits(
+      U32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELU32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELU32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelF32Limits(F32 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelF32Limits(
+      F32 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF32LIMITS, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF32LIMITS,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelF64(F64 arg, Fw::Time _tlmTime) const {
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelF64(
+      F64 arg,
+      Fw::Time _tlmTime
+  ) const
+{
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
 
-        this->tlmWrite(CHANNELID_CHANNELF64, _tlmBuff, _tlmTime);
-    }
+    this->tlmWrite(
+      CHANNELID_CHANNELF64,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelU32OnChange(U32 arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelU32OnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelU32OnChange) {
-            return;
-        } else {
-            this->m_last_ChannelU32OnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelU32OnChange = false;
-        this->m_last_ChannelU32OnChange = arg;
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelU32OnChange(
+      U32 arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelU32OnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelU32OnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELU32ONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelU32OnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelU32OnChange = false;
+    this->m_last_ChannelU32OnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELU32ONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelEnumOnChange(const E& arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelEnumOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelEnumOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelEnumOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelEnumOnChange = false;
-        this->m_last_ChannelEnumOnChange = arg;
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelEnumOnChange(
+      const E& arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelEnumOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelEnumOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELENUMONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelEnumOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelEnumOnChange = false;
+    this->m_last_ChannelEnumOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELENUMONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
-void QueuedTestComponentBase ::tlmWrite_ChannelBoolOnChange(bool arg, Fw::Time _tlmTime) {
-    // Check to see if it is the first time
-    if (not this->m_first_update_ChannelBoolOnChange) {
-        // Check to see if value has changed. If not, don't write it.
-        if (arg == this->m_last_ChannelBoolOnChange) {
-            return;
-        } else {
-            this->m_last_ChannelBoolOnChange = arg;
-        }
-    } else {
-        this->m_first_update_ChannelBoolOnChange = false;
-        this->m_last_ChannelBoolOnChange = arg;
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
     }
-
-    if (this->isConnected_tlmOut_OutputPort(0)) {
-        Fw::TlmBuffer _tlmBuff;
-        Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
-        FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-
-        this->tlmWrite(CHANNELID_CHANNELBOOLONCHANGE, _tlmBuff, _tlmTime);
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
     }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->isConnected_tlmOut_OutputPort(0)) {
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    this->tlmWrite(
+      CHANNELID_CHANNELBOOLONCHANGE,
+      _tlmBuff,
+      _tlmTime
+    );
+  }
 }
 
 // ----------------------------------------------------------------------
 // Parameter hook functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::parameterUpdated(FwPrmIdType id) {
-    // Do nothing by default
+void QueuedTestComponentBase ::
+  parameterUpdated(FwPrmIdType id)
+{
+  // Do nothing by default
 }
 
-void QueuedTestComponentBase ::parametersLoaded() {
-    // Do nothing by default
+void QueuedTestComponentBase ::
+  parametersLoaded()
+{
+  // Do nothing by default
 }
 
 // ----------------------------------------------------------------------
 // Parameter get functions
 // ----------------------------------------------------------------------
 
-U32 QueuedTestComponentBase ::paramGet_ParamU32(Fw::ParamValid& valid) {
-    U32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamU32_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamU32;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+U32 QueuedTestComponentBase ::
+  paramGet_ParamU32(Fw::ParamValid& valid)
+{
+  U32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamU32_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamU32;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 QueuedTestComponentBase ::paramGet_ParamF64(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamF64;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+F64 QueuedTestComponentBase ::
+  paramGet_ParamF64(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamF64;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString QueuedTestComponentBase ::paramGet_ParamString(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamString_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamString;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+Fw::ParamString QueuedTestComponentBase ::
+  paramGet_ParamString(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamString_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamString;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E QueuedTestComponentBase ::paramGet_ParamEnum(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnum_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamEnum;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+E QueuedTestComponentBase ::
+  paramGet_ParamEnum(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnum_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamEnum;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A QueuedTestComponentBase ::paramGet_ParamArray(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArray_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamArray;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+A QueuedTestComponentBase ::
+  paramGet_ParamArray(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArray_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamArray;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S QueuedTestComponentBase ::paramGet_ParamStruct(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStruct_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        _local = this->m_ParamStruct;
-    }
-    this->m_paramLock.unlock();
-    return _local;
+S QueuedTestComponentBase ::
+  paramGet_ParamStruct(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStruct_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    _local = this->m_ParamStruct;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-I32 QueuedTestComponentBase ::paramGet_ParamI32Ext(Fw::ParamValid& valid) {
-    I32 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamI32Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMI32EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+I32 QueuedTestComponentBase ::
+  paramGet_ParamI32Ext(Fw::ParamValid& valid)
+{
+  I32 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamI32Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-F64 QueuedTestComponentBase ::paramGet_ParamF64Ext(Fw::ParamValid& valid) {
-    F64 _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamF64Ext_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMF64EXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+F64 QueuedTestComponentBase ::
+  paramGet_ParamF64Ext(Fw::ParamValid& valid)
+{
+  F64 _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamF64Ext_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-Fw::ParamString QueuedTestComponentBase ::paramGet_ParamStringExt(Fw::ParamValid& valid) {
-    Fw::ParamString _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStringExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRINGEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+Fw::ParamString QueuedTestComponentBase ::
+  paramGet_ParamStringExt(Fw::ParamValid& valid)
+{
+  Fw::ParamString _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStringExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-E QueuedTestComponentBase ::paramGet_ParamEnumExt(Fw::ParamValid& valid) {
-    E _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamEnumExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMENUMEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+E QueuedTestComponentBase ::
+  paramGet_ParamEnumExt(Fw::ParamValid& valid)
+{
+  E _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamEnumExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-A QueuedTestComponentBase ::paramGet_ParamArrayExt(Fw::ParamValid& valid) {
-    A _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamArrayExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMARRAYEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+A QueuedTestComponentBase ::
+  paramGet_ParamArrayExt(Fw::ParamValid& valid)
+{
+  A _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamArrayExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
-S QueuedTestComponentBase ::paramGet_ParamStructExt(Fw::ParamValid& valid) {
-    S _local{};
-    this->m_paramLock.lock();
-    valid = this->m_param_ParamStructExt_valid;
-    if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
-        Fw::ParamBuffer _paramBuffer;
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(this->getIdBase()),
-                                                                           PARAMID_PARAMSTRUCTEXT, _paramBuffer);
-        if (_stat == Fw::FW_SERIALIZE_OK) {
-            _stat = _paramBuffer.deserializeTo(_local);
-            FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
-        } else {
-            valid = Fw::ParamValid::INVALID;
-        }
+S QueuedTestComponentBase ::
+  paramGet_ParamStructExt(Fw::ParamValid& valid)
+{
+  S _local{};
+  this->m_paramLock.lock();
+  valid = this->m_param_ParamStructExt_valid;
+  if ((valid == Fw::ParamValid::VALID) || (valid == Fw::ParamValid::DEFAULT)) {
+    Fw::ParamBuffer _paramBuffer;
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(this->getIdBase()),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+    if(_stat == Fw::FW_SERIALIZE_OK) {
+      _stat = _paramBuffer.deserializeTo(_local);
+      FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
+    } else {
+      valid = Fw::ParamValid::INVALID;
     }
-    this->m_paramLock.unlock();
-    return _local;
+  }
+  this->m_paramLock.unlock();
+  return _local;
 }
 
 // ----------------------------------------------------------------------
 // External parameter delegate initialization
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr) {
-    FW_ASSERT(paramExternalDelegatePtr != nullptr);
-    this->paramDelegatePtr = paramExternalDelegatePtr;
+void QueuedTestComponentBase ::
+  registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
+{
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
+  this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
 // ----------------------------------------------------------------------
 // Functions for managing data products
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::dpSend(DpContainer& container, Fw::Time timeTag) {
-    // Update the time tag
-    if (timeTag == Fw::ZERO_TIME) {
-        // Get the time from the time port
-        timeTag = this->getTime();
-    }
-    container.setTimeTag(timeTag);
-    // Serialize the header into the packet
-    container.serializeHeader();
-    // Update the size of the buffer according to the data size
-    const FwSizeType packetSize = container.getPacketSize();
-    Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
-              static_cast<FwAssertArgType>(buffer.getSize()));
-    buffer.setSize(static_cast<U32>(packetSize));
-    // Invalidate the buffer in the container, so it can't be reused
-    container.invalidateBuffer();
-    // Send the buffer
-    this->productSendOut_out(0, container.getId(), buffer);
+void QueuedTestComponentBase ::
+  dpSend(
+      DpContainer& container,
+      Fw::Time timeTag
+  )
+{
+  // Update the time tag
+  if (timeTag == Fw::ZERO_TIME) {
+    // Get the time from the time port
+    timeTag = this->getTime();
+  }
+  container.setTimeTag(timeTag);
+  // Serialize the header into the packet
+  container.serializeHeader();
+  // Update the size of the buffer according to the data size
+  const FwSizeType packetSize = container.getPacketSize();
+  Fw::Buffer buffer = container.getBuffer();
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
+  // Invalidate the buffer in the container, so it can't be reused
+  container.invalidateBuffer();
+  // Send the buffer
+  this->productSendOut_out(0, container.getId(), buffer);
 }
 
 // ----------------------------------------------------------------------
 // Time
 // ----------------------------------------------------------------------
 
-Fw::Time QueuedTestComponentBase ::getTime() const {
-    if (this->isConnected_timeGetOut_OutputPort(0)) {
-        Fw::Time _time;
-        this->timeGetOut_out(0, _time);
-        return _time;
-    } else {
-        return Fw::Time(TimeBase::TB_NONE, 0, 0);
-    }
+Fw::Time QueuedTestComponentBase ::
+  getTime() const
+{
+  if (this->isConnected_timeGetOut_OutputPort(0)) {
+    Fw::Time _time;
+    this->timeGetOut_out(0, _time);
+    return _time;
+  }
+  else {
+    return Fw::Time(TimeBase::TB_NONE, 0, 0);
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -4541,890 +7248,1393 @@ Fw::Time QueuedTestComponentBase ::getTime() const {
 // synchronization
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::lock() {
-    this->m_guardedPortMutex.lock();
+void QueuedTestComponentBase ::
+  lock()
+{
+  this->m_guardedPortMutex.lock();
 }
 
-void QueuedTestComponentBase ::unLock() {
-    this->m_guardedPortMutex.unLock();
+void QueuedTestComponentBase ::
+  unLock()
+{
+  this->m_guardedPortMutex.unLock();
 }
 
 // ----------------------------------------------------------------------
 // Message dispatch functions
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::doDispatch() {
-    ComponentIpcSerializableBuffer _msg;
-    FwQueuePriorityType _priority = 0;
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
+  doDispatch()
+{
+  ComponentIpcSerializableBuffer _msg;
+  FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
-    if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+  Os::Queue::Status _msgStatus = this->m_queue.receive(
+    _msg,
+    Os::Queue::NONBLOCKING,
+    _priority
+  );
+  if (Os::Queue::Status::EMPTY == _msgStatus) {
+    return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+  }
+  else {
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
+  }
+
+  // Reset to beginning of buffer
+  _msg.resetDeser();
+
+  FwEnumStoreType _desMsg = 0;
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+
+  if (_msgType == QUEUEDTEST_COMPONENT_EXIT) {
+    return MSG_DISPATCH_EXIT;
+  }
+
+  FwIndexType portNum = 0;
+  _deserStatus = _msg.deserializeTo(portNum);
+  FW_ASSERT(
+    _deserStatus == Fw::FW_SERIALIZE_OK,
+    static_cast<FwAssertArgType>(_deserStatus)
+  );
+
+  switch (_msgType) {
+    // Handle async input port productRecvIn
+    case PRODUCTRECVIN_DPRESPONSE: {
+      // Deserialize argument id
+      FwDpIdType id;
+      _deserStatus = _msg.deserializeTo(id);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument buffer
+      Fw::Buffer buffer;
+      _deserStatus = _msg.deserializeTo(buffer);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument status
+      Fw::Success status;
+      _deserStatus = _msg.deserializeTo(status);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->productRecvIn_handler(
+        portNum,
+        id,
+        buffer,
+        status
+      );
+
+      break;
     }
 
-    // Reset to beginning of buffer
-    _msg.resetDeser();
+    // Handle async input port aliasTypedAsync
+    case ALIASTYPEDASYNC_ALIASTYPED: {
+      // Deserialize argument u32
+      AliasPrim1 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+      // Deserialize argument f32
+      AliasPrim2 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
+      // Deserialize argument b
+      AliasBool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
 
-    if (_msgType == QUEUEDTEST_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      // Deserialize argument str2
+      char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
+      Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
+      _deserStatus = _msg.deserializeTo(str2);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      AliasEnum e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      AliasArray a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      AliasStruct s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->aliasTypedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str2,
+        e,
+        a,
+        s
+      );
+
+      break;
     }
 
-    FwIndexType portNum = 0;
-    _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-    switch (_msgType) {
-        // Handle async input port productRecvIn
-        case PRODUCTRECVIN_DPRESPONSE: {
-            // Deserialize argument id
-            FwDpIdType id;
-            _deserStatus = _msg.deserializeTo(id);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument buffer
-            Fw::Buffer buffer;
-            _deserStatus = _msg.deserializeTo(buffer);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument status
-            Fw::Success status;
-            _deserStatus = _msg.deserializeTo(status);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->productRecvIn_handler(portNum, id, buffer, status);
-
-            break;
-        }
-
-        // Handle async input port aliasTypedAsync
-        case ALIASTYPEDASYNC_ALIASTYPED: {
-            // Deserialize argument u32
-            AliasPrim1 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            AliasPrim2 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            AliasBool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str2
-            char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
-            Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-            _deserStatus = _msg.deserializeTo(str2);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            AliasEnum e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            AliasArray a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            AliasStruct s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->aliasTypedAsync_handler(portNum, u32, f32, b, str2, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port noArgsAsync
-        case NOARGSASYNC_NOARGS: {
-            // Call handler function
-            this->noArgsAsync_handler(portNum);
-
-            break;
-        }
-
-        // Handle async input port typedAsync
-        case TYPEDASYNC_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsync_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncAssert
-        case TYPEDASYNCASSERT_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncAssert_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncBlockPriority
-        case TYPEDASYNCBLOCKPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncBlockPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle async input port typedAsyncDropPriority
-        case TYPEDASYNCDROPPRIORITY_TYPED: {
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument f32
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument b
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument str1
-            char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-            _deserStatus = _msg.deserializeTo(str1);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument e
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument a
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize argument s
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-            // Call handler function
-            this->typedAsyncDropPriority_handler(portNum, u32, f32, b, str1, e, a, s);
-
-            break;
-        }
-
-        // Handle command CMD_ASYNC
-        case CMD_CMD_ASYNC: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PRIORITY
-        case CMD_CMD_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY
-        case CMD_CMD_PARAMS_PRIORITY: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle command CMD_DROP
-        case CMD_CMD_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
-
-            break;
-        }
-
-        // Handle command CMD_PARAMS_PRIORITY_DROP
-        case CMD_CMD_PARAMS_PRIORITY_DROP: {
-            // Deserialize opcode
-            FwOpcodeType _opCode = 0;
-            _deserStatus = _msg.deserializeTo(_opCode);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command sequence
-            U32 _cmdSeq = 0;
-            _deserStatus = _msg.deserializeTo(_cmdSeq);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Deserialize command argument buffer
-            Fw::CmdArgBuffer args;
-            _deserStatus = _msg.deserializeTo(args);
-            FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Reset buffer
-            args.resetDeser();
-
-            // Deserialize argument u32
-            U32 u32;
-            _deserStatus = args.deserializeTo(u32);
-            if (_deserStatus != Fw::FW_SERIALIZE_OK) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-
-            // Make sure there was no data left over.
-            // That means the argument buffer size was incorrect.
-#if FW_CMD_CHECK_RESIDUAL
-            if (args.getDeserializeSizeLeft() != 0) {
-                if (this->isConnected_cmdResponseOut_OutputPort(0)) {
-                    this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
-                }
-                // Don't crash the task if bad arguments were passed from the ground
-                break;
-            }
-#endif
-
-            // Call handler function
-            this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(_opCode, _cmdSeq, u32);
-
-            break;
-        }
-
-        // Handle internal interface internalArray
-        case INT_IF_INTERNALARRAY: {
-            A a;
-            _deserStatus = _msg.deserializeTo(a);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalArray_internalInterfaceHandler(a);
-
-            break;
-        }
-
-        // Handle internal interface internalEnum
-        case INT_IF_INTERNALENUM: {
-            E e;
-            _deserStatus = _msg.deserializeTo(e);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalEnum_internalInterfaceHandler(e);
-
-            break;
-        }
-
-        // Handle internal interface internalPrimitive
-        case INT_IF_INTERNALPRIMITIVE: {
-            U32 u32;
-            _deserStatus = _msg.deserializeTo(u32);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            F32 f32;
-            _deserStatus = _msg.deserializeTo(f32);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            bool b;
-            _deserStatus = _msg.deserializeTo(b);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalPrimitive_internalInterfaceHandler(u32, f32, b);
-
-            break;
-        }
-
-        // Handle internal interface internalPriorityDrop
-        case INT_IF_INTERNALPRIORITYDROP: {
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalPriorityDrop_internalInterfaceHandler();
-
-            break;
-        }
-
-        // Handle internal interface internalString
-        case INT_IF_INTERNALSTRING: {
-            Fw::InternalInterfaceString str1;
-            _deserStatus = _msg.deserializeTo(str1);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            Fw::InternalInterfaceString str2;
-            _deserStatus = _msg.deserializeTo(str2);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalString_internalInterfaceHandler(str1, str2);
-
-            break;
-        }
-
-        // Handle internal interface internalStruct
-        case INT_IF_INTERNALSTRUCT: {
-            S s;
-            _deserStatus = _msg.deserializeTo(s);
-
-            // Internal interface should always deserialize
-            FW_ASSERT(Fw::FW_SERIALIZE_OK == _deserStatus, static_cast<FwAssertArgType>(_deserStatus));
-
-            // Make sure there was no data left over.
-            // That means the buffer size was incorrect.
-            FW_ASSERT(_msg.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft()));
-
-            // Call handler function
-            this->internalStruct_internalInterfaceHandler(s);
-
-            break;
-        }
-
-        default:
-            return MSG_DISPATCH_ERROR;
+    // Handle async input port noArgsAsync
+    case NOARGSASYNC_NOARGS: {
+      // Call handler function
+      this->noArgsAsync_handler(portNum);
+
+      break;
     }
 
-    return MSG_DISPATCH_OK;
+    // Handle async input port typedAsync
+    case TYPEDASYNC_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsync_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncAssert
+    case TYPEDASYNCASSERT_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncAssert_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncBlockPriority
+    case TYPEDASYNCBLOCKPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncBlockPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle async input port typedAsyncDropPriority
+    case TYPEDASYNCDROPPRIORITY_TYPED: {
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument f32
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument b
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument str1
+      char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
+      _deserStatus = _msg.deserializeTo(str1);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument e
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument a
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize argument s
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+      FW_ASSERT(
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+      // Call handler function
+      this->typedAsyncDropPriority_handler(
+        portNum,
+        u32,
+        f32,
+        b,
+        str1,
+        e,
+        a,
+        s
+      );
+
+      break;
+    }
+
+    // Handle command CMD_ASYNC
+    case CMD_CMD_ASYNC: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_ASYNC_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PRIORITY
+    case CMD_CMD_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PRIORITY_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY
+    case CMD_CMD_PARAMS_PRIORITY: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle command CMD_DROP
+    case CMD_CMD_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_DROP_cmdHandler(_opCode, _cmdSeq);
+
+      break;
+    }
+
+    // Handle command CMD_PARAMS_PRIORITY_DROP
+    case CMD_CMD_PARAMS_PRIORITY_DROP: {
+      // Deserialize opcode
+      FwOpcodeType _opCode = 0;
+      _deserStatus = _msg.deserializeTo(_opCode);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command sequence
+      U32 _cmdSeq = 0;
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Deserialize command argument buffer
+      Fw::CmdArgBuffer args;
+      _deserStatus = _msg.deserializeTo(args);
+      FW_ASSERT (
+        _deserStatus == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Reset buffer
+      args.resetDeser();
+
+      // Deserialize argument u32
+      U32 u32;
+      _deserStatus = args.deserializeTo(u32);
+      if (_deserStatus != Fw::FW_SERIALIZE_OK) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(
+              _opCode,
+              _cmdSeq,
+              Fw::CmdResponse::FORMAT_ERROR
+          );
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+
+      // Make sure there was no data left over.
+      // That means the argument buffer size was incorrect.
+#if FW_CMD_CHECK_RESIDUAL
+      if (args.getDeserializeSizeLeft() != 0) {
+        if (this->isConnected_cmdResponseOut_OutputPort(0)) {
+          this->cmdResponse_out(_opCode, _cmdSeq, Fw::CmdResponse::FORMAT_ERROR);
+        }
+        // Don't crash the task if bad arguments were passed from the ground
+        break;
+      }
+#endif
+
+      // Call handler function
+      this->CMD_PARAMS_PRIORITY_DROP_cmdHandler(
+        _opCode, _cmdSeq,
+        u32
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalArray
+    case INT_IF_INTERNALARRAY: {
+      A a;
+      _deserStatus = _msg.deserializeTo(a);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalArray_internalInterfaceHandler(
+        a
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalEnum
+    case INT_IF_INTERNALENUM: {
+      E e;
+      _deserStatus = _msg.deserializeTo(e);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalEnum_internalInterfaceHandler(
+        e
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalPrimitive
+    case INT_IF_INTERNALPRIMITIVE: {
+      U32 u32;
+      _deserStatus = _msg.deserializeTo(u32);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      F32 f32;
+      _deserStatus = _msg.deserializeTo(f32);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      bool b;
+      _deserStatus = _msg.deserializeTo(b);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalPrimitive_internalInterfaceHandler(
+        u32,
+        f32,
+        b
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalPriorityDrop
+    case INT_IF_INTERNALPRIORITYDROP: {
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalPriorityDrop_internalInterfaceHandler();
+
+      break;
+    }
+
+    // Handle internal interface internalString
+    case INT_IF_INTERNALSTRING: {
+      Fw::InternalInterfaceString str1;
+      _deserStatus = _msg.deserializeTo(str1);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      Fw::InternalInterfaceString str2;
+      _deserStatus = _msg.deserializeTo(str2);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalString_internalInterfaceHandler(
+        str1,
+        str2
+      );
+
+      break;
+    }
+
+    // Handle internal interface internalStruct
+    case INT_IF_INTERNALSTRUCT: {
+      S s;
+      _deserStatus = _msg.deserializeTo(s);
+
+      // Internal interface should always deserialize
+      FW_ASSERT(
+        Fw::FW_SERIALIZE_OK == _deserStatus,
+        static_cast<FwAssertArgType>(_deserStatus)
+      );
+
+      // Make sure there was no data left over.
+      // That means the buffer size was incorrect.
+      FW_ASSERT(
+        _msg.getDeserializeSizeLeft() == 0,
+        static_cast<FwAssertArgType>(_msg.getDeserializeSizeLeft())
+      );
+
+      // Call handler function
+      this->internalStruct_internalInterfaceHandler(
+        s
+      );
+
+      break;
+    }
+
+    default:
+      return MSG_DISPATCH_ERROR;
+  }
+
+  return MSG_DISPATCH_OK;
 }
 
 // ----------------------------------------------------------------------
 // Helper functions for dispatching current messages
 // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::dispatchCurrentMessages() {
-    // Dispatch all current messages unless ERROR or EXIT occur
-    const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
-    MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
-    for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
+  dispatchCurrentMessages()
+{
+  // Dispatch all current messages unless ERROR or EXIT occur
+  const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
+  MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
+  for (FwSizeType i = 0; i < currentMessageCount; i++) {
+    messageStatus = this->doDispatch();
+    if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+      break;
     }
-    return messageStatus;
+  }
+  return messageStatus;
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on special input ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::m_p_cmdIn_in(Fw::PassiveComponentBase* callComp,
-                                            FwIndexType portNum,
-                                            FwOpcodeType opCode,
-                                            U32 cmdSeq,
-                                            Fw::CmdArgBuffer& args) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->cmdIn_handlerBase(portNum, opCode, cmdSeq, args);
+void QueuedTestComponentBase ::
+  m_p_cmdIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      Fw::CmdArgBuffer& args
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->cmdIn_handlerBase(
+    portNum,
+    opCode,
+    cmdSeq,
+    args
+  );
 }
 
-void QueuedTestComponentBase ::m_p_productRecvIn_in(Fw::PassiveComponentBase* callComp,
-                                                    FwIndexType portNum,
-                                                    FwDpIdType id,
-                                                    const Fw::Buffer& buffer,
-                                                    const Fw::Success& status) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->productRecvIn_handlerBase(portNum, id, buffer, status);
+void QueuedTestComponentBase ::
+  m_p_productRecvIn_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->productRecvIn_handlerBase(
+    portNum,
+    id,
+    buffer,
+    status
+  );
 }
 
 // ----------------------------------------------------------------------
 // Calls for messages received on typed input ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::m_p_aliasTypedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                      FwIndexType portNum,
-                                                      AliasPrim1 u32,
-                                                      AliasPrim2 f32,
-                                                      AliasBool b,
-                                                      const Fw::StringBase& str2,
-                                                      const AliasEnum& e,
-                                                      const AliasArray& a,
-                                                      const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->aliasTypedAsync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_aliasTypedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->aliasTypedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedTestComponentBase ::m_p_noArgsAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                        FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTestComponentBase ::
+  m_p_noArgsAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::m_p_noArgsAsync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->noArgsAsync_handlerBase(portNum);
+void QueuedTestComponentBase ::
+  m_p_noArgsAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->noArgsAsync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::m_p_noArgsGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->noArgsGuarded_handlerBase(portNum);
+void QueuedTestComponentBase ::
+  m_p_noArgsGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->noArgsGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTestComponentBase ::m_p_noArgsReturnGuarded_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->noArgsReturnGuarded_handlerBase(portNum);
+U32 QueuedTestComponentBase ::
+  m_p_noArgsReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
 
-U32 QueuedTestComponentBase ::m_p_noArgsReturnSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->noArgsReturnSync_handlerBase(portNum);
+U32 QueuedTestComponentBase ::
+  m_p_noArgsReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
 
-Fw::String QueuedTestComponentBase ::m_p_noArgsStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                   FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->noArgsStringReturnSync_handlerBase(portNum);
+Fw::String QueuedTestComponentBase ::
+  m_p_noArgsStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::m_p_noArgsSync_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->noArgsSync_handlerBase(portNum);
+void QueuedTestComponentBase ::
+  m_p_noArgsSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->noArgsSync_handlerBase(portNum);
 }
 
-void QueuedTestComponentBase ::m_p_typedAliasGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        AliasPrim1 u32,
-                                                        AliasPrim2 f32,
-                                                        AliasBool b,
-                                                        const Fw::StringBase& str2,
-                                                        const AliasEnum& e,
-                                                        const AliasArray& a,
-                                                        const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->typedAliasGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_typedAliasGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->typedAliasGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-AliasPrim2 QueuedTestComponentBase ::m_p_typedAliasReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                 FwIndexType portNum,
-                                                                 AliasPrim1 u32,
-                                                                 AliasPrim2 f32,
-                                                                 AliasBool b,
-                                                                 const Fw::StringBase& str2,
-                                                                 const AliasEnum& e,
-                                                                 const AliasArray& a,
-                                                                 const AliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->typedAliasReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+AliasPrim2 QueuedTestComponentBase ::
+  m_p_typedAliasReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->typedAliasReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-Fw::String QueuedTestComponentBase ::m_p_typedAliasStringReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                                       FwIndexType portNum,
-                                                                       AliasPrim1 u32,
-                                                                       AliasPrim2 f32,
-                                                                       AliasBool b,
-                                                                       const Fw::StringBase& str2,
-                                                                       const AliasEnum& e,
-                                                                       const AliasArray& a,
-                                                                       const AnotherAliasStruct& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->typedAliasStringReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+Fw::String QueuedTestComponentBase ::
+  m_p_typedAliasStringReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      AliasPrim1 u32,
+      AliasPrim2 f32,
+      AliasBool b,
+      const Fw::StringBase& str2,
+      const AliasEnum& e,
+      const AliasArray& a,
+      const AnotherAliasStruct& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->typedAliasStringReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::m_p_typedAsync_in(Fw::PassiveComponentBase* callComp,
-                                                 FwIndexType portNum,
-                                                 U32 u32,
-                                                 F32 f32,
-                                                 bool b,
-                                                 const Fw::StringBase& str1,
-                                                 const E& e,
-                                                 const A& a,
-                                                 const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->typedAsync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_typedAsync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->typedAsync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::m_p_typedAsyncAssert_in(Fw::PassiveComponentBase* callComp,
-                                                       FwIndexType portNum,
-                                                       U32 u32,
-                                                       F32 f32,
-                                                       bool b,
-                                                       const Fw::StringBase& str1,
-                                                       const E& e,
-                                                       const A& a,
-                                                       const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->typedAsyncAssert_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_typedAsyncAssert_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->typedAsyncAssert_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::m_p_typedAsyncBlockPriority_in(Fw::PassiveComponentBase* callComp,
-                                                              FwIndexType portNum,
-                                                              U32 u32,
-                                                              F32 f32,
-                                                              bool b,
-                                                              const Fw::StringBase& str1,
-                                                              const E& e,
-                                                              const A& a,
-                                                              const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->typedAsyncBlockPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_typedAsyncBlockPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->typedAsyncBlockPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::m_p_typedAsyncDropPriority_in(Fw::PassiveComponentBase* callComp,
-                                                             FwIndexType portNum,
-                                                             U32 u32,
-                                                             F32 f32,
-                                                             bool b,
-                                                             const Fw::StringBase& str1,
-                                                             const E& e,
-                                                             const A& a,
-                                                             const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->typedAsyncDropPriority_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_typedAsyncDropPriority_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->typedAsyncDropPriority_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::m_p_typedGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 u32,
-                                                   F32 f32,
-                                                   bool b,
-                                                   const Fw::StringBase& str1,
-                                                   const E& e,
-                                                   const A& a,
-                                                   const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->typedGuarded_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_typedGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->typedGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedTestComponentBase ::m_p_typedReturnGuarded_in(Fw::PassiveComponentBase* callComp,
-                                                        FwIndexType portNum,
-                                                        U32 u32,
-                                                        F32 f32,
-                                                        bool b,
-                                                        const Fw::StringBase& str2,
-                                                        const E& e,
-                                                        const A& a,
-                                                        const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->typedReturnGuarded_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedTestComponentBase ::
+  m_p_typedReturnGuarded_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->typedReturnGuarded_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-F32 QueuedTestComponentBase ::m_p_typedReturnSync_in(Fw::PassiveComponentBase* callComp,
-                                                     FwIndexType portNum,
-                                                     U32 u32,
-                                                     F32 f32,
-                                                     bool b,
-                                                     const Fw::StringBase& str2,
-                                                     const E& e,
-                                                     const A& a,
-                                                     const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    return compPtr->typedReturnSync_handlerBase(portNum, u32, f32, b, str2, e, a, s);
+F32 QueuedTestComponentBase ::
+  m_p_typedReturnSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str2,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  return compPtr->typedReturnSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str2,
+    e,
+    a,
+    s
+  );
 }
 
-void QueuedTestComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callComp,
-                                                FwIndexType portNum,
-                                                U32 u32,
-                                                F32 f32,
-                                                bool b,
-                                                const Fw::StringBase& str1,
-                                                const E& e,
-                                                const A& a,
-                                                const S& s) {
-    FW_ASSERT(callComp);
-    QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
-    compPtr->typedSync_handlerBase(portNum, u32, f32, b, str1, e, a, s);
+void QueuedTestComponentBase ::
+  m_p_typedSync_in(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      F32 f32,
+      bool b,
+      const Fw::StringBase& str1,
+      const E& e,
+      const A& a,
+      const S& s
+  )
+{
+  FW_ASSERT(callComp);
+  QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
+  compPtr->typedSync_handlerBase(
+    portNum,
+    u32,
+    f32,
+    b,
+    str1,
+    e,
+    a,
+    s
+  );
 }
 
 #if !FW_DIRECT_PORT_CALLS
@@ -5433,102 +8643,236 @@ void QueuedTestComponentBase ::m_p_typedSync_in(Fw::PassiveComponentBase* callCo
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::cmdRegOut_out(FwIndexType portNum, FwOpcodeType opCode) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  cmdRegOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdRegOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdRegOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdRegOut_OutputPort[portNum].invoke(opCode);
+  FW_ASSERT(
+    this->m_cmdRegOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdRegOut_OutputPort[portNum].invoke(
+    opCode
+  );
 }
 
-void QueuedTestComponentBase ::cmdResponseOut_out(FwIndexType portNum,
-                                                  FwOpcodeType opCode,
-                                                  U32 cmdSeq,
-                                                  const Fw::CmdResponse& response) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  cmdResponseOut_out(
+      FwIndexType portNum,
+      FwOpcodeType opCode,
+      U32 cmdSeq,
+      const Fw::CmdResponse& response
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_cmdResponseOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_cmdResponseOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_cmdResponseOut_OutputPort[portNum].invoke(opCode, cmdSeq, response);
+  FW_ASSERT(
+    this->m_cmdResponseOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_cmdResponseOut_OutputPort[portNum].invoke(
+    opCode,
+    cmdSeq,
+    response
+  );
 }
 
-void QueuedTestComponentBase ::eventOut_out(FwIndexType portNum,
-                                            FwEventIdType id,
-                                            Fw::Time& timeTag,
-                                            const Fw::LogSeverity& severity,
-                                            Fw::LogBuffer& args) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  eventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::LogBuffer& args
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_eventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_eventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_eventOut_OutputPort[portNum].invoke(id, timeTag, severity, args);
+  FW_ASSERT(
+    this->m_eventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_eventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    args
+  );
 }
 
-Fw::ParamValid QueuedTestComponentBase ::prmGetOut_out(FwIndexType portNum,
-                                                       FwPrmIdType id,
-                                                       Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+Fw::ParamValid QueuedTestComponentBase ::
+  prmGetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    return this->m_prmGetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  return this->m_prmGetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void QueuedTestComponentBase ::prmSetOut_out(FwIndexType portNum, FwPrmIdType id, Fw::ParamBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  prmSetOut_out(
+      FwIndexType portNum,
+      FwPrmIdType id,
+      Fw::ParamBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_prmSetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_prmSetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_prmSetOut_OutputPort[portNum].invoke(id, val);
+  FW_ASSERT(
+    this->m_prmSetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_prmSetOut_OutputPort[portNum].invoke(
+    id,
+    val
+  );
 }
 
-void QueuedTestComponentBase ::productRequestOut_out(FwIndexType portNum, FwDpIdType id, FwSizeType dataSize) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  productRequestOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      FwSizeType dataSize
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productRequestOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productRequestOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productRequestOut_OutputPort[portNum].invoke(id, dataSize);
+  FW_ASSERT(
+    this->m_productRequestOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productRequestOut_OutputPort[portNum].invoke(
+    id,
+    dataSize
+  );
 }
 
-void QueuedTestComponentBase ::productSendOut_out(FwIndexType portNum, FwDpIdType id, const Fw::Buffer& buffer) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  productSendOut_out(
+      FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_productSendOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_productSendOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_productSendOut_OutputPort[portNum].invoke(id, buffer);
+  FW_ASSERT(
+    this->m_productSendOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_productSendOut_OutputPort[portNum].invoke(
+    id,
+    buffer
+  );
 }
 
 #if FW_ENABLE_TEXT_LOGGING
 
-void QueuedTestComponentBase ::textEventOut_out(FwIndexType portNum,
-                                                FwEventIdType id,
-                                                Fw::Time& timeTag,
-                                                const Fw::LogSeverity& severity,
-                                                Fw::TextLogString& text) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  textEventOut_out(
+      FwIndexType portNum,
+      FwEventIdType id,
+      Fw::Time& timeTag,
+      const Fw::LogSeverity& severity,
+      Fw::TextLogString& text
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_textEventOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_textEventOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_textEventOut_OutputPort[portNum].invoke(id, timeTag, severity, text);
+  FW_ASSERT(
+    this->m_textEventOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_textEventOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    severity,
+    text
+  );
 }
 
 #endif
 
-void QueuedTestComponentBase ::timeGetOut_out(FwIndexType portNum, Fw::Time& time) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
-              static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  timeGetOut_out(
+      FwIndexType portNum,
+      Fw::Time& time
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_timeGetOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_timeGetOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_timeGetOut_OutputPort[portNum].invoke(time);
+  FW_ASSERT(
+    this->m_timeGetOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_timeGetOut_OutputPort[portNum].invoke(
+    time
+  );
 }
 
-void QueuedTestComponentBase ::tlmOut_out(FwIndexType portNum,
-                                          FwChanIdType id,
-                                          Fw::Time& timeTag,
-                                          Fw::TlmBuffer& val) const {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()), static_cast<FwAssertArgType>(portNum));
+void QueuedTestComponentBase ::
+  tlmOut_out(
+      FwIndexType portNum,
+      FwChanIdType id,
+      Fw::Time& timeTag,
+      Fw::TlmBuffer& val
+  ) const
+{
+  FW_ASSERT(
+    (0 <= portNum) && (portNum < this->getNum_tlmOut_OutputPorts()),
+    static_cast<FwAssertArgType>(portNum)
+  );
 
-    FW_ASSERT(this->m_tlmOut_OutputPort[portNum].isConnected(), static_cast<FwAssertArgType>(portNum));
-    this->m_tlmOut_OutputPort[portNum].invoke(id, timeTag, val);
+  FW_ASSERT(
+    this->m_tlmOut_OutputPort[portNum].isConnected(),
+    static_cast<FwAssertArgType>(portNum)
+  );
+  this->m_tlmOut_OutputPort[portNum].invoke(
+    id,
+    timeTag,
+    val
+  );
 }
 
 #endif
@@ -5537,612 +8881,757 @@ void QueuedTestComponentBase ::tlmOut_out(FwIndexType portNum,
 // Parameter set functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamU32(Fw::SerialBufferBase& val) {
-    U32 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamU32(Fw::SerialBufferBase& val)
+{
+  U32 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamU32 = _localVal;
-    this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamU32 = _localVal;
+  this->m_param_ParamU32_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMU32);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMU32);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamF64(Fw::SerialBufferBase& val) {
-    F64 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamF64(Fw::SerialBufferBase& val)
+{
+  F64 _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamF64 = _localVal;
-    this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamF64 = _localVal;
+  this->m_param_ParamF64_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMF64);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMF64);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamString(Fw::SerialBufferBase& val) {
-    Fw::ParamString _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamString(Fw::SerialBufferBase& val)
+{
+  Fw::ParamString _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamString = _localVal;
-    this->m_param_ParamString_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamString = _localVal;
+  this->m_param_ParamString_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamEnum(Fw::SerialBufferBase& val) {
-    E _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamEnum(Fw::SerialBufferBase& val)
+{
+  E _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamEnum = _localVal;
-    this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamEnum = _localVal;
+  this->m_param_ParamEnum_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMENUM);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamArray(Fw::SerialBufferBase& val) {
-    A _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamArray(Fw::SerialBufferBase& val)
+{
+  A _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamArray = _localVal;
-    this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamArray = _localVal;
+  this->m_param_ParamArray_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamStruct(Fw::SerialBufferBase& val) {
-    S _localVal{};
-    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamStruct(Fw::SerialBufferBase& val)
+{
+  S _localVal{};
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
 
-    // Assign value only if successfully deserialized
-    this->m_paramLock.lock();
-    this->m_ParamStruct = _localVal;
-    this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
-    this->m_paramLock.unlock();
+  // Assign value only if successfully deserialized
+  this->m_paramLock.lock();
+  this->m_ParamStruct = _localVal;
+  this->m_param_ParamStruct_valid = Fw::ParamValid::VALID;
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-    return Fw::CmdResponse::OK;
+  // Call notifier
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamI32Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamI32Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMI32EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMI32EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamI32Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMI32EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamF64Ext(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamF64Ext(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMF64EXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMF64EXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamF64Ext_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMF64EXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamStringExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamStringExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRINGEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRINGEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStringExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamEnumExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamEnumExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMENUMEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMENUMEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamEnumExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMENUMEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamArrayExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamArrayExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMARRAYEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMARRAYEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamArrayExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  return _response;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSet_ParamStructExt(Fw::SerialBufferBase& val) {
-    Fw::CmdResponse _response{};
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSet_ParamStructExt(Fw::SerialBufferBase& val)
+{
+  Fw::CmdResponse _response{};
 
-    this->m_paramLock.lock();
-    // Update the external parameter
-    FW_ASSERT(this->paramDelegatePtr != nullptr);
-    const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
-        static_cast<FwPrmIdType>(this->getIdBase()), PARAMID_PARAMSTRUCTEXT, Fw::ParamValid::VALID, val);
-    // Set response and update component state
-    if (_stat == Fw::FW_SERIALIZE_OK) {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
-        _response = Fw::CmdResponse::OK;
-    } else {
-        this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
-        _response = Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    this->m_paramLock.unlock();
+  this->m_paramLock.lock();
+  // Update the external parameter
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
+  const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
+    static_cast<FwPrmIdType>(this->getIdBase()),
+    PARAMID_PARAMSTRUCTEXT,
+    Fw::ParamValid::VALID,
+    val
+  );
+  // Set response and update component state
+  if (_stat == Fw::FW_SERIALIZE_OK) {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::VALID;
+    _response = Fw::CmdResponse::OK;
+  }
+  else {
+    this->m_param_ParamStructExt_valid = Fw::ParamValid::INVALID;
+    _response = Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  this->m_paramLock.unlock();
 
-    // Call notifier
-    if (_response == Fw::CmdResponse::OK) {
-        this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
-    }
-    return _response;
+  // Call notifier
+  if (_response == Fw::CmdResponse::OK) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
+  return _response;
 }
 
 // ----------------------------------------------------------------------
 // Parameter save functions
 // ----------------------------------------------------------------------
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamU32() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamU32);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamU32()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamU32_valid == Fw::ParamValid::VALID) || (this->m_param_ParamU32_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamU32);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMU32),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamF64() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamF64);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamF64()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamF64);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamString() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamString);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamString()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamString_valid == Fw::ParamValid::VALID) || (this->m_param_ParamString_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamString);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRING),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamEnum() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamEnum);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamEnum()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnum_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamEnum);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUM),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamArray() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamArray);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamArray()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArray_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArray_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamArray);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAY),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamStruct() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
-        _stat = _paramBuffer.serializeFrom(m_ParamStruct);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamStruct()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStruct_valid == Fw::ParamValid::DEFAULT)) {
+    _stat = _paramBuffer.serializeFrom(m_ParamStruct);
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamI32Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMI32EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamI32Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamI32Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMI32EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMI32EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamF64Ext() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat =
-            this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMF64EXT, _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamF64Ext()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) || (this->m_param_ParamF64Ext_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMF64EXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMF64EXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamStringExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRINGEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamStringExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStringExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRINGEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRINGEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamEnumExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMENUMEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamEnumExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamEnumExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMENUMEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMENUMEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamArrayExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMARRAYEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamArrayExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamArrayExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMARRAYEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMARRAYEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
-Fw::CmdResponse QueuedTestComponentBase ::paramSave_ParamStructExt() {
-    if (!this->isConnected_prmSetOut_OutputPort(0)) {
-        return Fw::CmdResponse::EXECUTION_ERROR;
-    }
-    Fw::ParamBuffer _paramBuffer;
-    const FwIdType idBase = this->getIdBase();
-    Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
-    // Serialize the parameter
-    this->m_paramLock.lock();
-    if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) ||
-        (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
-        FW_ASSERT(this->paramDelegatePtr != nullptr);
-        _stat = this->paramDelegatePtr->serializeParam(static_cast<FwPrmIdType>(idBase), PARAMID_PARAMSTRUCTEXT,
-                                                       _paramBuffer);
-    }
-    this->m_paramLock.unlock();
-    if (_stat != Fw::FW_SERIALIZE_OK) {
-        return Fw::CmdResponse::VALIDATION_ERROR;
-    }
-    // Save the parameter
-    this->prmSetOut_out(0, static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT), _paramBuffer);
-    // Return the command response
-    return Fw::CmdResponse::OK;
+Fw::CmdResponse QueuedTestComponentBase ::
+  paramSave_ParamStructExt()
+{
+  if (!this->isConnected_prmSetOut_OutputPort(0)) {
+    return Fw::CmdResponse::EXECUTION_ERROR;
+  }
+  Fw::ParamBuffer _paramBuffer;
+  const FwIdType idBase = this->getIdBase();
+  Fw::SerializeStatus _stat = Fw::FW_SERIALIZE_FORMAT_ERROR;
+  // Serialize the parameter
+  this->m_paramLock.lock();
+  if ((this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) || (this->m_param_ParamStructExt_valid == Fw::ParamValid::DEFAULT)) {
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
+    _stat = this->paramDelegatePtr->serializeParam(
+      static_cast<FwPrmIdType>(idBase),
+      PARAMID_PARAMSTRUCTEXT,
+      _paramBuffer
+    );
+  }
+  this->m_paramLock.unlock();
+  if (_stat != Fw::FW_SERIALIZE_OK) {
+    return Fw::CmdResponse::VALIDATION_ERROR;
+  }
+  // Save the parameter
+  this->prmSetOut_out(
+    0,
+    static_cast<FwPrmIdType>(idBase + PARAMID_PARAMSTRUCTEXT),
+    _paramBuffer
+  );
+  // Return the command response
+  return Fw::CmdResponse::OK;
 }
 
 // ----------------------------------------------------------------------
 // Private data product handling functions
 // ----------------------------------------------------------------------
 
-void QueuedTestComponentBase ::dpRequest(ContainerId::T containerId, FwSizeType dataSize) {
-    const FwDpIdType globalId = this->getIdBase() + containerId;
-    const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
-    this->productRequestOut_out(0, globalId, size);
+void QueuedTestComponentBase ::
+  dpRequest(
+      ContainerId::T containerId,
+      FwSizeType dataSize
+  )
+{
+  const FwDpIdType globalId = this->getIdBase() + containerId;
+  const FwSizeType size = DpContainer::getPacketSizeForDataSize(dataSize);
+  this->productRequestOut_out(0, globalId, size);
 }
 
-void QueuedTestComponentBase ::productRecvIn_handler(const FwIndexType portNum,
-                                                     FwDpIdType id,
-                                                     const Fw::Buffer& buffer,
-                                                     const Fw::Success& status) {
-    DpContainer container;
-    if (status == Fw::Success::SUCCESS) {
-        container = DpContainer(id, buffer, this->getIdBase());
-    }
-    // Convert global id to local id
-    const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, static_cast<FwAssertArgType>(id), static_cast<FwAssertArgType>(idBase));
-    const FwDpIdType localId = id - idBase;
-    // Switch on the local id
-    switch (localId) {
-        case ContainerId::Container1:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container1);
-            // Call the handler
-            this->dpRecv_Container1_handler(container, status.e);
-            break;
-        case ContainerId::Container2:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container2);
-            // Call the handler
-            this->dpRecv_Container2_handler(container, status.e);
-            break;
-        case ContainerId::Container3:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container3);
-            // Call the handler
-            this->dpRecv_Container3_handler(container, status.e);
-            break;
-        case ContainerId::Container4:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container4);
-            // Call the handler
-            this->dpRecv_Container4_handler(container, status.e);
-            break;
-        case ContainerId::Container5:
-            // Set the priority
-            container.setPriority(ContainerPriority::Container5);
-            // Call the handler
-            this->dpRecv_Container5_handler(container, status.e);
-            break;
-        default:
-            FW_ASSERT(0);
-            break;
-    }
+void QueuedTestComponentBase ::
+  productRecvIn_handler(
+      const FwIndexType portNum,
+      FwDpIdType id,
+      const Fw::Buffer& buffer,
+      const Fw::Success& status
+  )
+{
+  DpContainer container;
+  if (status == Fw::Success::SUCCESS) {
+    container = DpContainer(id, buffer, this->getIdBase());
+  }
+  // Convert global id to local id
+  const FwDpIdType idBase = this->getIdBase();
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
+  const FwDpIdType localId = id - idBase;
+  // Switch on the local id
+  switch (localId) {
+    case ContainerId::Container1:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container1);
+      // Call the handler
+      this->dpRecv_Container1_handler(container, status.e);
+      break;
+    case ContainerId::Container2:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container2);
+      // Call the handler
+      this->dpRecv_Container2_handler(container, status.e);
+      break;
+    case ContainerId::Container3:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container3);
+      // Call the handler
+      this->dpRecv_Container3_handler(container, status.e);
+      break;
+    case ContainerId::Container4:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container4);
+      // Call the handler
+      this->dpRecv_Container4_handler(container, status.e);
+      break;
+    case ContainerId::Container5:
+      // Set the priority
+      container.setPriority(ContainerPriority::Container5);
+      // Call the handler
+      this->dpRecv_Container5_handler(container, status.e);
+      break;
+    default:
+      FW_ASSERT(0);
+      break;
+  }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -86,9 +86,8 @@ namespace {
         SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
       };
 
-      ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
+      ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
@@ -13,280 +13,425 @@
 
 namespace FppTest {
 
-namespace {
+  namespace {
 
-// Constant definitions for the state machine signal buffer
-namespace SmSignalBuffer {
+    // Constant definitions for the state machine signal buffer
+    namespace SmSignalBuffer {
 
-// Union for computing the max size of a signal type
-union SignalTypeUnion {
-    BYTE size_of_U16[sizeof(U16)];
-    BYTE size_of_U32[sizeof(U32)];
-};
+      // Union for computing the max size of a signal type
+      union SignalTypeUnion {
+        BYTE size_of_U16[sizeof(U16)];
+        BYTE size_of_U32[sizeof(U32)];
+      };
 
-// The serialized size
-static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
+      // The serialized size
+      static constexpr FwSizeType SERIALIZED_SIZE =
+        2 * sizeof(FwEnumStoreType) +
+        sizeof(SignalTypeUnion);
 
-}  // namespace SmSignalBuffer
-
-enum MsgTypeEnum {
-    SMCHOICEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    INTERNAL_STATE_MACHINE_SIGNAL,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    // Size of buffer for internal state machine signals
-    // The internal SmSignalBuffer stores the state machine id, the
-    // signal id, and the signal data
-    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
-
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
     }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    enum MsgTypeEnum {
+      SMCHOICEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      INTERNAL_STATE_MACHINE_SIGNAL,
+    };
 
-// ----------------------------------------------------------------------
-// Types for internal state machines
-// ----------------------------------------------------------------------
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      // Size of buffer for internal state machine signals
+      // The internal SmSignalBuffer stores the state machine id, the
+      // signal id, and the signal data
+      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+    };
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::FppTest_SmChoice_Basic(SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::init(SmChoiceActiveComponentBase::SmId smId) {
+      public:
+
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
+
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
+
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Types for internal state machines
+  // ----------------------------------------------------------------------
+
+  SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
+    FppTest_SmChoice_Basic(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
+
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::action_a(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Basic_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::action_b(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Basic_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::guard_g(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_Basic_guard_g(this->getId(), signal);
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::FppTest_SmChoice_BasicU32(
-    SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+  SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
+    FppTest_SmChoice_BasicU32(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::init(SmChoiceActiveComponentBase::SmId smId) {
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::action_a(Signal signal, U32 value) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmChoice_BasicU32_action_a(this->getId(), signal, value);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::action_b(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_BasicU32_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::guard_g(Signal signal, U32 value) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
+    guard_g(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmChoice_BasicU32_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::FppTest_SmChoice_ChoiceToChoice(
-    SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    FppTest_SmChoice_ChoiceToChoice(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::init(SmChoiceActiveComponentBase::SmId smId) {
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_exitS1(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_a(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_enterS2(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_enterS2(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g1(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    guard_g1(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g1(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g2(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    guard_g2(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g2(this->getId(), signal);
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::FppTest_SmChoice_ChoiceToState(
-    SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    FppTest_SmChoice_ChoiceToState(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::init(SmChoiceActiveComponentBase::SmId smId) {
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_exitS1(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_a(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS2(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS3(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS3(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::guard_g(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_ChoiceToState_guard_g(this->getId(), signal);
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::FppTest_SmChoice_InputPairU16U32(
-    SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+  SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    FppTest_SmChoice_InputPairU16U32(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::init(SmChoiceActiveComponentBase::SmId smId) {
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::action_a(Signal signal, U32 value) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmChoice_InputPairU16U32_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::guard_g(Signal signal, U32 value) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    guard_g(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmChoice_InputPairU16U32_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::FppTest_SmChoice_Sequence(
-    SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+  SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
+    FppTest_SmChoice_Sequence(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::init(SmChoiceActiveComponentBase::SmId smId) {
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::action_a(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Sequence_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::action_b(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Sequence_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::guard_g1(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
+    guard_g1(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g1(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::guard_g2(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
+    guard_g2(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g2(this->getId(), signal);
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::FppTest_SmChoice_SequenceU32(
-    SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+  SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
+    FppTest_SmChoice_SequenceU32(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::init(SmChoiceActiveComponentBase::SmId smId) {
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::action_a(Signal signal, U32 value) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmChoice_SequenceU32_action_a(this->getId(), signal, value);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::action_b(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_SequenceU32_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g1(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
+    guard_g1(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g1(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g2(Signal signal, U32 value) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
+    guard_g2(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g2(this->getId(), signal, value);
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::FppTest_SmChoiceActive_Basic(
-    SmChoiceActiveComponentBase& component)
-    : m_component(component) {}
+  SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
+    FppTest_SmChoiceActive_Basic(SmChoiceActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::init(SmChoiceActiveComponentBase::SmId smId) {
+  }
+
+  void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
+    init(SmChoiceActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::getId() const {
+  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
+    getId() const
+  {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::action_a(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoiceActive_Basic_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::action_b(Signal signal) {
+  void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoiceActive_Basic_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::guard_g(Signal signal) const {
+  bool SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoiceActive_Basic_guard_g(this->getId(), signal);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
 
-void SmChoiceActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+  void SmChoiceActiveComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -301,17 +446,23 @@ void SmChoiceActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType i
     this->m_stateMachine_smChoiceSequenceU32.init(SmId::smChoiceSequenceU32);
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-SmChoiceActiveComponentBase ::SmChoiceActiveComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName),
+  SmChoiceActiveComponentBase ::
+    SmChoiceActiveComponentBase(const char* compName) :
+      Fw::ActiveComponentBase(compName),
       m_stateMachine_basic(*this),
       m_stateMachine_smChoiceBasic(*this),
       m_stateMachine_smChoiceBasicU32(*this),
@@ -319,300 +470,393 @@ SmChoiceActiveComponentBase ::SmChoiceActiveComponentBase(const char* compName)
       m_stateMachine_smChoiceChoiceToState(*this),
       m_stateMachine_smChoiceInputPairU16U32(*this),
       m_stateMachine_smChoiceSequence(*this),
-      m_stateMachine_smChoiceSequenceU32(*this) {}
+      m_stateMachine_smChoiceSequenceU32(*this)
+  {
 
-SmChoiceActiveComponentBase ::~SmChoiceActiveComponentBase() {}
+  }
 
-// ----------------------------------------------------------------------
-// State getter functions
-// ----------------------------------------------------------------------
+  SmChoiceActiveComponentBase ::
+    ~SmChoiceActiveComponentBase()
+  {
 
-SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic::State SmChoiceActiveComponentBase ::basic_getState() const {
+  }
+
+  // ----------------------------------------------------------------------
+  // State getter functions
+  // ----------------------------------------------------------------------
+
+  SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic::State SmChoiceActiveComponentBase ::
+    basic_getState() const
+  {
     return this->m_stateMachine_basic.getState();
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_Basic::State SmChoiceActiveComponentBase ::smChoiceBasic_getState()
-    const {
+  SmChoiceActiveComponentBase::FppTest_SmChoice_Basic::State SmChoiceActiveComponentBase ::
+    smChoiceBasic_getState() const
+  {
     return this->m_stateMachine_smChoiceBasic.getState();
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceActiveComponentBase ::smChoiceBasicU32_getState()
-    const {
+  SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceActiveComponentBase ::
+    smChoiceBasicU32_getState() const
+  {
     return this->m_stateMachine_smChoiceBasicU32.getState();
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice::State
-SmChoiceActiveComponentBase ::smChoiceChoiceToChoice_getState() const {
+  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice::State SmChoiceActiveComponentBase ::
+    smChoiceChoiceToChoice_getState() const
+  {
     return this->m_stateMachine_smChoiceChoiceToChoice.getState();
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState::State
-SmChoiceActiveComponentBase ::smChoiceChoiceToState_getState() const {
+  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState::State SmChoiceActiveComponentBase ::
+    smChoiceChoiceToState_getState() const
+  {
     return this->m_stateMachine_smChoiceChoiceToState.getState();
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32::State
-SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_getState() const {
+  SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32::State SmChoiceActiveComponentBase ::
+    smChoiceInputPairU16U32_getState() const
+  {
     return this->m_stateMachine_smChoiceInputPairU16U32.getState();
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence::State SmChoiceActiveComponentBase ::smChoiceSequence_getState()
-    const {
+  SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence::State SmChoiceActiveComponentBase ::
+    smChoiceSequence_getState() const
+  {
     return this->m_stateMachine_smChoiceSequence.getState();
-}
+  }
 
-SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32::State
-SmChoiceActiveComponentBase ::smChoiceSequenceU32_getState() const {
+  SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32::State SmChoiceActiveComponentBase ::
+    smChoiceSequenceU32_getState() const
+  {
     return this->m_stateMachine_smChoiceSequenceU32.getState();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Signal send functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Signal send functions
+  // ----------------------------------------------------------------------
 
-void SmChoiceActiveComponentBase ::basic_sendSignal_s() {
+  void SmChoiceActiveComponentBase ::
+    basic_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic, static_cast<FwEnumStoreType>(FppTest_SmChoiceActive_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceBasic_sendSignal_s() {
+  void SmChoiceActiveComponentBase ::
+    smChoiceBasic_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceBasic, static_cast<FwEnumStoreType>(FppTest_SmChoice_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceBasic_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceBasicU32_sendSignal_s(U32 value) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceBasicU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceBasicU32_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceChoiceToChoice_sendSignal_s() {
+  void SmChoiceActiveComponentBase ::
+    smChoiceChoiceToChoice_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToChoice, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceChoiceToState_sendSignal_s() {
+  void SmChoiceActiveComponentBase ::
+    smChoiceChoiceToState_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToState, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToState_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_sendSignal_s1(U16 value) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceInputPairU16U32_sendSignal_s1(U16 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_sendSignal_s2(U32 value) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceInputPairU16U32_sendSignal_s2(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceSequence_sendSignal_s() {
+  void SmChoiceActiveComponentBase ::
+    smChoiceSequence_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceSequence_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceSequenceU32_sendSignal_s(U32 value) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceSequenceU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequenceU32,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceSequenceU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceSequenceU32_sendSignalFinish(buffer);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceActiveComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceActiveComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::BLOCKING,
+      _priority
+    );
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMCHOICEACTIVE_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle signals to internal state machines
-        case INTERNAL_STATE_MACHINE_SIGNAL:
-            this->smDispatch(_msg);
-            break;
 
-        default:
-            return MSG_DISPATCH_ERROR;
+      // Handle signals to internal state machines
+      case INTERNAL_STATE_MACHINE_SIGNAL:
+        this->smDispatch(_msg);
+        break;
+
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Send signal helper functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Send signal helper functions
+  // ----------------------------------------------------------------------
 
-void SmChoiceActiveComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    sendSignalStart(
+        SmId smId,
+        FwEnumStoreType signal,
+        Fw::SerialBufferBase& buffer
+    )
+  {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmChoiceActiveComponentBase ::basic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    basic_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        // Deserialize the state machine ID and signal
-        FwEnumStoreType smId;
-        FwEnumStoreType signal;
-        SmChoiceActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Call the overflow hook
-        this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+      // Deserialize the state machine ID and signal
+      FwEnumStoreType smId;
+      FwEnumStoreType signal;
+      SmChoiceActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Continue execution
-        return;
+      // Call the overflow hook
+      this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+
+      // Continue execution
+      return;
+
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceActiveComponentBase ::smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for state machine dispatch
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for state machine dispatch
+  // ----------------------------------------------------------------------
 
-void SmChoiceActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
+  void SmChoiceActiveComponentBase ::
+    smDispatch(Fw::SerialBufferBase& buffer)
+  {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -621,66 +865,62 @@ void SmChoiceActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-        case SmId::basic: {
-            const FppTest_SmChoiceActive_Basic::Signal signal =
-                static_cast<FppTest_SmChoiceActive_Basic::Signal>(storedSignal);
-            this->FppTest_SmChoiceActive_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
-            break;
-        }
-        case SmId::smChoiceBasic: {
-            const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
-            this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
-            break;
-        }
-        case SmId::smChoiceBasicU32: {
-            const FppTest_SmChoice_BasicU32::Signal signal =
-                static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
-            this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
-            break;
-        }
-        case SmId::smChoiceChoiceToChoice: {
-            const FppTest_SmChoice_ChoiceToChoice::Signal signal =
-                static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
-            this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice,
-                                                             signal);
-            break;
-        }
-        case SmId::smChoiceChoiceToState: {
-            const FppTest_SmChoice_ChoiceToState::Signal signal =
-                static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
-            this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
-            break;
-        }
-        case SmId::smChoiceInputPairU16U32: {
-            const FppTest_SmChoice_InputPairU16U32::Signal signal =
-                static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
-            this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32,
-                                                              signal);
-            break;
-        }
-        case SmId::smChoiceSequence: {
-            const FppTest_SmChoice_Sequence::Signal signal =
-                static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
-            this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
-            break;
-        }
-        case SmId::smChoiceSequenceU32: {
-            const FppTest_SmChoice_SequenceU32::Signal signal =
-                static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
-            this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-            break;
+      case SmId::basic: {
+        const FppTest_SmChoiceActive_Basic::Signal signal = static_cast<FppTest_SmChoiceActive_Basic::Signal>(storedSignal);
+        this->FppTest_SmChoiceActive_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
+        break;
+      }
+      case SmId::smChoiceBasic: {
+        const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
+        this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
+        break;
+      }
+      case SmId::smChoiceBasicU32: {
+        const FppTest_SmChoice_BasicU32::Signal signal = static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
+        this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
+        break;
+      }
+      case SmId::smChoiceChoiceToChoice: {
+        const FppTest_SmChoice_ChoiceToChoice::Signal signal = static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
+        this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice, signal);
+        break;
+      }
+      case SmId::smChoiceChoiceToState: {
+        const FppTest_SmChoice_ChoiceToState::Signal signal = static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
+        this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
+        break;
+      }
+      case SmId::smChoiceInputPairU16U32: {
+        const FppTest_SmChoice_InputPairU16U32::Signal signal = static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
+        this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32, signal);
+        break;
+      }
+      case SmId::smChoiceSequence: {
+        const FppTest_SmChoice_Sequence::Signal signal = static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
+        this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
+        break;
+      }
+      case SmId::smChoiceSequenceU32: {
+        const FppTest_SmChoice_SequenceU32::Signal signal = static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
+        this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
-                                                            FwEnumStoreType& smId,
-                                                            FwEnumStoreType& signal) {
+  void SmChoiceActiveComponentBase ::
+    deserializeSmIdAndSignal(
+        Fw::SerialBufferBase& buffer,
+        FwEnumStoreType& smId,
+        FwEnumStoreType& signal
+    )
+  {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status =
+      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -690,179 +930,197 @@ void SmChoiceActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoice_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                     FppTest_SmChoice_Basic& sm,
-                                                                     FppTest_SmChoice_Basic::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoice_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_Basic& sm,
+        FppTest_SmChoice_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoice_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmChoice_BasicU32& sm,
-                                                                        FppTest_SmChoice_BasicU32::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoice_BasicU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_BasicU32& sm,
+        FppTest_SmChoice_BasicU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_BasicU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_BasicU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoice_ChoiceToChoice_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_ChoiceToChoice& sm,
-    FppTest_SmChoice_ChoiceToChoice::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoice_ChoiceToChoice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_ChoiceToChoice& sm,
+        FppTest_SmChoice_ChoiceToChoice::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoice_ChoiceToState_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_ChoiceToState& sm,
-    FppTest_SmChoice_ChoiceToState::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoice_ChoiceToState_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_ChoiceToState& sm,
+        FppTest_SmChoice_ChoiceToState::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_ChoiceToState::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_ChoiceToState::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoice_InputPairU16U32_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_InputPairU16U32& sm,
-    FppTest_SmChoice_InputPairU16U32::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoice_InputPairU16U32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_InputPairU16U32& sm,
+        FppTest_SmChoice_InputPairU16U32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
-            // Deserialize the data
-            U16 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s1
-            sm.sendSignal_s1(value);
-            break;
-        }
-        case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s2
-            sm.sendSignal_s2(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
+        // Deserialize the data
+        U16 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s1
+        sm.sendSignal_s1(value);
+        break;
+      }
+      case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s2
+        sm.sendSignal_s2(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoice_Sequence_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmChoice_Sequence& sm,
-                                                                        FppTest_SmChoice_Sequence::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoice_Sequence_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_Sequence& sm,
+        FppTest_SmChoice_Sequence::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_Sequence::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_Sequence::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoice_SequenceU32_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_SequenceU32& sm,
-    FppTest_SmChoice_SequenceU32::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoice_SequenceU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_SequenceU32& sm,
+        FppTest_SmChoice_SequenceU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_SequenceU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_SequenceU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceActiveComponentBase ::FppTest_SmChoiceActive_Basic_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoiceActive_Basic& sm,
-    FppTest_SmChoiceActive_Basic::Signal signal) {
+  void SmChoiceActiveComponentBase ::
+    FppTest_SmChoiceActive_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoiceActive_Basic& sm,
+        FppTest_SmChoiceActive_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoiceActive_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoiceActive_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-}  // namespace FppTest
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
@@ -62,9 +62,8 @@ namespace FppTest {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
@@ -13,432 +13,280 @@
 
 namespace FppTest {
 
-  namespace {
+namespace {
 
-    // Constant definitions for the state machine signal buffer
-    namespace SmSignalBuffer {
+// Constant definitions for the state machine signal buffer
+namespace SmSignalBuffer {
 
-      // Union for computing the max size of a signal type
-      union SignalTypeUnion {
-        BYTE size_of_U16[sizeof(U16)];
-        BYTE size_of_U32[sizeof(U32)];
-      };
+// Union for computing the max size of a signal type
+union SignalTypeUnion {
+    BYTE size_of_U16[sizeof(U16)];
+    BYTE size_of_U32[sizeof(U32)];
+};
 
-      // The serialized size
-      static constexpr FwSizeType SERIALIZED_SIZE =
-        2 * sizeof(FwEnumStoreType) +
-        sizeof(SignalTypeUnion);
+// The serialized size
+static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
 
+}  // namespace SmSignalBuffer
+
+enum MsgTypeEnum {
+    SMCHOICEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    INTERNAL_STATE_MACHINE_SIGNAL,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    // Size of buffer for internal state machine signals
+    // The internal SmSignalBuffer stores the state machine id, the
+    // signal id, and the signal data
+    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+    };
+
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
     }
 
-    enum MsgTypeEnum {
-      SMCHOICEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      INTERNAL_STATE_MACHINE_SIGNAL,
-    };
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      // Size of buffer for internal state machine signals
-      // The internal SmSignalBuffer stores the state machine id, the
-      // signal id, and the signal data
-      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-    };
+// ----------------------------------------------------------------------
+// Types for internal state machines
+// ----------------------------------------------------------------------
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::FppTest_SmChoice_Basic(SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-      public:
-
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
-
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
-
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Types for internal state machines
-  // ----------------------------------------------------------------------
-
-  SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
-    FppTest_SmChoice_Basic(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
-
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
-    action_a(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
-    action_b(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_Basic_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::
-    guard_g(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_Basic ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmChoice_Basic_guard_g(this->getId(), signal);
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
-    FppTest_SmChoice_BasicU32(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::FppTest_SmChoice_BasicU32(
+    SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmChoice_BasicU32_action_a(this->getId(), signal, value);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
-    action_b(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_BasicU32_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::
-    guard_g(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32 ::guard_g(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmChoice_BasicU32_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    FppTest_SmChoice_ChoiceToChoice(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::FppTest_SmChoice_ChoiceToChoice(
+    SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    action_exitS1(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    action_a(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    action_enterS2(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_enterS2(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    guard_g1(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g1(Signal signal) const {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g1(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    guard_g2(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g2(Signal signal) const {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g2(this->getId(), signal);
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    FppTest_SmChoice_ChoiceToState(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::FppTest_SmChoice_ChoiceToState(
+    SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_exitS1(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_a(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_enterS2(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_enterS3(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS3(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::
-    guard_g(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmChoice_ChoiceToState_guard_g(this->getId(), signal);
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    FppTest_SmChoice_InputPairU16U32(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::FppTest_SmChoice_InputPairU16U32(
+    SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmChoice_InputPairU16U32_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    guard_g(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32 ::guard_g(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmChoice_InputPairU16U32_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
-    FppTest_SmChoice_Sequence(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::FppTest_SmChoice_Sequence(
+    SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
-    action_a(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_Sequence_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
-    action_b(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_Sequence_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
-    guard_g1(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::guard_g1(Signal signal) const {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g1(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::
-    guard_g2(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence ::guard_g2(Signal signal) const {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g2(this->getId(), signal);
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
-    FppTest_SmChoice_SequenceU32(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::FppTest_SmChoice_SequenceU32(
+    SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmChoice_SequenceU32_action_a(this->getId(), signal, value);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
-    action_b(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_SequenceU32_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
-    guard_g1(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g1(Signal signal) const {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g1(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::
-    guard_g2(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g2(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g2(this->getId(), signal, value);
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
-    FppTest_SmChoiceActive_Basic(SmChoiceActiveComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::FppTest_SmChoiceActive_Basic(
+    SmChoiceActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
-    init(SmChoiceActiveComponentBase::SmId smId)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::init(SmChoiceActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
-    getId() const
-  {
+SmChoiceActiveComponentBase::SmId SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::getId() const {
     return static_cast<SmChoiceActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
-    action_a(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoiceActive_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
-    action_b(Signal signal)
-  {
+void SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoiceActive_Basic_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::
-    guard_g(Signal signal) const
-  {
+bool SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmChoiceActive_Basic_guard_g(this->getId(), signal);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
 
-  void SmChoiceActiveComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+void SmChoiceActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -453,23 +301,17 @@ namespace FppTest {
     this->m_stateMachine_smChoiceSequenceU32.init(SmId::smChoiceSequenceU32);
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  SmChoiceActiveComponentBase ::
-    SmChoiceActiveComponentBase(const char* compName) :
-      Fw::ActiveComponentBase(compName),
+SmChoiceActiveComponentBase ::SmChoiceActiveComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName),
       m_stateMachine_basic(*this),
       m_stateMachine_smChoiceBasic(*this),
       m_stateMachine_smChoiceBasicU32(*this),
@@ -477,393 +319,300 @@ namespace FppTest {
       m_stateMachine_smChoiceChoiceToState(*this),
       m_stateMachine_smChoiceInputPairU16U32(*this),
       m_stateMachine_smChoiceSequence(*this),
-      m_stateMachine_smChoiceSequenceU32(*this)
-  {
+      m_stateMachine_smChoiceSequenceU32(*this) {}
 
-  }
+SmChoiceActiveComponentBase ::~SmChoiceActiveComponentBase() {}
 
-  SmChoiceActiveComponentBase ::
-    ~SmChoiceActiveComponentBase()
-  {
+// ----------------------------------------------------------------------
+// State getter functions
+// ----------------------------------------------------------------------
 
-  }
-
-  // ----------------------------------------------------------------------
-  // State getter functions
-  // ----------------------------------------------------------------------
-
-  SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic::State SmChoiceActiveComponentBase ::
-    basic_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoiceActive_Basic::State SmChoiceActiveComponentBase ::basic_getState() const {
     return this->m_stateMachine_basic.getState();
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_Basic::State SmChoiceActiveComponentBase ::
-    smChoiceBasic_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_Basic::State SmChoiceActiveComponentBase ::smChoiceBasic_getState()
+    const {
     return this->m_stateMachine_smChoiceBasic.getState();
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceActiveComponentBase ::
-    smChoiceBasicU32_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceActiveComponentBase ::smChoiceBasicU32_getState()
+    const {
     return this->m_stateMachine_smChoiceBasicU32.getState();
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice::State SmChoiceActiveComponentBase ::
-    smChoiceChoiceToChoice_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToChoice::State
+SmChoiceActiveComponentBase ::smChoiceChoiceToChoice_getState() const {
     return this->m_stateMachine_smChoiceChoiceToChoice.getState();
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState::State SmChoiceActiveComponentBase ::
-    smChoiceChoiceToState_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_ChoiceToState::State
+SmChoiceActiveComponentBase ::smChoiceChoiceToState_getState() const {
     return this->m_stateMachine_smChoiceChoiceToState.getState();
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32::State SmChoiceActiveComponentBase ::
-    smChoiceInputPairU16U32_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_InputPairU16U32::State
+SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_getState() const {
     return this->m_stateMachine_smChoiceInputPairU16U32.getState();
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence::State SmChoiceActiveComponentBase ::
-    smChoiceSequence_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_Sequence::State SmChoiceActiveComponentBase ::smChoiceSequence_getState()
+    const {
     return this->m_stateMachine_smChoiceSequence.getState();
-  }
+}
 
-  SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32::State SmChoiceActiveComponentBase ::
-    smChoiceSequenceU32_getState() const
-  {
+SmChoiceActiveComponentBase::FppTest_SmChoice_SequenceU32::State
+SmChoiceActiveComponentBase ::smChoiceSequenceU32_getState() const {
     return this->m_stateMachine_smChoiceSequenceU32.getState();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Signal send functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Signal send functions
+// ----------------------------------------------------------------------
 
-  void SmChoiceActiveComponentBase ::
-    basic_sendSignal_s()
-  {
+void SmChoiceActiveComponentBase ::basic_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic, static_cast<FwEnumStoreType>(FppTest_SmChoiceActive_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceBasic_sendSignal_s()
-  {
+void SmChoiceActiveComponentBase ::smChoiceBasic_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceBasic, static_cast<FwEnumStoreType>(FppTest_SmChoice_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceBasic_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceBasicU32_sendSignal_s(U32 value)
-  {
+void SmChoiceActiveComponentBase ::smChoiceBasicU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s),
+                          buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceBasicU32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceChoiceToChoice_sendSignal_s()
-  {
+void SmChoiceActiveComponentBase ::smChoiceChoiceToChoice_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToChoice, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceChoiceToState_sendSignal_s()
-  {
+void SmChoiceActiveComponentBase ::smChoiceChoiceToState_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToState, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToState_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceInputPairU16U32_sendSignal_s1(U16 value)
-  {
+void SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_sendSignal_s1(U16 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceInputPairU16U32_sendSignal_s2(U32 value)
-  {
+void SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_sendSignal_s2(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceSequence_sendSignal_s()
-  {
+void SmChoiceActiveComponentBase ::smChoiceSequence_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s),
+                          buffer);
     // Send the message and handle overflow
     this->smChoiceSequence_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceSequenceU32_sendSignal_s(U32 value)
-  {
+void SmChoiceActiveComponentBase ::smChoiceSequenceU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequenceU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceSequenceU32,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceSequenceU32_sendSignalFinish(buffer);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceActiveComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceActiveComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::BLOCKING,
-      _priority
-    );
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMCHOICEACTIVE_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
+        // Handle signals to internal state machines
+        case INTERNAL_STATE_MACHINE_SIGNAL:
+            this->smDispatch(_msg);
+            break;
 
-      // Handle signals to internal state machines
-      case INTERNAL_STATE_MACHINE_SIGNAL:
-        this->smDispatch(_msg);
-        break;
-
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Send signal helper functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Send signal helper functions
+// ----------------------------------------------------------------------
 
-  void SmChoiceActiveComponentBase ::
-    sendSignalStart(
-        SmId smId,
-        FwEnumStoreType signal,
-        Fw::SerialBufferBase& buffer
-    )
-  {
+void SmChoiceActiveComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    basic_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::basic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
+        // Deserialize the state machine ID and signal
+        FwEnumStoreType smId;
+        FwEnumStoreType signal;
+        SmChoiceActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-      // Deserialize the state machine ID and signal
-      FwEnumStoreType smId;
-      FwEnumStoreType signal;
-      SmChoiceActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
+        // Call the overflow hook
+        this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
 
-      // Call the overflow hook
-      this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
-
-      // Continue execution
-      return;
-
+        // Continue execution
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceActiveComponentBase ::
-    smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for state machine dispatch
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for state machine dispatch
+// ----------------------------------------------------------------------
 
-  void SmChoiceActiveComponentBase ::
-    smDispatch(Fw::SerialBufferBase& buffer)
-  {
+void SmChoiceActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -872,62 +621,66 @@ namespace FppTest {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-      case SmId::basic: {
-        const FppTest_SmChoiceActive_Basic::Signal signal = static_cast<FppTest_SmChoiceActive_Basic::Signal>(storedSignal);
-        this->FppTest_SmChoiceActive_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
-        break;
-      }
-      case SmId::smChoiceBasic: {
-        const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
-        this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
-        break;
-      }
-      case SmId::smChoiceBasicU32: {
-        const FppTest_SmChoice_BasicU32::Signal signal = static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
-        this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
-        break;
-      }
-      case SmId::smChoiceChoiceToChoice: {
-        const FppTest_SmChoice_ChoiceToChoice::Signal signal = static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
-        this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice, signal);
-        break;
-      }
-      case SmId::smChoiceChoiceToState: {
-        const FppTest_SmChoice_ChoiceToState::Signal signal = static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
-        this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
-        break;
-      }
-      case SmId::smChoiceInputPairU16U32: {
-        const FppTest_SmChoice_InputPairU16U32::Signal signal = static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
-        this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32, signal);
-        break;
-      }
-      case SmId::smChoiceSequence: {
-        const FppTest_SmChoice_Sequence::Signal signal = static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
-        this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
-        break;
-      }
-      case SmId::smChoiceSequenceU32: {
-        const FppTest_SmChoice_SequenceU32::Signal signal = static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
-        this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-        break;
+        case SmId::basic: {
+            const FppTest_SmChoiceActive_Basic::Signal signal =
+                static_cast<FppTest_SmChoiceActive_Basic::Signal>(storedSignal);
+            this->FppTest_SmChoiceActive_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
+            break;
+        }
+        case SmId::smChoiceBasic: {
+            const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
+            this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
+            break;
+        }
+        case SmId::smChoiceBasicU32: {
+            const FppTest_SmChoice_BasicU32::Signal signal =
+                static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
+            this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
+            break;
+        }
+        case SmId::smChoiceChoiceToChoice: {
+            const FppTest_SmChoice_ChoiceToChoice::Signal signal =
+                static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
+            this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice,
+                                                             signal);
+            break;
+        }
+        case SmId::smChoiceChoiceToState: {
+            const FppTest_SmChoice_ChoiceToState::Signal signal =
+                static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
+            this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
+            break;
+        }
+        case SmId::smChoiceInputPairU16U32: {
+            const FppTest_SmChoice_InputPairU16U32::Signal signal =
+                static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
+            this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32,
+                                                              signal);
+            break;
+        }
+        case SmId::smChoiceSequence: {
+            const FppTest_SmChoice_Sequence::Signal signal =
+                static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
+            this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
+            break;
+        }
+        case SmId::smChoiceSequenceU32: {
+            const FppTest_SmChoice_SequenceU32::Signal signal =
+                static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
+            this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+            break;
     }
-  }
+}
 
-  void SmChoiceActiveComponentBase ::
-    deserializeSmIdAndSignal(
-        Fw::SerialBufferBase& buffer,
-        FwEnumStoreType& smId,
-        FwEnumStoreType& signal
-    )
-  {
+void SmChoiceActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
+                                                            FwEnumStoreType& smId,
+                                                            FwEnumStoreType& signal) {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status =
-      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -937,197 +690,179 @@ namespace FppTest {
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoice_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_Basic& sm,
-        FppTest_SmChoice_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoice_BasicU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_BasicU32& sm,
-        FppTest_SmChoice_BasicU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_BasicU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoice_ChoiceToChoice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_ChoiceToChoice& sm,
-        FppTest_SmChoice_ChoiceToChoice::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoice_ChoiceToState_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_ChoiceToState& sm,
-        FppTest_SmChoice_ChoiceToState::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_ChoiceToState::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoice_InputPairU16U32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_InputPairU16U32& sm,
-        FppTest_SmChoice_InputPairU16U32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
-        // Deserialize the data
-        U16 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s1
-        sm.sendSignal_s1(value);
-        break;
-      }
-      case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s2
-        sm.sendSignal_s2(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoice_Sequence_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_Sequence& sm,
-        FppTest_SmChoice_Sequence::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_Sequence::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoice_SequenceU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_SequenceU32& sm,
-        FppTest_SmChoice_SequenceU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_SequenceU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceActiveComponentBase ::
-    FppTest_SmChoiceActive_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoiceActive_Basic& sm,
-        FppTest_SmChoiceActive_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoiceActive_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
 }
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoice_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                     FppTest_SmChoice_Basic& sm,
+                                                                     FppTest_SmChoice_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoice_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmChoice_BasicU32& sm,
+                                                                        FppTest_SmChoice_BasicU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_BasicU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoice_ChoiceToChoice_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_ChoiceToChoice& sm,
+    FppTest_SmChoice_ChoiceToChoice::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoice_ChoiceToState_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_ChoiceToState& sm,
+    FppTest_SmChoice_ChoiceToState::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_ChoiceToState::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoice_InputPairU16U32_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_InputPairU16U32& sm,
+    FppTest_SmChoice_InputPairU16U32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
+            // Deserialize the data
+            U16 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s1
+            sm.sendSignal_s1(value);
+            break;
+        }
+        case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s2
+            sm.sendSignal_s2(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoice_Sequence_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmChoice_Sequence& sm,
+                                                                        FppTest_SmChoice_Sequence::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_Sequence::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoice_SequenceU32_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_SequenceU32& sm,
+    FppTest_SmChoice_SequenceU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_SequenceU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceActiveComponentBase ::FppTest_SmChoiceActive_Basic_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoiceActive_Basic& sm,
+    FppTest_SmChoiceActive_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoiceActive_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+}  // namespace FppTest

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
@@ -13,280 +13,425 @@
 
 namespace FppTest {
 
-namespace {
+  namespace {
 
-// Constant definitions for the state machine signal buffer
-namespace SmSignalBuffer {
+    // Constant definitions for the state machine signal buffer
+    namespace SmSignalBuffer {
 
-// Union for computing the max size of a signal type
-union SignalTypeUnion {
-    BYTE size_of_U16[sizeof(U16)];
-    BYTE size_of_U32[sizeof(U32)];
-};
+      // Union for computing the max size of a signal type
+      union SignalTypeUnion {
+        BYTE size_of_U16[sizeof(U16)];
+        BYTE size_of_U32[sizeof(U32)];
+      };
 
-// The serialized size
-static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
+      // The serialized size
+      static constexpr FwSizeType SERIALIZED_SIZE =
+        2 * sizeof(FwEnumStoreType) +
+        sizeof(SignalTypeUnion);
 
-}  // namespace SmSignalBuffer
-
-enum MsgTypeEnum {
-    SMCHOICEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    INTERNAL_STATE_MACHINE_SIGNAL,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    // Size of buffer for internal state machine signals
-    // The internal SmSignalBuffer stores the state machine id, the
-    // signal id, and the signal data
-    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
-
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
     }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    enum MsgTypeEnum {
+      SMCHOICEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      INTERNAL_STATE_MACHINE_SIGNAL,
+    };
 
-// ----------------------------------------------------------------------
-// Types for internal state machines
-// ----------------------------------------------------------------------
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      // Size of buffer for internal state machine signals
+      // The internal SmSignalBuffer stores the state machine id, the
+      // signal id, and the signal data
+      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+    };
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::FppTest_SmChoice_Basic(SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::init(SmChoiceQueuedComponentBase::SmId smId) {
+      public:
+
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
+
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
+
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Types for internal state machines
+  // ----------------------------------------------------------------------
+
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
+    FppTest_SmChoice_Basic(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
+
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::action_a(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Basic_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::action_b(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Basic_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::guard_g(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_Basic_guard_g(this->getId(), signal);
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::FppTest_SmChoice_BasicU32(
-    SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
+    FppTest_SmChoice_BasicU32(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::init(SmChoiceQueuedComponentBase::SmId smId) {
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::action_a(Signal signal, U32 value) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmChoice_BasicU32_action_a(this->getId(), signal, value);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::action_b(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_BasicU32_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::guard_g(Signal signal, U32 value) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
+    guard_g(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmChoice_BasicU32_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::FppTest_SmChoice_ChoiceToChoice(
-    SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    FppTest_SmChoice_ChoiceToChoice(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::init(SmChoiceQueuedComponentBase::SmId smId) {
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_exitS1(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_a(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_enterS2(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_enterS2(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g1(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    guard_g1(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g1(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g2(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
+    guard_g2(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g2(this->getId(), signal);
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::FppTest_SmChoice_ChoiceToState(
-    SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    FppTest_SmChoice_ChoiceToState(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::init(SmChoiceQueuedComponentBase::SmId smId) {
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_exitS1(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_a(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS2(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS3(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS3(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::guard_g(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_ChoiceToState_guard_g(this->getId(), signal);
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::FppTest_SmChoice_InputPairU16U32(
-    SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    FppTest_SmChoice_InputPairU16U32(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::init(SmChoiceQueuedComponentBase::SmId smId) {
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::action_a(Signal signal, U32 value) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmChoice_InputPairU16U32_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::guard_g(Signal signal, U32 value) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
+    guard_g(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmChoice_InputPairU16U32_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::FppTest_SmChoice_Sequence(
-    SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
+    FppTest_SmChoice_Sequence(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::init(SmChoiceQueuedComponentBase::SmId smId) {
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::action_a(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Sequence_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::action_b(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_Sequence_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::guard_g1(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
+    guard_g1(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g1(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::guard_g2(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
+    guard_g2(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g2(this->getId(), signal);
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::FppTest_SmChoice_SequenceU32(
-    SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
+    FppTest_SmChoice_SequenceU32(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::init(SmChoiceQueuedComponentBase::SmId smId) {
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::action_a(Signal signal, U32 value) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmChoice_SequenceU32_action_a(this->getId(), signal, value);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::action_b(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoice_SequenceU32_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g1(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
+    guard_g1(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g1(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g2(Signal signal, U32 value) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
+    guard_g2(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g2(this->getId(), signal, value);
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::FppTest_SmChoiceQueued_Basic(
-    SmChoiceQueuedComponentBase& component)
-    : m_component(component) {}
+  SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
+    FppTest_SmChoiceQueued_Basic(SmChoiceQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::init(SmChoiceQueuedComponentBase::SmId smId) {
+  }
+
+  void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
+    init(SmChoiceQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::getId() const {
+  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
+    getId() const
+  {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::action_a(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmChoiceQueued_Basic_action_a(this->getId(), signal);
-}
+  }
 
-void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::action_b(Signal signal) {
+  void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
+    action_b(Signal signal)
+  {
     this->m_component.FppTest_SmChoiceQueued_Basic_action_b(this->getId(), signal);
-}
+  }
 
-bool SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::guard_g(Signal signal) const {
+  bool SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmChoiceQueued_Basic_guard_g(this->getId(), signal);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
 
-void SmChoiceQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+  void SmChoiceQueuedComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::QueuedComponentBase::init(instance);
 
@@ -302,45 +447,67 @@ void SmChoiceQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType i
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port schedIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts()); port++) {
-        this->m_schedIn_InputPort[port].init();
-        this->m_schedIn_InputPort[port].addCallComp(this, m_p_schedIn_in);
-        this->m_schedIn_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts());
+      port++
+    ) {
+      this->m_schedIn_InputPort[port].init();
+      this->m_schedIn_InputPort[port].addCallComp(
+        this,
+        m_p_schedIn_in
+      );
+      this->m_schedIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_schedIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_schedIn_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_schedIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Getters for typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Getters for typed input ports
+  // ----------------------------------------------------------------------
 
-Svc::InputSchedPort* SmChoiceQueuedComponentBase ::get_schedIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+  Svc::InputSchedPort* SmChoiceQueuedComponentBase ::
+    get_schedIn_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_schedIn_InputPort[portNum];
-}
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-SmChoiceQueuedComponentBase ::SmChoiceQueuedComponentBase(const char* compName)
-    : Fw::QueuedComponentBase(compName),
+  SmChoiceQueuedComponentBase ::
+    SmChoiceQueuedComponentBase(const char* compName) :
+      Fw::QueuedComponentBase(compName),
       m_stateMachine_basic(*this),
       m_stateMachine_smChoiceBasic(*this),
       m_stateMachine_smChoiceBasicU32(*this),
@@ -348,175 +515,223 @@ SmChoiceQueuedComponentBase ::SmChoiceQueuedComponentBase(const char* compName)
       m_stateMachine_smChoiceChoiceToState(*this),
       m_stateMachine_smChoiceInputPairU16U32(*this),
       m_stateMachine_smChoiceSequence(*this),
-      m_stateMachine_smChoiceSequenceU32(*this) {}
+      m_stateMachine_smChoiceSequenceU32(*this)
+  {
 
-SmChoiceQueuedComponentBase ::~SmChoiceQueuedComponentBase() {}
+  }
 
-// ----------------------------------------------------------------------
-// Port handler base-class functions for typed input ports
-//
-// Call these functions directly to bypass the corresponding ports
-// ----------------------------------------------------------------------
+  SmChoiceQueuedComponentBase ::
+    ~SmChoiceQueuedComponentBase()
+  {
 
-void SmChoiceQueuedComponentBase ::schedIn_handlerBase(FwIndexType portNum, U32 context) {
+  }
+
+  // ----------------------------------------------------------------------
+  // Port handler base-class functions for typed input ports
+  //
+  // Call these functions directly to bypass the corresponding ports
+  // ----------------------------------------------------------------------
+
+  void SmChoiceQueuedComponentBase ::
+    schedIn_handlerBase(
+        FwIndexType portNum,
+        U32 context
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call handler function
-    this->schedIn_handler(portNum, context);
-}
+    this->schedIn_handler(
+      portNum,
+      context
+    );
+  }
 
-// ----------------------------------------------------------------------
-// State getter functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // State getter functions
+  // ----------------------------------------------------------------------
 
-SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic::State SmChoiceQueuedComponentBase ::basic_getState() const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic::State SmChoiceQueuedComponentBase ::
+    basic_getState() const
+  {
     return this->m_stateMachine_basic.getState();
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic::State SmChoiceQueuedComponentBase ::smChoiceBasic_getState()
-    const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic::State SmChoiceQueuedComponentBase ::
+    smChoiceBasic_getState() const
+  {
     return this->m_stateMachine_smChoiceBasic.getState();
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceQueuedComponentBase ::smChoiceBasicU32_getState()
-    const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceQueuedComponentBase ::
+    smChoiceBasicU32_getState() const
+  {
     return this->m_stateMachine_smChoiceBasicU32.getState();
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice::State
-SmChoiceQueuedComponentBase ::smChoiceChoiceToChoice_getState() const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice::State SmChoiceQueuedComponentBase ::
+    smChoiceChoiceToChoice_getState() const
+  {
     return this->m_stateMachine_smChoiceChoiceToChoice.getState();
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState::State
-SmChoiceQueuedComponentBase ::smChoiceChoiceToState_getState() const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState::State SmChoiceQueuedComponentBase ::
+    smChoiceChoiceToState_getState() const
+  {
     return this->m_stateMachine_smChoiceChoiceToState.getState();
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32::State
-SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_getState() const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32::State SmChoiceQueuedComponentBase ::
+    smChoiceInputPairU16U32_getState() const
+  {
     return this->m_stateMachine_smChoiceInputPairU16U32.getState();
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence::State SmChoiceQueuedComponentBase ::smChoiceSequence_getState()
-    const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence::State SmChoiceQueuedComponentBase ::
+    smChoiceSequence_getState() const
+  {
     return this->m_stateMachine_smChoiceSequence.getState();
-}
+  }
 
-SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32::State
-SmChoiceQueuedComponentBase ::smChoiceSequenceU32_getState() const {
+  SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32::State SmChoiceQueuedComponentBase ::
+    smChoiceSequenceU32_getState() const
+  {
     return this->m_stateMachine_smChoiceSequenceU32.getState();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Signal send functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Signal send functions
+  // ----------------------------------------------------------------------
 
-void SmChoiceQueuedComponentBase ::basic_sendSignal_s() {
+  void SmChoiceQueuedComponentBase ::
+    basic_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic, static_cast<FwEnumStoreType>(FppTest_SmChoiceQueued_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceBasic_sendSignal_s() {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceBasic_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceBasic, static_cast<FwEnumStoreType>(FppTest_SmChoice_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceBasic_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceBasicU32_sendSignal_s(U32 value) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceBasicU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceBasicU32_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceChoiceToChoice_sendSignal_s() {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceChoiceToChoice_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToChoice, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceChoiceToState_sendSignal_s() {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceChoiceToState_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToState, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToState_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_sendSignal_s1(U16 value) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceInputPairU16U32_sendSignal_s1(U16 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_sendSignal_s2(U32 value) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceInputPairU16U32_sendSignal_s2(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceSequence_sendSignal_s() {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceSequence_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceSequence_sendSignalFinish(buffer);
-}
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceSequenceU32_sendSignal_s(U32 value) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceSequenceU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequenceU32,
-                          static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceSequenceU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceSequenceU32_sendSignalFinish(buffer);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::NONBLOCKING,
+      _priority
+    );
     if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+      return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    }
+    else {
+      FW_ASSERT(
+        _msgStatus == Os::Queue::OP_OK,
+        static_cast<FwAssertArgType>(_msgStatus)
+      );
     }
 
     // Reset to beginning of buffer
@@ -524,171 +739,237 @@ Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::doDispa
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMCHOICEQUEUED_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle signals to internal state machines
-        case INTERNAL_STATE_MACHINE_SIGNAL:
-            this->smDispatch(_msg);
-            break;
 
-        default:
-            return MSG_DISPATCH_ERROR;
+      // Handle signals to internal state machines
+      case INTERNAL_STATE_MACHINE_SIGNAL:
+        this->smDispatch(_msg);
+        break;
+
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for dispatching current messages
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for dispatching current messages
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::dispatchCurrentMessages() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::
+    dispatchCurrentMessages()
+  {
     // Dispatch all current messages unless ERROR or EXIT occur
     const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
     MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
     for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+      messageStatus = this->doDispatch();
+      if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+        break;
+      }
     }
     return messageStatus;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Calls for messages received on typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Calls for messages received on typed input ports
+  // ----------------------------------------------------------------------
 
-void SmChoiceQueuedComponentBase ::m_p_schedIn_in(Fw::PassiveComponentBase* callComp,
-                                                  FwIndexType portNum,
-                                                  U32 context) {
+  void SmChoiceQueuedComponentBase ::
+    m_p_schedIn_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 context
+    )
+  {
     FW_ASSERT(callComp);
     SmChoiceQueuedComponentBase* compPtr = static_cast<SmChoiceQueuedComponentBase*>(callComp);
-    compPtr->schedIn_handlerBase(portNum, context);
-}
+    compPtr->schedIn_handlerBase(
+      portNum,
+      context
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Send signal helper functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Send signal helper functions
+  // ----------------------------------------------------------------------
 
-void SmChoiceQueuedComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    sendSignalStart(
+        SmId smId,
+        FwEnumStoreType signal,
+        Fw::SerialBufferBase& buffer
+    )
+  {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmChoiceQueuedComponentBase ::basic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    basic_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        // Deserialize the state machine ID and signal
-        FwEnumStoreType smId;
-        FwEnumStoreType signal;
-        SmChoiceQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Call the overflow hook
-        this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+      // Deserialize the state machine ID and signal
+      FwEnumStoreType smId;
+      FwEnumStoreType signal;
+      SmChoiceQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Continue execution
-        return;
+      // Call the overflow hook
+      this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+
+      // Continue execution
+      return;
+
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmChoiceQueuedComponentBase ::smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for state machine dispatch
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for state machine dispatch
+  // ----------------------------------------------------------------------
 
-void SmChoiceQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
+  void SmChoiceQueuedComponentBase ::
+    smDispatch(Fw::SerialBufferBase& buffer)
+  {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -697,66 +978,62 @@ void SmChoiceQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-        case SmId::basic: {
-            const FppTest_SmChoiceQueued_Basic::Signal signal =
-                static_cast<FppTest_SmChoiceQueued_Basic::Signal>(storedSignal);
-            this->FppTest_SmChoiceQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
-            break;
-        }
-        case SmId::smChoiceBasic: {
-            const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
-            this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
-            break;
-        }
-        case SmId::smChoiceBasicU32: {
-            const FppTest_SmChoice_BasicU32::Signal signal =
-                static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
-            this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
-            break;
-        }
-        case SmId::smChoiceChoiceToChoice: {
-            const FppTest_SmChoice_ChoiceToChoice::Signal signal =
-                static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
-            this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice,
-                                                             signal);
-            break;
-        }
-        case SmId::smChoiceChoiceToState: {
-            const FppTest_SmChoice_ChoiceToState::Signal signal =
-                static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
-            this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
-            break;
-        }
-        case SmId::smChoiceInputPairU16U32: {
-            const FppTest_SmChoice_InputPairU16U32::Signal signal =
-                static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
-            this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32,
-                                                              signal);
-            break;
-        }
-        case SmId::smChoiceSequence: {
-            const FppTest_SmChoice_Sequence::Signal signal =
-                static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
-            this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
-            break;
-        }
-        case SmId::smChoiceSequenceU32: {
-            const FppTest_SmChoice_SequenceU32::Signal signal =
-                static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
-            this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-            break;
+      case SmId::basic: {
+        const FppTest_SmChoiceQueued_Basic::Signal signal = static_cast<FppTest_SmChoiceQueued_Basic::Signal>(storedSignal);
+        this->FppTest_SmChoiceQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
+        break;
+      }
+      case SmId::smChoiceBasic: {
+        const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
+        this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
+        break;
+      }
+      case SmId::smChoiceBasicU32: {
+        const FppTest_SmChoice_BasicU32::Signal signal = static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
+        this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
+        break;
+      }
+      case SmId::smChoiceChoiceToChoice: {
+        const FppTest_SmChoice_ChoiceToChoice::Signal signal = static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
+        this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice, signal);
+        break;
+      }
+      case SmId::smChoiceChoiceToState: {
+        const FppTest_SmChoice_ChoiceToState::Signal signal = static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
+        this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
+        break;
+      }
+      case SmId::smChoiceInputPairU16U32: {
+        const FppTest_SmChoice_InputPairU16U32::Signal signal = static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
+        this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32, signal);
+        break;
+      }
+      case SmId::smChoiceSequence: {
+        const FppTest_SmChoice_Sequence::Signal signal = static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
+        this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
+        break;
+      }
+      case SmId::smChoiceSequenceU32: {
+        const FppTest_SmChoice_SequenceU32::Signal signal = static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
+        this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
-                                                            FwEnumStoreType& smId,
-                                                            FwEnumStoreType& signal) {
+  void SmChoiceQueuedComponentBase ::
+    deserializeSmIdAndSignal(
+        Fw::SerialBufferBase& buffer,
+        FwEnumStoreType& smId,
+        FwEnumStoreType& signal
+    )
+  {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status =
+      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -766,179 +1043,197 @@ void SmChoiceQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoice_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                     FppTest_SmChoice_Basic& sm,
-                                                                     FppTest_SmChoice_Basic::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoice_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_Basic& sm,
+        FppTest_SmChoice_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoice_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmChoice_BasicU32& sm,
-                                                                        FppTest_SmChoice_BasicU32::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoice_BasicU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_BasicU32& sm,
+        FppTest_SmChoice_BasicU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_BasicU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_BasicU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoice_ChoiceToChoice_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_ChoiceToChoice& sm,
-    FppTest_SmChoice_ChoiceToChoice::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoice_ChoiceToChoice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_ChoiceToChoice& sm,
+        FppTest_SmChoice_ChoiceToChoice::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoice_ChoiceToState_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_ChoiceToState& sm,
-    FppTest_SmChoice_ChoiceToState::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoice_ChoiceToState_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_ChoiceToState& sm,
+        FppTest_SmChoice_ChoiceToState::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_ChoiceToState::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_ChoiceToState::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoice_InputPairU16U32_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_InputPairU16U32& sm,
-    FppTest_SmChoice_InputPairU16U32::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoice_InputPairU16U32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_InputPairU16U32& sm,
+        FppTest_SmChoice_InputPairU16U32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
-            // Deserialize the data
-            U16 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s1
-            sm.sendSignal_s1(value);
-            break;
-        }
-        case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s2
-            sm.sendSignal_s2(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
+        // Deserialize the data
+        U16 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s1
+        sm.sendSignal_s1(value);
+        break;
+      }
+      case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s2
+        sm.sendSignal_s2(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoice_Sequence_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmChoice_Sequence& sm,
-                                                                        FppTest_SmChoice_Sequence::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoice_Sequence_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_Sequence& sm,
+        FppTest_SmChoice_Sequence::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_Sequence::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_Sequence::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoice_SequenceU32_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoice_SequenceU32& sm,
-    FppTest_SmChoice_SequenceU32::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoice_SequenceU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoice_SequenceU32& sm,
+        FppTest_SmChoice_SequenceU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoice_SequenceU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoice_SequenceU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmChoiceQueuedComponentBase ::FppTest_SmChoiceQueued_Basic_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmChoiceQueued_Basic& sm,
-    FppTest_SmChoiceQueued_Basic::Signal signal) {
+  void SmChoiceQueuedComponentBase ::
+    FppTest_SmChoiceQueued_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmChoiceQueued_Basic& sm,
+        FppTest_SmChoiceQueued_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmChoiceQueued_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmChoiceQueued_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-}  // namespace FppTest
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
@@ -13,432 +13,280 @@
 
 namespace FppTest {
 
-  namespace {
+namespace {
 
-    // Constant definitions for the state machine signal buffer
-    namespace SmSignalBuffer {
+// Constant definitions for the state machine signal buffer
+namespace SmSignalBuffer {
 
-      // Union for computing the max size of a signal type
-      union SignalTypeUnion {
-        BYTE size_of_U16[sizeof(U16)];
-        BYTE size_of_U32[sizeof(U32)];
-      };
+// Union for computing the max size of a signal type
+union SignalTypeUnion {
+    BYTE size_of_U16[sizeof(U16)];
+    BYTE size_of_U32[sizeof(U32)];
+};
 
-      // The serialized size
-      static constexpr FwSizeType SERIALIZED_SIZE =
-        2 * sizeof(FwEnumStoreType) +
-        sizeof(SignalTypeUnion);
+// The serialized size
+static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
 
+}  // namespace SmSignalBuffer
+
+enum MsgTypeEnum {
+    SMCHOICEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    INTERNAL_STATE_MACHINE_SIGNAL,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    // Size of buffer for internal state machine signals
+    // The internal SmSignalBuffer stores the state machine id, the
+    // signal id, and the signal data
+    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+    };
+
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
     }
 
-    enum MsgTypeEnum {
-      SMCHOICEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      INTERNAL_STATE_MACHINE_SIGNAL,
-    };
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      // Size of buffer for internal state machine signals
-      // The internal SmSignalBuffer stores the state machine id, the
-      // signal id, and the signal data
-      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-    };
+// ----------------------------------------------------------------------
+// Types for internal state machines
+// ----------------------------------------------------------------------
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::FppTest_SmChoice_Basic(SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-      public:
-
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
-
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
-
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Types for internal state machines
-  // ----------------------------------------------------------------------
-
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
-    FppTest_SmChoice_Basic(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
-
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
-    action_a(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
-    action_b(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_Basic_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::
-    guard_g(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmChoice_Basic_guard_g(this->getId(), signal);
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
-    FppTest_SmChoice_BasicU32(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::FppTest_SmChoice_BasicU32(
+    SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmChoice_BasicU32_action_a(this->getId(), signal, value);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
-    action_b(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_BasicU32_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::
-    guard_g(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32 ::guard_g(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmChoice_BasicU32_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    FppTest_SmChoice_ChoiceToChoice(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::FppTest_SmChoice_ChoiceToChoice(
+    SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    action_exitS1(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    action_a(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    action_enterS2(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToChoice_action_enterS2(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    guard_g1(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g1(Signal signal) const {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g1(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::
-    guard_g2(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice ::guard_g2(Signal signal) const {
     return this->m_component.FppTest_SmChoice_ChoiceToChoice_guard_g2(this->getId(), signal);
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    FppTest_SmChoice_ChoiceToState(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::FppTest_SmChoice_ChoiceToState(
+    SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_exitS1(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_a(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_enterS2(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    action_enterS3(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmChoice_ChoiceToState_action_enterS3(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::
-    guard_g(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmChoice_ChoiceToState_guard_g(this->getId(), signal);
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    FppTest_SmChoice_InputPairU16U32(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::FppTest_SmChoice_InputPairU16U32(
+    SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmChoice_InputPairU16U32_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::
-    guard_g(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32 ::guard_g(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmChoice_InputPairU16U32_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
-    FppTest_SmChoice_Sequence(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::FppTest_SmChoice_Sequence(
+    SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
-    action_a(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoice_Sequence_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
-    action_b(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_Sequence_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
-    guard_g1(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::guard_g1(Signal signal) const {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g1(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::
-    guard_g2(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence ::guard_g2(Signal signal) const {
     return this->m_component.FppTest_SmChoice_Sequence_guard_g2(this->getId(), signal);
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
-    FppTest_SmChoice_SequenceU32(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::FppTest_SmChoice_SequenceU32(
+    SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmChoice_SequenceU32_action_a(this->getId(), signal, value);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
-    action_b(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoice_SequenceU32_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
-    guard_g1(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g1(Signal signal) const {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g1(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::
-    guard_g2(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32 ::guard_g2(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmChoice_SequenceU32_guard_g2(this->getId(), signal, value);
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
-    FppTest_SmChoiceQueued_Basic(SmChoiceQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::FppTest_SmChoiceQueued_Basic(
+    SmChoiceQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
-    init(SmChoiceQueuedComponentBase::SmId smId)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::init(SmChoiceQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
-    getId() const
-  {
+SmChoiceQueuedComponentBase::SmId SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::getId() const {
     return static_cast<SmChoiceQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
-    action_a(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmChoiceQueued_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
-    action_b(Signal signal)
-  {
+void SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::action_b(Signal signal) {
     this->m_component.FppTest_SmChoiceQueued_Basic_action_b(this->getId(), signal);
-  }
+}
 
-  bool SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::
-    guard_g(Signal signal) const
-  {
+bool SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmChoiceQueued_Basic_guard_g(this->getId(), signal);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
 
-  void SmChoiceQueuedComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+void SmChoiceQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::QueuedComponentBase::init(instance);
 
@@ -454,67 +302,45 @@ namespace FppTest {
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port schedIn
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts());
-      port++
-    ) {
-      this->m_schedIn_InputPort[port].init();
-      this->m_schedIn_InputPort[port].addCallComp(
-        this,
-        m_p_schedIn_in
-      );
-      this->m_schedIn_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts()); port++) {
+        this->m_schedIn_InputPort[port].init();
+        this->m_schedIn_InputPort[port].addCallComp(this, m_p_schedIn_in);
+        this->m_schedIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_schedIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_schedIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_schedIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Getters for typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Getters for typed input ports
+// ----------------------------------------------------------------------
 
-  Svc::InputSchedPort* SmChoiceQueuedComponentBase ::
-    get_schedIn_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Svc::InputSchedPort* SmChoiceQueuedComponentBase ::get_schedIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return &this->m_schedIn_InputPort[portNum];
-  }
+}
 
 #endif
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  SmChoiceQueuedComponentBase ::
-    SmChoiceQueuedComponentBase(const char* compName) :
-      Fw::QueuedComponentBase(compName),
+SmChoiceQueuedComponentBase ::SmChoiceQueuedComponentBase(const char* compName)
+    : Fw::QueuedComponentBase(compName),
       m_stateMachine_basic(*this),
       m_stateMachine_smChoiceBasic(*this),
       m_stateMachine_smChoiceBasicU32(*this),
@@ -522,223 +348,175 @@ namespace FppTest {
       m_stateMachine_smChoiceChoiceToState(*this),
       m_stateMachine_smChoiceInputPairU16U32(*this),
       m_stateMachine_smChoiceSequence(*this),
-      m_stateMachine_smChoiceSequenceU32(*this)
-  {
+      m_stateMachine_smChoiceSequenceU32(*this) {}
 
-  }
+SmChoiceQueuedComponentBase ::~SmChoiceQueuedComponentBase() {}
 
-  SmChoiceQueuedComponentBase ::
-    ~SmChoiceQueuedComponentBase()
-  {
+// ----------------------------------------------------------------------
+// Port handler base-class functions for typed input ports
+//
+// Call these functions directly to bypass the corresponding ports
+// ----------------------------------------------------------------------
 
-  }
-
-  // ----------------------------------------------------------------------
-  // Port handler base-class functions for typed input ports
-  //
-  // Call these functions directly to bypass the corresponding ports
-  // ----------------------------------------------------------------------
-
-  void SmChoiceQueuedComponentBase ::
-    schedIn_handlerBase(
-        FwIndexType portNum,
-        U32 context
-    )
-  {
+void SmChoiceQueuedComponentBase ::schedIn_handlerBase(FwIndexType portNum, U32 context) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     // Call handler function
-    this->schedIn_handler(
-      portNum,
-      context
-    );
-  }
+    this->schedIn_handler(portNum, context);
+}
 
-  // ----------------------------------------------------------------------
-  // State getter functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// State getter functions
+// ----------------------------------------------------------------------
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic::State SmChoiceQueuedComponentBase ::
-    basic_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoiceQueued_Basic::State SmChoiceQueuedComponentBase ::basic_getState() const {
     return this->m_stateMachine_basic.getState();
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic::State SmChoiceQueuedComponentBase ::
-    smChoiceBasic_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_Basic::State SmChoiceQueuedComponentBase ::smChoiceBasic_getState()
+    const {
     return this->m_stateMachine_smChoiceBasic.getState();
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceQueuedComponentBase ::
-    smChoiceBasicU32_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_BasicU32::State SmChoiceQueuedComponentBase ::smChoiceBasicU32_getState()
+    const {
     return this->m_stateMachine_smChoiceBasicU32.getState();
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice::State SmChoiceQueuedComponentBase ::
-    smChoiceChoiceToChoice_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToChoice::State
+SmChoiceQueuedComponentBase ::smChoiceChoiceToChoice_getState() const {
     return this->m_stateMachine_smChoiceChoiceToChoice.getState();
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState::State SmChoiceQueuedComponentBase ::
-    smChoiceChoiceToState_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_ChoiceToState::State
+SmChoiceQueuedComponentBase ::smChoiceChoiceToState_getState() const {
     return this->m_stateMachine_smChoiceChoiceToState.getState();
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32::State SmChoiceQueuedComponentBase ::
-    smChoiceInputPairU16U32_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_InputPairU16U32::State
+SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_getState() const {
     return this->m_stateMachine_smChoiceInputPairU16U32.getState();
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence::State SmChoiceQueuedComponentBase ::
-    smChoiceSequence_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_Sequence::State SmChoiceQueuedComponentBase ::smChoiceSequence_getState()
+    const {
     return this->m_stateMachine_smChoiceSequence.getState();
-  }
+}
 
-  SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32::State SmChoiceQueuedComponentBase ::
-    smChoiceSequenceU32_getState() const
-  {
+SmChoiceQueuedComponentBase::FppTest_SmChoice_SequenceU32::State
+SmChoiceQueuedComponentBase ::smChoiceSequenceU32_getState() const {
     return this->m_stateMachine_smChoiceSequenceU32.getState();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Signal send functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Signal send functions
+// ----------------------------------------------------------------------
 
-  void SmChoiceQueuedComponentBase ::
-    basic_sendSignal_s()
-  {
+void SmChoiceQueuedComponentBase ::basic_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic, static_cast<FwEnumStoreType>(FppTest_SmChoiceQueued_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceBasic_sendSignal_s()
-  {
+void SmChoiceQueuedComponentBase ::smChoiceBasic_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceBasic, static_cast<FwEnumStoreType>(FppTest_SmChoice_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceBasic_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceBasicU32_sendSignal_s(U32 value)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceBasicU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s),
+                          buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceBasicU32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceChoiceToChoice_sendSignal_s()
-  {
+void SmChoiceQueuedComponentBase ::smChoiceChoiceToChoice_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToChoice, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToChoice::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceChoiceToState_sendSignal_s()
-  {
+void SmChoiceQueuedComponentBase ::smChoiceChoiceToState_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceChoiceToState, static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceChoiceToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_ChoiceToState::Signal::s), buffer);
     // Send the message and handle overflow
     this->smChoiceChoiceToState_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceInputPairU16U32_sendSignal_s1(U16 value)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_sendSignal_s1(U16 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceInputPairU16U32_sendSignal_s2(U32 value)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_sendSignal_s2(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
+    this->sendSignalStart(SmId::smChoiceInputPairU16U32,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceSequence_sendSignal_s()
-  {
+void SmChoiceQueuedComponentBase ::smChoiceSequence_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceSequence, static_cast<FwEnumStoreType>(FppTest_SmChoice_Sequence::Signal::s),
+                          buffer);
     // Send the message and handle overflow
     this->smChoiceSequence_sendSignalFinish(buffer);
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceSequenceU32_sendSignal_s(U32 value)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceSequenceU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smChoiceSequenceU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smChoiceSequenceU32,
+                          static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceSequenceU32_sendSignalFinish(buffer);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::NONBLOCKING,
-      _priority
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
     if (Os::Queue::Status::EMPTY == _msgStatus) {
-      return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    }
-    else {
-      FW_ASSERT(
-        _msgStatus == Os::Queue::OP_OK,
-        static_cast<FwAssertArgType>(_msgStatus)
-      );
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
     // Reset to beginning of buffer
@@ -746,237 +524,171 @@ namespace FppTest {
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMCHOICEQUEUED_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
+        // Handle signals to internal state machines
+        case INTERNAL_STATE_MACHINE_SIGNAL:
+            this->smDispatch(_msg);
+            break;
 
-      // Handle signals to internal state machines
-      case INTERNAL_STATE_MACHINE_SIGNAL:
-        this->smDispatch(_msg);
-        break;
-
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for dispatching current messages
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for dispatching current messages
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::
-    dispatchCurrentMessages()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmChoiceQueuedComponentBase ::dispatchCurrentMessages() {
     // Dispatch all current messages unless ERROR or EXIT occur
     const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
     MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
     for (FwSizeType i = 0; i < currentMessageCount; i++) {
-      messageStatus = this->doDispatch();
-      if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-        break;
-      }
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
     return messageStatus;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Calls for messages received on typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Calls for messages received on typed input ports
+// ----------------------------------------------------------------------
 
-  void SmChoiceQueuedComponentBase ::
-    m_p_schedIn_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 context
-    )
-  {
+void SmChoiceQueuedComponentBase ::m_p_schedIn_in(Fw::PassiveComponentBase* callComp,
+                                                  FwIndexType portNum,
+                                                  U32 context) {
     FW_ASSERT(callComp);
     SmChoiceQueuedComponentBase* compPtr = static_cast<SmChoiceQueuedComponentBase*>(callComp);
-    compPtr->schedIn_handlerBase(
-      portNum,
-      context
-    );
-  }
+    compPtr->schedIn_handlerBase(portNum, context);
+}
 
-  // ----------------------------------------------------------------------
-  // Send signal helper functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Send signal helper functions
+// ----------------------------------------------------------------------
 
-  void SmChoiceQueuedComponentBase ::
-    sendSignalStart(
-        SmId smId,
-        FwEnumStoreType signal,
-        Fw::SerialBufferBase& buffer
-    )
-  {
+void SmChoiceQueuedComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    basic_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::basic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceBasic_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceChoiceToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
+        // Deserialize the state machine ID and signal
+        FwEnumStoreType smId;
+        FwEnumStoreType signal;
+        SmChoiceQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-      // Deserialize the state machine ID and signal
-      FwEnumStoreType smId;
-      FwEnumStoreType signal;
-      SmChoiceQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
+        // Call the overflow hook
+        this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
 
-      // Call the overflow hook
-      this->smChoiceChoiceToChoice_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
-
-      // Continue execution
-      return;
-
+        // Continue execution
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceChoiceToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceInputPairU16U32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceSequence_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmChoiceQueuedComponentBase ::
-    smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smChoiceSequenceU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for state machine dispatch
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for state machine dispatch
+// ----------------------------------------------------------------------
 
-  void SmChoiceQueuedComponentBase ::
-    smDispatch(Fw::SerialBufferBase& buffer)
-  {
+void SmChoiceQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -985,62 +697,66 @@ namespace FppTest {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-      case SmId::basic: {
-        const FppTest_SmChoiceQueued_Basic::Signal signal = static_cast<FppTest_SmChoiceQueued_Basic::Signal>(storedSignal);
-        this->FppTest_SmChoiceQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
-        break;
-      }
-      case SmId::smChoiceBasic: {
-        const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
-        this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
-        break;
-      }
-      case SmId::smChoiceBasicU32: {
-        const FppTest_SmChoice_BasicU32::Signal signal = static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
-        this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
-        break;
-      }
-      case SmId::smChoiceChoiceToChoice: {
-        const FppTest_SmChoice_ChoiceToChoice::Signal signal = static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
-        this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice, signal);
-        break;
-      }
-      case SmId::smChoiceChoiceToState: {
-        const FppTest_SmChoice_ChoiceToState::Signal signal = static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
-        this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
-        break;
-      }
-      case SmId::smChoiceInputPairU16U32: {
-        const FppTest_SmChoice_InputPairU16U32::Signal signal = static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
-        this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32, signal);
-        break;
-      }
-      case SmId::smChoiceSequence: {
-        const FppTest_SmChoice_Sequence::Signal signal = static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
-        this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
-        break;
-      }
-      case SmId::smChoiceSequenceU32: {
-        const FppTest_SmChoice_SequenceU32::Signal signal = static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
-        this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-        break;
+        case SmId::basic: {
+            const FppTest_SmChoiceQueued_Basic::Signal signal =
+                static_cast<FppTest_SmChoiceQueued_Basic::Signal>(storedSignal);
+            this->FppTest_SmChoiceQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic, signal);
+            break;
+        }
+        case SmId::smChoiceBasic: {
+            const FppTest_SmChoice_Basic::Signal signal = static_cast<FppTest_SmChoice_Basic::Signal>(storedSignal);
+            this->FppTest_SmChoice_Basic_smDispatch(buffer, this->m_stateMachine_smChoiceBasic, signal);
+            break;
+        }
+        case SmId::smChoiceBasicU32: {
+            const FppTest_SmChoice_BasicU32::Signal signal =
+                static_cast<FppTest_SmChoice_BasicU32::Signal>(storedSignal);
+            this->FppTest_SmChoice_BasicU32_smDispatch(buffer, this->m_stateMachine_smChoiceBasicU32, signal);
+            break;
+        }
+        case SmId::smChoiceChoiceToChoice: {
+            const FppTest_SmChoice_ChoiceToChoice::Signal signal =
+                static_cast<FppTest_SmChoice_ChoiceToChoice::Signal>(storedSignal);
+            this->FppTest_SmChoice_ChoiceToChoice_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToChoice,
+                                                             signal);
+            break;
+        }
+        case SmId::smChoiceChoiceToState: {
+            const FppTest_SmChoice_ChoiceToState::Signal signal =
+                static_cast<FppTest_SmChoice_ChoiceToState::Signal>(storedSignal);
+            this->FppTest_SmChoice_ChoiceToState_smDispatch(buffer, this->m_stateMachine_smChoiceChoiceToState, signal);
+            break;
+        }
+        case SmId::smChoiceInputPairU16U32: {
+            const FppTest_SmChoice_InputPairU16U32::Signal signal =
+                static_cast<FppTest_SmChoice_InputPairU16U32::Signal>(storedSignal);
+            this->FppTest_SmChoice_InputPairU16U32_smDispatch(buffer, this->m_stateMachine_smChoiceInputPairU16U32,
+                                                              signal);
+            break;
+        }
+        case SmId::smChoiceSequence: {
+            const FppTest_SmChoice_Sequence::Signal signal =
+                static_cast<FppTest_SmChoice_Sequence::Signal>(storedSignal);
+            this->FppTest_SmChoice_Sequence_smDispatch(buffer, this->m_stateMachine_smChoiceSequence, signal);
+            break;
+        }
+        case SmId::smChoiceSequenceU32: {
+            const FppTest_SmChoice_SequenceU32::Signal signal =
+                static_cast<FppTest_SmChoice_SequenceU32::Signal>(storedSignal);
+            this->FppTest_SmChoice_SequenceU32_smDispatch(buffer, this->m_stateMachine_smChoiceSequenceU32, signal);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+            break;
     }
-  }
+}
 
-  void SmChoiceQueuedComponentBase ::
-    deserializeSmIdAndSignal(
-        Fw::SerialBufferBase& buffer,
-        FwEnumStoreType& smId,
-        FwEnumStoreType& signal
-    )
-  {
+void SmChoiceQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
+                                                            FwEnumStoreType& smId,
+                                                            FwEnumStoreType& signal) {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status =
-      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -1050,197 +766,179 @@ namespace FppTest {
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoice_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_Basic& sm,
-        FppTest_SmChoice_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoice_BasicU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_BasicU32& sm,
-        FppTest_SmChoice_BasicU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_BasicU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoice_ChoiceToChoice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_ChoiceToChoice& sm,
-        FppTest_SmChoice_ChoiceToChoice::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoice_ChoiceToState_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_ChoiceToState& sm,
-        FppTest_SmChoice_ChoiceToState::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_ChoiceToState::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoice_InputPairU16U32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_InputPairU16U32& sm,
-        FppTest_SmChoice_InputPairU16U32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
-        // Deserialize the data
-        U16 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s1
-        sm.sendSignal_s1(value);
-        break;
-      }
-      case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s2
-        sm.sendSignal_s2(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoice_Sequence_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_Sequence& sm,
-        FppTest_SmChoice_Sequence::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_Sequence::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoice_SequenceU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoice_SequenceU32& sm,
-        FppTest_SmChoice_SequenceU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoice_SequenceU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmChoiceQueuedComponentBase ::
-    FppTest_SmChoiceQueued_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmChoiceQueued_Basic& sm,
-        FppTest_SmChoiceQueued_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmChoiceQueued_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
 }
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoice_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                     FppTest_SmChoice_Basic& sm,
+                                                                     FppTest_SmChoice_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoice_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmChoice_BasicU32& sm,
+                                                                        FppTest_SmChoice_BasicU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_BasicU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoice_ChoiceToChoice_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_ChoiceToChoice& sm,
+    FppTest_SmChoice_ChoiceToChoice::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_ChoiceToChoice::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoice_ChoiceToState_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_ChoiceToState& sm,
+    FppTest_SmChoice_ChoiceToState::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_ChoiceToState::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoice_InputPairU16U32_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_InputPairU16U32& sm,
+    FppTest_SmChoice_InputPairU16U32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
+            // Deserialize the data
+            U16 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s1
+            sm.sendSignal_s1(value);
+            break;
+        }
+        case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s2
+            sm.sendSignal_s2(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoice_Sequence_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmChoice_Sequence& sm,
+                                                                        FppTest_SmChoice_Sequence::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_Sequence::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoice_SequenceU32_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoice_SequenceU32& sm,
+    FppTest_SmChoice_SequenceU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoice_SequenceU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmChoiceQueuedComponentBase ::FppTest_SmChoiceQueued_Basic_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmChoiceQueued_Basic& sm,
+    FppTest_SmChoiceQueued_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmChoiceQueued_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+}  // namespace FppTest

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
@@ -62,9 +62,8 @@ namespace FppTest {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
@@ -55,9 +55,8 @@ namespace FppTest {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
@@ -13,166 +13,236 @@
 
 namespace FppTest {
 
-namespace {
+  namespace {
 
-// Constant definitions for the state machine signal buffer
-namespace SmSignalBuffer {
+    // Constant definitions for the state machine signal buffer
+    namespace SmSignalBuffer {
 
-// The serialized size
-static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType);
+      // The serialized size
+      static constexpr FwSizeType SERIALIZED_SIZE =
+        2 * sizeof(FwEnumStoreType);
 
-}  // namespace SmSignalBuffer
-
-enum MsgTypeEnum {
-    SMINITIALACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    INTERNAL_STATE_MACHINE_SIGNAL,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    // Size of buffer for internal state machine signals
-    // The internal SmSignalBuffer stores the state machine id, the
-    // signal id, and the signal data
-    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
-
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
     }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    enum MsgTypeEnum {
+      SMINITIALACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      INTERNAL_STATE_MACHINE_SIGNAL,
+    };
 
-// ----------------------------------------------------------------------
-// Types for internal state machines
-// ----------------------------------------------------------------------
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      // Size of buffer for internal state machine signals
+      // The internal SmSignalBuffer stores the state machine id, the
+      // signal id, and the signal data
+      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+    };
 
-SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::FppTest_SmInitial_Basic(SmInitialActiveComponentBase& component)
-    : m_component(component) {}
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::init(SmInitialActiveComponentBase::SmId smId) {
+      public:
+
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
+
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
+
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Types for internal state machines
+  // ----------------------------------------------------------------------
+
+  SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
+    FppTest_SmInitial_Basic(SmInitialActiveComponentBase& component) :
+      m_component(component)
+  {
+
+  }
+
+  void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
+    init(SmInitialActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::getId() const {
+  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
+    getId() const
+  {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::action_a(Signal signal) {
+  void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitial_Basic_action_a(this->getId(), signal);
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::FppTest_SmInitial_Choice(
-    SmInitialActiveComponentBase& component)
-    : m_component(component) {}
+  SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
+    FppTest_SmInitial_Choice(SmInitialActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::init(SmInitialActiveComponentBase::SmId smId) {
+  }
+
+  void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
+    init(SmInitialActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::getId() const {
+  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
+    getId() const
+  {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::action_a(Signal signal) {
+  void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitial_Choice_action_a(this->getId(), signal);
-}
+  }
 
-bool SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::guard_g(Signal signal) const {
+  bool SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmInitial_Choice_guard_g(this->getId(), signal);
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::FppTest_SmInitial_Nested(
-    SmInitialActiveComponentBase& component)
-    : m_component(component) {}
+  SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
+    FppTest_SmInitial_Nested(SmInitialActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::init(SmInitialActiveComponentBase::SmId smId) {
+  }
+
+  void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
+    init(SmInitialActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::getId() const {
+  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
+    getId() const
+  {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::action_a(Signal signal) {
+  void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitial_Nested_action_a(this->getId(), signal);
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::FppTest_SmInitialActive_Basic(
-    SmInitialActiveComponentBase& component)
-    : m_component(component) {}
+  SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
+    FppTest_SmInitialActive_Basic(SmInitialActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::init(SmInitialActiveComponentBase::SmId smId) {
+  }
+
+  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
+    init(SmInitialActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::getId() const {
+  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
+    getId() const
+  {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::action_a(Signal signal) {
+  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitialActive_Basic_action_a(this->getId(), signal);
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::FppTest_SmInitialActive_Choice(
-    SmInitialActiveComponentBase& component)
-    : m_component(component) {}
+  SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
+    FppTest_SmInitialActive_Choice(SmInitialActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::init(SmInitialActiveComponentBase::SmId smId) {
+  }
+
+  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
+    init(SmInitialActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::getId() const {
+  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
+    getId() const
+  {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::action_a(Signal signal) {
+  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitialActive_Choice_action_a(this->getId(), signal);
-}
+  }
 
-bool SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::guard_g(Signal signal) const {
+  bool SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmInitialActive_Choice_guard_g(this->getId(), signal);
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::FppTest_SmInitialActive_Nested(
-    SmInitialActiveComponentBase& component)
-    : m_component(component) {}
+  SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
+    FppTest_SmInitialActive_Nested(SmInitialActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::init(SmInitialActiveComponentBase::SmId smId) {
+  }
+
+  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
+    init(SmInitialActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::getId() const {
+  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
+    getId() const
+  {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::action_a(Signal signal) {
+  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitialActive_Nested_action_a(this->getId(), signal);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
 
-void SmInitialActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+  void SmInitialActiveComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -187,17 +257,23 @@ void SmInitialActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType 
     this->m_stateMachine_smInitialNested.init(SmId::smInitialNested);
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-SmInitialActiveComponentBase ::SmInitialActiveComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName),
+  SmInitialActiveComponentBase ::
+    SmInitialActiveComponentBase(const char* compName) :
+      Fw::ActiveComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_choice(*this),
@@ -205,100 +281,133 @@ SmInitialActiveComponentBase ::SmInitialActiveComponentBase(const char* compName
       m_stateMachine_smInitialBasic1(*this),
       m_stateMachine_smInitialBasic2(*this),
       m_stateMachine_smInitialChoice(*this),
-      m_stateMachine_smInitialNested(*this) {}
+      m_stateMachine_smInitialNested(*this)
+  {
 
-SmInitialActiveComponentBase ::~SmInitialActiveComponentBase() {}
+  }
 
-// ----------------------------------------------------------------------
-// State getter functions
-// ----------------------------------------------------------------------
+  SmInitialActiveComponentBase ::
+    ~SmInitialActiveComponentBase()
+  {
 
-SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::basic1_getState()
-    const {
+  }
+
+  // ----------------------------------------------------------------------
+  // State getter functions
+  // ----------------------------------------------------------------------
+
+  SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::
+    basic1_getState() const
+  {
     return this->m_stateMachine_basic1.getState();
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::basic2_getState()
-    const {
+  SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::
+    basic2_getState() const
+  {
     return this->m_stateMachine_basic2.getState();
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice::State SmInitialActiveComponentBase ::choice_getState()
-    const {
+  SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice::State SmInitialActiveComponentBase ::
+    choice_getState() const
+  {
     return this->m_stateMachine_choice.getState();
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested::State SmInitialActiveComponentBase ::nested_getState()
-    const {
+  SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested::State SmInitialActiveComponentBase ::
+    nested_getState() const
+  {
     return this->m_stateMachine_nested.getState();
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::smInitialBasic1_getState()
-    const {
+  SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::
+    smInitialBasic1_getState() const
+  {
     return this->m_stateMachine_smInitialBasic1.getState();
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::smInitialBasic2_getState()
-    const {
+  SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::
+    smInitialBasic2_getState() const
+  {
     return this->m_stateMachine_smInitialBasic2.getState();
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitial_Choice::State SmInitialActiveComponentBase ::smInitialChoice_getState()
-    const {
+  SmInitialActiveComponentBase::FppTest_SmInitial_Choice::State SmInitialActiveComponentBase ::
+    smInitialChoice_getState() const
+  {
     return this->m_stateMachine_smInitialChoice.getState();
-}
+  }
 
-SmInitialActiveComponentBase::FppTest_SmInitial_Nested::State SmInitialActiveComponentBase ::smInitialNested_getState()
-    const {
+  SmInitialActiveComponentBase::FppTest_SmInitial_Nested::State SmInitialActiveComponentBase ::
+    smInitialNested_getState() const
+  {
     return this->m_stateMachine_smInitialNested.getState();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmInitialActiveComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmInitialActiveComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::BLOCKING,
+      _priority
+    );
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMINITIALACTIVE_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle signals to internal state machines
-        case INTERNAL_STATE_MACHINE_SIGNAL:
-            this->smDispatch(_msg);
-            break;
 
-        default:
-            return MSG_DISPATCH_ERROR;
+      // Handle signals to internal state machines
+      case INTERNAL_STATE_MACHINE_SIGNAL:
+        this->smDispatch(_msg);
+        break;
+
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for state machine dispatch
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for state machine dispatch
+  // ----------------------------------------------------------------------
 
-void SmInitialActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
+  void SmInitialActiveComponentBase ::
+    smDispatch(Fw::SerialBufferBase& buffer)
+  {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -307,61 +416,62 @@ void SmInitialActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-        case SmId::basic1: {
-            const FppTest_SmInitialActive_Basic::Signal signal =
-                static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-            break;
-        }
-        case SmId::basic2: {
-            const FppTest_SmInitialActive_Basic::Signal signal =
-                static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-            break;
-        }
-        case SmId::choice: {
-            const FppTest_SmInitialActive_Choice::Signal signal =
-                static_cast<FppTest_SmInitialActive_Choice::Signal>(storedSignal);
-            this->FppTest_SmInitialActive_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
-            break;
-        }
-        case SmId::nested: {
-            const FppTest_SmInitialActive_Nested::Signal signal =
-                static_cast<FppTest_SmInitialActive_Nested::Signal>(storedSignal);
-            this->FppTest_SmInitialActive_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
-            break;
-        }
-        case SmId::smInitialBasic1: {
-            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
-            break;
-        }
-        case SmId::smInitialBasic2: {
-            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
-            break;
-        }
-        case SmId::smInitialChoice: {
-            const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
-            this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
-            break;
-        }
-        case SmId::smInitialNested: {
-            const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
-            this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-            break;
+      case SmId::basic1: {
+        const FppTest_SmInitialActive_Basic::Signal signal = static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+        break;
+      }
+      case SmId::basic2: {
+        const FppTest_SmInitialActive_Basic::Signal signal = static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+        break;
+      }
+      case SmId::choice: {
+        const FppTest_SmInitialActive_Choice::Signal signal = static_cast<FppTest_SmInitialActive_Choice::Signal>(storedSignal);
+        this->FppTest_SmInitialActive_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
+        break;
+      }
+      case SmId::nested: {
+        const FppTest_SmInitialActive_Nested::Signal signal = static_cast<FppTest_SmInitialActive_Nested::Signal>(storedSignal);
+        this->FppTest_SmInitialActive_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
+        break;
+      }
+      case SmId::smInitialBasic1: {
+        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
+        break;
+      }
+      case SmId::smInitialBasic2: {
+        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
+        break;
+      }
+      case SmId::smInitialChoice: {
+        const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
+        this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
+        break;
+      }
+      case SmId::smInitialNested: {
+        const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
+        this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        break;
     }
-}
+  }
 
-void SmInitialActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
-                                                             FwEnumStoreType& smId,
-                                                             FwEnumStoreType& signal) {
+  void SmInitialActiveComponentBase ::
+    deserializeSmIdAndSignal(
+        Fw::SerialBufferBase& buffer,
+        FwEnumStoreType& smId,
+        FwEnumStoreType& signal
+    )
+  {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status =
+      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -371,69 +481,90 @@ void SmInitialActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBas
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmInitialActiveComponentBase ::FppTest_SmInitial_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                       FppTest_SmInitial_Basic& sm,
-                                                                       FppTest_SmInitial_Basic::Signal signal) {
+  void SmInitialActiveComponentBase ::
+    FppTest_SmInitial_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitial_Basic& sm,
+        FppTest_SmInitial_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialActiveComponentBase ::FppTest_SmInitial_Choice_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmInitial_Choice& sm,
-                                                                        FppTest_SmInitial_Choice::Signal signal) {
+  void SmInitialActiveComponentBase ::
+    FppTest_SmInitial_Choice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitial_Choice& sm,
+        FppTest_SmInitial_Choice::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialActiveComponentBase ::FppTest_SmInitial_Nested_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmInitial_Nested& sm,
-                                                                        FppTest_SmInitial_Nested::Signal signal) {
+  void SmInitialActiveComponentBase ::
+    FppTest_SmInitial_Nested_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitial_Nested& sm,
+        FppTest_SmInitial_Nested::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialActiveComponentBase ::FppTest_SmInitialActive_Basic_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmInitialActive_Basic& sm,
-    FppTest_SmInitialActive_Basic::Signal signal) {
+  void SmInitialActiveComponentBase ::
+    FppTest_SmInitialActive_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitialActive_Basic& sm,
+        FppTest_SmInitialActive_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialActiveComponentBase ::FppTest_SmInitialActive_Choice_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmInitialActive_Choice& sm,
-    FppTest_SmInitialActive_Choice::Signal signal) {
+  void SmInitialActiveComponentBase ::
+    FppTest_SmInitialActive_Choice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitialActive_Choice& sm,
+        FppTest_SmInitialActive_Choice::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialActiveComponentBase ::FppTest_SmInitialActive_Nested_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmInitialActive_Nested& sm,
-    FppTest_SmInitialActive_Nested::Signal signal) {
+  void SmInitialActiveComponentBase ::
+    FppTest_SmInitialActive_Nested_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitialActive_Nested& sm,
+        FppTest_SmInitialActive_Nested::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-}  // namespace FppTest
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
@@ -13,243 +13,166 @@
 
 namespace FppTest {
 
-  namespace {
+namespace {
 
-    // Constant definitions for the state machine signal buffer
-    namespace SmSignalBuffer {
+// Constant definitions for the state machine signal buffer
+namespace SmSignalBuffer {
 
-      // The serialized size
-      static constexpr FwSizeType SERIALIZED_SIZE =
-        2 * sizeof(FwEnumStoreType);
+// The serialized size
+static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType);
 
+}  // namespace SmSignalBuffer
+
+enum MsgTypeEnum {
+    SMINITIALACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    INTERNAL_STATE_MACHINE_SIGNAL,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    // Size of buffer for internal state machine signals
+    // The internal SmSignalBuffer stores the state machine id, the
+    // signal id, and the signal data
+    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+    };
+
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
     }
 
-    enum MsgTypeEnum {
-      SMINITIALACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      INTERNAL_STATE_MACHINE_SIGNAL,
-    };
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      // Size of buffer for internal state machine signals
-      // The internal SmSignalBuffer stores the state machine id, the
-      // signal id, and the signal data
-      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-    };
+// ----------------------------------------------------------------------
+// Types for internal state machines
+// ----------------------------------------------------------------------
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::FppTest_SmInitial_Basic(SmInitialActiveComponentBase& component)
+    : m_component(component) {}
 
-      public:
-
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
-
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
-
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Types for internal state machines
-  // ----------------------------------------------------------------------
-
-  SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
-    FppTest_SmInitial_Basic(SmInitialActiveComponentBase& component) :
-      m_component(component)
-  {
-
-  }
-
-  void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
-    init(SmInitialActiveComponentBase::SmId smId)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::init(SmInitialActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
-    getId() const
-  {
+SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::getId() const {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::
-    action_a(Signal signal)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitial_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitial_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
-    FppTest_SmInitial_Choice(SmInitialActiveComponentBase& component) :
-      m_component(component)
-  {
+SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::FppTest_SmInitial_Choice(
+    SmInitialActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
-    init(SmInitialActiveComponentBase::SmId smId)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::init(SmInitialActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
-    getId() const
-  {
+SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::getId() const {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
-    action_a(Signal signal)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitial_Choice_action_a(this->getId(), signal);
-  }
+}
 
-  bool SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::
-    guard_g(Signal signal) const
-  {
+bool SmInitialActiveComponentBase::FppTest_SmInitial_Choice ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmInitial_Choice_guard_g(this->getId(), signal);
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
-    FppTest_SmInitial_Nested(SmInitialActiveComponentBase& component) :
-      m_component(component)
-  {
+SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::FppTest_SmInitial_Nested(
+    SmInitialActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
-    init(SmInitialActiveComponentBase::SmId smId)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::init(SmInitialActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
-    getId() const
-  {
+SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::getId() const {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::
-    action_a(Signal signal)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitial_Nested ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitial_Nested_action_a(this->getId(), signal);
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
-    FppTest_SmInitialActive_Basic(SmInitialActiveComponentBase& component) :
-      m_component(component)
-  {
+SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::FppTest_SmInitialActive_Basic(
+    SmInitialActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
-    init(SmInitialActiveComponentBase::SmId smId)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::init(SmInitialActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
-    getId() const
-  {
+SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::getId() const {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::
-    action_a(Signal signal)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitialActive_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
-    FppTest_SmInitialActive_Choice(SmInitialActiveComponentBase& component) :
-      m_component(component)
-  {
+SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::FppTest_SmInitialActive_Choice(
+    SmInitialActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
-    init(SmInitialActiveComponentBase::SmId smId)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::init(SmInitialActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
-    getId() const
-  {
+SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::getId() const {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
-    action_a(Signal signal)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitialActive_Choice_action_a(this->getId(), signal);
-  }
+}
 
-  bool SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::
-    guard_g(Signal signal) const
-  {
+bool SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmInitialActive_Choice_guard_g(this->getId(), signal);
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
-    FppTest_SmInitialActive_Nested(SmInitialActiveComponentBase& component) :
-      m_component(component)
-  {
+SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::FppTest_SmInitialActive_Nested(
+    SmInitialActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
-    init(SmInitialActiveComponentBase::SmId smId)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::init(SmInitialActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
-    getId() const
-  {
+SmInitialActiveComponentBase::SmId SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::getId() const {
     return static_cast<SmInitialActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::
-    action_a(Signal signal)
-  {
+void SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitialActive_Nested_action_a(this->getId(), signal);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
 
-  void SmInitialActiveComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+void SmInitialActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -264,23 +187,17 @@ namespace FppTest {
     this->m_stateMachine_smInitialNested.init(SmId::smInitialNested);
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  SmInitialActiveComponentBase ::
-    SmInitialActiveComponentBase(const char* compName) :
-      Fw::ActiveComponentBase(compName),
+SmInitialActiveComponentBase ::SmInitialActiveComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_choice(*this),
@@ -288,133 +205,100 @@ namespace FppTest {
       m_stateMachine_smInitialBasic1(*this),
       m_stateMachine_smInitialBasic2(*this),
       m_stateMachine_smInitialChoice(*this),
-      m_stateMachine_smInitialNested(*this)
-  {
+      m_stateMachine_smInitialNested(*this) {}
 
-  }
+SmInitialActiveComponentBase ::~SmInitialActiveComponentBase() {}
 
-  SmInitialActiveComponentBase ::
-    ~SmInitialActiveComponentBase()
-  {
+// ----------------------------------------------------------------------
+// State getter functions
+// ----------------------------------------------------------------------
 
-  }
-
-  // ----------------------------------------------------------------------
-  // State getter functions
-  // ----------------------------------------------------------------------
-
-  SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::
-    basic1_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::basic1_getState()
+    const {
     return this->m_stateMachine_basic1.getState();
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::
-    basic2_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitialActive_Basic::State SmInitialActiveComponentBase ::basic2_getState()
+    const {
     return this->m_stateMachine_basic2.getState();
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice::State SmInitialActiveComponentBase ::
-    choice_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitialActive_Choice::State SmInitialActiveComponentBase ::choice_getState()
+    const {
     return this->m_stateMachine_choice.getState();
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested::State SmInitialActiveComponentBase ::
-    nested_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitialActive_Nested::State SmInitialActiveComponentBase ::nested_getState()
+    const {
     return this->m_stateMachine_nested.getState();
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::
-    smInitialBasic1_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::smInitialBasic1_getState()
+    const {
     return this->m_stateMachine_smInitialBasic1.getState();
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::
-    smInitialBasic2_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitial_Basic::State SmInitialActiveComponentBase ::smInitialBasic2_getState()
+    const {
     return this->m_stateMachine_smInitialBasic2.getState();
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitial_Choice::State SmInitialActiveComponentBase ::
-    smInitialChoice_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitial_Choice::State SmInitialActiveComponentBase ::smInitialChoice_getState()
+    const {
     return this->m_stateMachine_smInitialChoice.getState();
-  }
+}
 
-  SmInitialActiveComponentBase::FppTest_SmInitial_Nested::State SmInitialActiveComponentBase ::
-    smInitialNested_getState() const
-  {
+SmInitialActiveComponentBase::FppTest_SmInitial_Nested::State SmInitialActiveComponentBase ::smInitialNested_getState()
+    const {
     return this->m_stateMachine_smInitialNested.getState();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmInitialActiveComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmInitialActiveComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::BLOCKING,
-      _priority
-    );
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMINITIALACTIVE_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
+        // Handle signals to internal state machines
+        case INTERNAL_STATE_MACHINE_SIGNAL:
+            this->smDispatch(_msg);
+            break;
 
-      // Handle signals to internal state machines
-      case INTERNAL_STATE_MACHINE_SIGNAL:
-        this->smDispatch(_msg);
-        break;
-
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for state machine dispatch
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for state machine dispatch
+// ----------------------------------------------------------------------
 
-  void SmInitialActiveComponentBase ::
-    smDispatch(Fw::SerialBufferBase& buffer)
-  {
+void SmInitialActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -423,62 +307,61 @@ namespace FppTest {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-      case SmId::basic1: {
-        const FppTest_SmInitialActive_Basic::Signal signal = static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-        break;
-      }
-      case SmId::basic2: {
-        const FppTest_SmInitialActive_Basic::Signal signal = static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-        break;
-      }
-      case SmId::choice: {
-        const FppTest_SmInitialActive_Choice::Signal signal = static_cast<FppTest_SmInitialActive_Choice::Signal>(storedSignal);
-        this->FppTest_SmInitialActive_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
-        break;
-      }
-      case SmId::nested: {
-        const FppTest_SmInitialActive_Nested::Signal signal = static_cast<FppTest_SmInitialActive_Nested::Signal>(storedSignal);
-        this->FppTest_SmInitialActive_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
-        break;
-      }
-      case SmId::smInitialBasic1: {
-        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
-        break;
-      }
-      case SmId::smInitialBasic2: {
-        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
-        break;
-      }
-      case SmId::smInitialChoice: {
-        const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
-        this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
-        break;
-      }
-      case SmId::smInitialNested: {
-        const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
-        this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-        break;
+        case SmId::basic1: {
+            const FppTest_SmInitialActive_Basic::Signal signal =
+                static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+            break;
+        }
+        case SmId::basic2: {
+            const FppTest_SmInitialActive_Basic::Signal signal =
+                static_cast<FppTest_SmInitialActive_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitialActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+            break;
+        }
+        case SmId::choice: {
+            const FppTest_SmInitialActive_Choice::Signal signal =
+                static_cast<FppTest_SmInitialActive_Choice::Signal>(storedSignal);
+            this->FppTest_SmInitialActive_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
+            break;
+        }
+        case SmId::nested: {
+            const FppTest_SmInitialActive_Nested::Signal signal =
+                static_cast<FppTest_SmInitialActive_Nested::Signal>(storedSignal);
+            this->FppTest_SmInitialActive_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
+            break;
+        }
+        case SmId::smInitialBasic1: {
+            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
+            break;
+        }
+        case SmId::smInitialBasic2: {
+            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
+            break;
+        }
+        case SmId::smInitialChoice: {
+            const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
+            this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
+            break;
+        }
+        case SmId::smInitialNested: {
+            const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
+            this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+            break;
     }
-  }
+}
 
-  void SmInitialActiveComponentBase ::
-    deserializeSmIdAndSignal(
-        Fw::SerialBufferBase& buffer,
-        FwEnumStoreType& smId,
-        FwEnumStoreType& signal
-    )
-  {
+void SmInitialActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
+                                                             FwEnumStoreType& smId,
+                                                             FwEnumStoreType& signal) {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status =
-      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -488,90 +371,69 @@ namespace FppTest {
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
-
-  void SmInitialActiveComponentBase ::
-    FppTest_SmInitial_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitial_Basic& sm,
-        FppTest_SmInitial_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialActiveComponentBase ::
-    FppTest_SmInitial_Choice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitial_Choice& sm,
-        FppTest_SmInitial_Choice::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialActiveComponentBase ::
-    FppTest_SmInitial_Nested_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitial_Nested& sm,
-        FppTest_SmInitial_Nested::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialActiveComponentBase ::
-    FppTest_SmInitialActive_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitialActive_Basic& sm,
-        FppTest_SmInitialActive_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialActiveComponentBase ::
-    FppTest_SmInitialActive_Choice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitialActive_Choice& sm,
-        FppTest_SmInitialActive_Choice::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialActiveComponentBase ::
-    FppTest_SmInitialActive_Nested_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitialActive_Nested& sm,
-        FppTest_SmInitialActive_Nested::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
 }
+
+void SmInitialActiveComponentBase ::FppTest_SmInitial_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                       FppTest_SmInitial_Basic& sm,
+                                                                       FppTest_SmInitial_Basic::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialActiveComponentBase ::FppTest_SmInitial_Choice_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmInitial_Choice& sm,
+                                                                        FppTest_SmInitial_Choice::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialActiveComponentBase ::FppTest_SmInitial_Nested_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmInitial_Nested& sm,
+                                                                        FppTest_SmInitial_Nested::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialActiveComponentBase ::FppTest_SmInitialActive_Basic_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmInitialActive_Basic& sm,
+    FppTest_SmInitialActive_Basic::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialActiveComponentBase ::FppTest_SmInitialActive_Choice_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmInitialActive_Choice& sm,
+    FppTest_SmInitialActive_Choice::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialActiveComponentBase ::FppTest_SmInitialActive_Nested_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmInitialActive_Nested& sm,
+    FppTest_SmInitialActive_Nested::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+}  // namespace FppTest

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
@@ -55,9 +55,8 @@ namespace FppTest {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
@@ -13,243 +13,166 @@
 
 namespace FppTest {
 
-  namespace {
+namespace {
 
-    // Constant definitions for the state machine signal buffer
-    namespace SmSignalBuffer {
+// Constant definitions for the state machine signal buffer
+namespace SmSignalBuffer {
 
-      // The serialized size
-      static constexpr FwSizeType SERIALIZED_SIZE =
-        2 * sizeof(FwEnumStoreType);
+// The serialized size
+static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType);
 
+}  // namespace SmSignalBuffer
+
+enum MsgTypeEnum {
+    SMINITIALQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    INTERNAL_STATE_MACHINE_SIGNAL,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    // Size of buffer for internal state machine signals
+    // The internal SmSignalBuffer stores the state machine id, the
+    // signal id, and the signal data
+    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+    };
+
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
     }
 
-    enum MsgTypeEnum {
-      SMINITIALQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      INTERNAL_STATE_MACHINE_SIGNAL,
-    };
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      // Size of buffer for internal state machine signals
-      // The internal SmSignalBuffer stores the state machine id, the
-      // signal id, and the signal data
-      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-    };
+// ----------------------------------------------------------------------
+// Types for internal state machines
+// ----------------------------------------------------------------------
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::FppTest_SmInitial_Basic(SmInitialQueuedComponentBase& component)
+    : m_component(component) {}
 
-      public:
-
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
-
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
-
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Types for internal state machines
-  // ----------------------------------------------------------------------
-
-  SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
-    FppTest_SmInitial_Basic(SmInitialQueuedComponentBase& component) :
-      m_component(component)
-  {
-
-  }
-
-  void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
-    init(SmInitialQueuedComponentBase::SmId smId)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::init(SmInitialQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
-    getId() const
-  {
+SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::getId() const {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
-    action_a(Signal signal)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitial_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
-    FppTest_SmInitial_Choice(SmInitialQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::FppTest_SmInitial_Choice(
+    SmInitialQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
-    init(SmInitialQueuedComponentBase::SmId smId)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::init(SmInitialQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
-    getId() const
-  {
+SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::getId() const {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
-    action_a(Signal signal)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitial_Choice_action_a(this->getId(), signal);
-  }
+}
 
-  bool SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
-    guard_g(Signal signal) const
-  {
+bool SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmInitial_Choice_guard_g(this->getId(), signal);
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
-    FppTest_SmInitial_Nested(SmInitialQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::FppTest_SmInitial_Nested(
+    SmInitialQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
-    init(SmInitialQueuedComponentBase::SmId smId)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::init(SmInitialQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
-    getId() const
-  {
+SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::getId() const {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
-    action_a(Signal signal)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitial_Nested_action_a(this->getId(), signal);
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
-    FppTest_SmInitialQueued_Basic(SmInitialQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::FppTest_SmInitialQueued_Basic(
+    SmInitialQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
-    init(SmInitialQueuedComponentBase::SmId smId)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::init(SmInitialQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
-    getId() const
-  {
+SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::getId() const {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
-    action_a(Signal signal)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitialQueued_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
-    FppTest_SmInitialQueued_Choice(SmInitialQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::FppTest_SmInitialQueued_Choice(
+    SmInitialQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
-    init(SmInitialQueuedComponentBase::SmId smId)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::init(SmInitialQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
-    getId() const
-  {
+SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::getId() const {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
-    action_a(Signal signal)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitialQueued_Choice_action_a(this->getId(), signal);
-  }
+}
 
-  bool SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
-    guard_g(Signal signal) const
-  {
+bool SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmInitialQueued_Choice_guard_g(this->getId(), signal);
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
-    FppTest_SmInitialQueued_Nested(SmInitialQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::FppTest_SmInitialQueued_Nested(
+    SmInitialQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
-    init(SmInitialQueuedComponentBase::SmId smId)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::init(SmInitialQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
-    getId() const
-  {
+SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::getId() const {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
-    action_a(Signal signal)
-  {
+void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::action_a(Signal signal) {
     this->m_component.FppTest_SmInitialQueued_Nested_action_a(this->getId(), signal);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
 
-  void SmInitialQueuedComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+void SmInitialQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::QueuedComponentBase::init(instance);
 
@@ -265,67 +188,45 @@ namespace FppTest {
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port schedIn
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts());
-      port++
-    ) {
-      this->m_schedIn_InputPort[port].init();
-      this->m_schedIn_InputPort[port].addCallComp(
-        this,
-        m_p_schedIn_in
-      );
-      this->m_schedIn_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts()); port++) {
+        this->m_schedIn_InputPort[port].init();
+        this->m_schedIn_InputPort[port].addCallComp(this, m_p_schedIn_in);
+        this->m_schedIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_schedIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_schedIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_schedIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Getters for typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Getters for typed input ports
+// ----------------------------------------------------------------------
 
-  Svc::InputSchedPort* SmInitialQueuedComponentBase ::
-    get_schedIn_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Svc::InputSchedPort* SmInitialQueuedComponentBase ::get_schedIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return &this->m_schedIn_InputPort[portNum];
-  }
+}
 
 #endif
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  SmInitialQueuedComponentBase ::
-    SmInitialQueuedComponentBase(const char* compName) :
-      Fw::QueuedComponentBase(compName),
+SmInitialQueuedComponentBase ::SmInitialQueuedComponentBase(const char* compName)
+    : Fw::QueuedComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_choice(*this),
@@ -333,117 +234,81 @@ namespace FppTest {
       m_stateMachine_smInitialBasic1(*this),
       m_stateMachine_smInitialBasic2(*this),
       m_stateMachine_smInitialChoice(*this),
-      m_stateMachine_smInitialNested(*this)
-  {
+      m_stateMachine_smInitialNested(*this) {}
 
-  }
+SmInitialQueuedComponentBase ::~SmInitialQueuedComponentBase() {}
 
-  SmInitialQueuedComponentBase ::
-    ~SmInitialQueuedComponentBase()
-  {
+// ----------------------------------------------------------------------
+// Port handler base-class functions for typed input ports
+//
+// Call these functions directly to bypass the corresponding ports
+// ----------------------------------------------------------------------
 
-  }
-
-  // ----------------------------------------------------------------------
-  // Port handler base-class functions for typed input ports
-  //
-  // Call these functions directly to bypass the corresponding ports
-  // ----------------------------------------------------------------------
-
-  void SmInitialQueuedComponentBase ::
-    schedIn_handlerBase(
-        FwIndexType portNum,
-        U32 context
-    )
-  {
+void SmInitialQueuedComponentBase ::schedIn_handlerBase(FwIndexType portNum, U32 context) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     // Call handler function
-    this->schedIn_handler(
-      portNum,
-      context
-    );
-  }
+    this->schedIn_handler(portNum, context);
+}
 
-  // ----------------------------------------------------------------------
-  // State getter functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// State getter functions
+// ----------------------------------------------------------------------
 
-  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::
-    basic1_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::basic1_getState()
+    const {
     return this->m_stateMachine_basic1.getState();
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::
-    basic2_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::basic2_getState()
+    const {
     return this->m_stateMachine_basic2.getState();
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice::State SmInitialQueuedComponentBase ::
-    choice_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice::State SmInitialQueuedComponentBase ::choice_getState()
+    const {
     return this->m_stateMachine_choice.getState();
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested::State SmInitialQueuedComponentBase ::
-    nested_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested::State SmInitialQueuedComponentBase ::nested_getState()
+    const {
     return this->m_stateMachine_nested.getState();
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::
-    smInitialBasic1_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::smInitialBasic1_getState()
+    const {
     return this->m_stateMachine_smInitialBasic1.getState();
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::
-    smInitialBasic2_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::smInitialBasic2_getState()
+    const {
     return this->m_stateMachine_smInitialBasic2.getState();
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitial_Choice::State SmInitialQueuedComponentBase ::
-    smInitialChoice_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitial_Choice::State SmInitialQueuedComponentBase ::smInitialChoice_getState()
+    const {
     return this->m_stateMachine_smInitialChoice.getState();
-  }
+}
 
-  SmInitialQueuedComponentBase::FppTest_SmInitial_Nested::State SmInitialQueuedComponentBase ::
-    smInitialNested_getState() const
-  {
+SmInitialQueuedComponentBase::FppTest_SmInitial_Nested::State SmInitialQueuedComponentBase ::smInitialNested_getState()
+    const {
     return this->m_stateMachine_smInitialNested.getState();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::NONBLOCKING,
-      _priority
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
     if (Os::Queue::Status::EMPTY == _msgStatus) {
-      return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    }
-    else {
-      FW_ASSERT(
-        _msgStatus == Os::Queue::OP_OK,
-        static_cast<FwAssertArgType>(_msgStatus)
-      );
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
     // Reset to beginning of buffer
@@ -451,83 +316,65 @@ namespace FppTest {
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMINITIALQUEUED_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
+        // Handle signals to internal state machines
+        case INTERNAL_STATE_MACHINE_SIGNAL:
+            this->smDispatch(_msg);
+            break;
 
-      // Handle signals to internal state machines
-      case INTERNAL_STATE_MACHINE_SIGNAL:
-        this->smDispatch(_msg);
-        break;
-
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for dispatching current messages
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for dispatching current messages
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::
-    dispatchCurrentMessages()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::dispatchCurrentMessages() {
     // Dispatch all current messages unless ERROR or EXIT occur
     const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
     MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
     for (FwSizeType i = 0; i < currentMessageCount; i++) {
-      messageStatus = this->doDispatch();
-      if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-        break;
-      }
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
     return messageStatus;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Calls for messages received on typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Calls for messages received on typed input ports
+// ----------------------------------------------------------------------
 
-  void SmInitialQueuedComponentBase ::
-    m_p_schedIn_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 context
-    )
-  {
+void SmInitialQueuedComponentBase ::m_p_schedIn_in(Fw::PassiveComponentBase* callComp,
+                                                   FwIndexType portNum,
+                                                   U32 context) {
     FW_ASSERT(callComp);
     SmInitialQueuedComponentBase* compPtr = static_cast<SmInitialQueuedComponentBase*>(callComp);
-    compPtr->schedIn_handlerBase(
-      portNum,
-      context
-    );
-  }
+    compPtr->schedIn_handlerBase(portNum, context);
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for state machine dispatch
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for state machine dispatch
+// ----------------------------------------------------------------------
 
-  void SmInitialQueuedComponentBase ::
-    smDispatch(Fw::SerialBufferBase& buffer)
-  {
+void SmInitialQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -536,62 +383,61 @@ namespace FppTest {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-      case SmId::basic1: {
-        const FppTest_SmInitialQueued_Basic::Signal signal = static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-        break;
-      }
-      case SmId::basic2: {
-        const FppTest_SmInitialQueued_Basic::Signal signal = static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-        break;
-      }
-      case SmId::choice: {
-        const FppTest_SmInitialQueued_Choice::Signal signal = static_cast<FppTest_SmInitialQueued_Choice::Signal>(storedSignal);
-        this->FppTest_SmInitialQueued_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
-        break;
-      }
-      case SmId::nested: {
-        const FppTest_SmInitialQueued_Nested::Signal signal = static_cast<FppTest_SmInitialQueued_Nested::Signal>(storedSignal);
-        this->FppTest_SmInitialQueued_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
-        break;
-      }
-      case SmId::smInitialBasic1: {
-        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
-        break;
-      }
-      case SmId::smInitialBasic2: {
-        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
-        break;
-      }
-      case SmId::smInitialChoice: {
-        const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
-        this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
-        break;
-      }
-      case SmId::smInitialNested: {
-        const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
-        this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-        break;
+        case SmId::basic1: {
+            const FppTest_SmInitialQueued_Basic::Signal signal =
+                static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+            break;
+        }
+        case SmId::basic2: {
+            const FppTest_SmInitialQueued_Basic::Signal signal =
+                static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+            break;
+        }
+        case SmId::choice: {
+            const FppTest_SmInitialQueued_Choice::Signal signal =
+                static_cast<FppTest_SmInitialQueued_Choice::Signal>(storedSignal);
+            this->FppTest_SmInitialQueued_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
+            break;
+        }
+        case SmId::nested: {
+            const FppTest_SmInitialQueued_Nested::Signal signal =
+                static_cast<FppTest_SmInitialQueued_Nested::Signal>(storedSignal);
+            this->FppTest_SmInitialQueued_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
+            break;
+        }
+        case SmId::smInitialBasic1: {
+            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
+            break;
+        }
+        case SmId::smInitialBasic2: {
+            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
+            break;
+        }
+        case SmId::smInitialChoice: {
+            const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
+            this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
+            break;
+        }
+        case SmId::smInitialNested: {
+            const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
+            this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+            break;
     }
-  }
+}
 
-  void SmInitialQueuedComponentBase ::
-    deserializeSmIdAndSignal(
-        Fw::SerialBufferBase& buffer,
-        FwEnumStoreType& smId,
-        FwEnumStoreType& signal
-    )
-  {
+void SmInitialQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
+                                                             FwEnumStoreType& smId,
+                                                             FwEnumStoreType& signal) {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status =
-      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -601,90 +447,69 @@ namespace FppTest {
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
-
-  void SmInitialQueuedComponentBase ::
-    FppTest_SmInitial_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitial_Basic& sm,
-        FppTest_SmInitial_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialQueuedComponentBase ::
-    FppTest_SmInitial_Choice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitial_Choice& sm,
-        FppTest_SmInitial_Choice::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialQueuedComponentBase ::
-    FppTest_SmInitial_Nested_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitial_Nested& sm,
-        FppTest_SmInitial_Nested::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialQueuedComponentBase ::
-    FppTest_SmInitialQueued_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitialQueued_Basic& sm,
-        FppTest_SmInitialQueued_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialQueuedComponentBase ::
-    FppTest_SmInitialQueued_Choice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitialQueued_Choice& sm,
-        FppTest_SmInitialQueued_Choice::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmInitialQueuedComponentBase ::
-    FppTest_SmInitialQueued_Nested_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmInitialQueued_Nested& sm,
-        FppTest_SmInitialQueued_Nested::Signal signal
-    )
-  {
-    switch (signal) {
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
 }
+
+void SmInitialQueuedComponentBase ::FppTest_SmInitial_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                       FppTest_SmInitial_Basic& sm,
+                                                                       FppTest_SmInitial_Basic::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialQueuedComponentBase ::FppTest_SmInitial_Choice_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmInitial_Choice& sm,
+                                                                        FppTest_SmInitial_Choice::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialQueuedComponentBase ::FppTest_SmInitial_Nested_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmInitial_Nested& sm,
+                                                                        FppTest_SmInitial_Nested::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialQueuedComponentBase ::FppTest_SmInitialQueued_Basic_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmInitialQueued_Basic& sm,
+    FppTest_SmInitialQueued_Basic::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialQueuedComponentBase ::FppTest_SmInitialQueued_Choice_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmInitialQueued_Choice& sm,
+    FppTest_SmInitialQueued_Choice::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmInitialQueuedComponentBase ::FppTest_SmInitialQueued_Nested_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmInitialQueued_Nested& sm,
+    FppTest_SmInitialQueued_Nested::Signal signal) {
+    switch (signal) {
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+}  // namespace FppTest

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
@@ -13,166 +13,236 @@
 
 namespace FppTest {
 
-namespace {
+  namespace {
 
-// Constant definitions for the state machine signal buffer
-namespace SmSignalBuffer {
+    // Constant definitions for the state machine signal buffer
+    namespace SmSignalBuffer {
 
-// The serialized size
-static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType);
+      // The serialized size
+      static constexpr FwSizeType SERIALIZED_SIZE =
+        2 * sizeof(FwEnumStoreType);
 
-}  // namespace SmSignalBuffer
-
-enum MsgTypeEnum {
-    SMINITIALQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    INTERNAL_STATE_MACHINE_SIGNAL,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    // Size of buffer for internal state machine signals
-    // The internal SmSignalBuffer stores the state machine id, the
-    // signal id, and the signal data
-    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
-
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
     }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    enum MsgTypeEnum {
+      SMINITIALQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      INTERNAL_STATE_MACHINE_SIGNAL,
+    };
 
-// ----------------------------------------------------------------------
-// Types for internal state machines
-// ----------------------------------------------------------------------
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      // Size of buffer for internal state machine signals
+      // The internal SmSignalBuffer stores the state machine id, the
+      // signal id, and the signal data
+      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+    };
 
-SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::FppTest_SmInitial_Basic(SmInitialQueuedComponentBase& component)
-    : m_component(component) {}
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::init(SmInitialQueuedComponentBase::SmId smId) {
+      public:
+
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
+
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
+
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Types for internal state machines
+  // ----------------------------------------------------------------------
+
+  SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
+    FppTest_SmInitial_Basic(SmInitialQueuedComponentBase& component) :
+      m_component(component)
+  {
+
+  }
+
+  void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
+    init(SmInitialQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::getId() const {
+  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
+    getId() const
+  {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::action_a(Signal signal) {
+  void SmInitialQueuedComponentBase::FppTest_SmInitial_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitial_Basic_action_a(this->getId(), signal);
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::FppTest_SmInitial_Choice(
-    SmInitialQueuedComponentBase& component)
-    : m_component(component) {}
+  SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
+    FppTest_SmInitial_Choice(SmInitialQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::init(SmInitialQueuedComponentBase::SmId smId) {
+  }
+
+  void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
+    init(SmInitialQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::getId() const {
+  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
+    getId() const
+  {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::action_a(Signal signal) {
+  void SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitial_Choice_action_a(this->getId(), signal);
-}
+  }
 
-bool SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::guard_g(Signal signal) const {
+  bool SmInitialQueuedComponentBase::FppTest_SmInitial_Choice ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmInitial_Choice_guard_g(this->getId(), signal);
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::FppTest_SmInitial_Nested(
-    SmInitialQueuedComponentBase& component)
-    : m_component(component) {}
+  SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
+    FppTest_SmInitial_Nested(SmInitialQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::init(SmInitialQueuedComponentBase::SmId smId) {
+  }
+
+  void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
+    init(SmInitialQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::getId() const {
+  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
+    getId() const
+  {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::action_a(Signal signal) {
+  void SmInitialQueuedComponentBase::FppTest_SmInitial_Nested ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitial_Nested_action_a(this->getId(), signal);
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::FppTest_SmInitialQueued_Basic(
-    SmInitialQueuedComponentBase& component)
-    : m_component(component) {}
+  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
+    FppTest_SmInitialQueued_Basic(SmInitialQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::init(SmInitialQueuedComponentBase::SmId smId) {
+  }
+
+  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
+    init(SmInitialQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::getId() const {
+  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
+    getId() const
+  {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::action_a(Signal signal) {
+  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitialQueued_Basic_action_a(this->getId(), signal);
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::FppTest_SmInitialQueued_Choice(
-    SmInitialQueuedComponentBase& component)
-    : m_component(component) {}
+  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
+    FppTest_SmInitialQueued_Choice(SmInitialQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::init(SmInitialQueuedComponentBase::SmId smId) {
+  }
+
+  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
+    init(SmInitialQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::getId() const {
+  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
+    getId() const
+  {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::action_a(Signal signal) {
+  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitialQueued_Choice_action_a(this->getId(), signal);
-}
+  }
 
-bool SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::guard_g(Signal signal) const {
+  bool SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmInitialQueued_Choice_guard_g(this->getId(), signal);
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::FppTest_SmInitialQueued_Nested(
-    SmInitialQueuedComponentBase& component)
-    : m_component(component) {}
+  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
+    FppTest_SmInitialQueued_Nested(SmInitialQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::init(SmInitialQueuedComponentBase::SmId smId) {
+  }
+
+  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
+    init(SmInitialQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::getId() const {
+  SmInitialQueuedComponentBase::SmId SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
+    getId() const
+  {
     return static_cast<SmInitialQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::action_a(Signal signal) {
+  void SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmInitialQueued_Nested_action_a(this->getId(), signal);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
 
-void SmInitialQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+  void SmInitialQueuedComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::QueuedComponentBase::init(instance);
 
@@ -188,45 +258,67 @@ void SmInitialQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType 
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port schedIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts()); port++) {
-        this->m_schedIn_InputPort[port].init();
-        this->m_schedIn_InputPort[port].addCallComp(this, m_p_schedIn_in);
-        this->m_schedIn_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts());
+      port++
+    ) {
+      this->m_schedIn_InputPort[port].init();
+      this->m_schedIn_InputPort[port].addCallComp(
+        this,
+        m_p_schedIn_in
+      );
+      this->m_schedIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_schedIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_schedIn_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_schedIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Getters for typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Getters for typed input ports
+  // ----------------------------------------------------------------------
 
-Svc::InputSchedPort* SmInitialQueuedComponentBase ::get_schedIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+  Svc::InputSchedPort* SmInitialQueuedComponentBase ::
+    get_schedIn_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_schedIn_InputPort[portNum];
-}
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-SmInitialQueuedComponentBase ::SmInitialQueuedComponentBase(const char* compName)
-    : Fw::QueuedComponentBase(compName),
+  SmInitialQueuedComponentBase ::
+    SmInitialQueuedComponentBase(const char* compName) :
+      Fw::QueuedComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_choice(*this),
@@ -234,81 +326,117 @@ SmInitialQueuedComponentBase ::SmInitialQueuedComponentBase(const char* compName
       m_stateMachine_smInitialBasic1(*this),
       m_stateMachine_smInitialBasic2(*this),
       m_stateMachine_smInitialChoice(*this),
-      m_stateMachine_smInitialNested(*this) {}
+      m_stateMachine_smInitialNested(*this)
+  {
 
-SmInitialQueuedComponentBase ::~SmInitialQueuedComponentBase() {}
+  }
 
-// ----------------------------------------------------------------------
-// Port handler base-class functions for typed input ports
-//
-// Call these functions directly to bypass the corresponding ports
-// ----------------------------------------------------------------------
+  SmInitialQueuedComponentBase ::
+    ~SmInitialQueuedComponentBase()
+  {
 
-void SmInitialQueuedComponentBase ::schedIn_handlerBase(FwIndexType portNum, U32 context) {
+  }
+
+  // ----------------------------------------------------------------------
+  // Port handler base-class functions for typed input ports
+  //
+  // Call these functions directly to bypass the corresponding ports
+  // ----------------------------------------------------------------------
+
+  void SmInitialQueuedComponentBase ::
+    schedIn_handlerBase(
+        FwIndexType portNum,
+        U32 context
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call handler function
-    this->schedIn_handler(portNum, context);
-}
+    this->schedIn_handler(
+      portNum,
+      context
+    );
+  }
 
-// ----------------------------------------------------------------------
-// State getter functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // State getter functions
+  // ----------------------------------------------------------------------
 
-SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::basic1_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::
+    basic1_getState() const
+  {
     return this->m_stateMachine_basic1.getState();
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::basic2_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Basic::State SmInitialQueuedComponentBase ::
+    basic2_getState() const
+  {
     return this->m_stateMachine_basic2.getState();
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice::State SmInitialQueuedComponentBase ::choice_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Choice::State SmInitialQueuedComponentBase ::
+    choice_getState() const
+  {
     return this->m_stateMachine_choice.getState();
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested::State SmInitialQueuedComponentBase ::nested_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitialQueued_Nested::State SmInitialQueuedComponentBase ::
+    nested_getState() const
+  {
     return this->m_stateMachine_nested.getState();
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::smInitialBasic1_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::
+    smInitialBasic1_getState() const
+  {
     return this->m_stateMachine_smInitialBasic1.getState();
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::smInitialBasic2_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitial_Basic::State SmInitialQueuedComponentBase ::
+    smInitialBasic2_getState() const
+  {
     return this->m_stateMachine_smInitialBasic2.getState();
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitial_Choice::State SmInitialQueuedComponentBase ::smInitialChoice_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitial_Choice::State SmInitialQueuedComponentBase ::
+    smInitialChoice_getState() const
+  {
     return this->m_stateMachine_smInitialChoice.getState();
-}
+  }
 
-SmInitialQueuedComponentBase::FppTest_SmInitial_Nested::State SmInitialQueuedComponentBase ::smInitialNested_getState()
-    const {
+  SmInitialQueuedComponentBase::FppTest_SmInitial_Nested::State SmInitialQueuedComponentBase ::
+    smInitialNested_getState() const
+  {
     return this->m_stateMachine_smInitialNested.getState();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::NONBLOCKING,
+      _priority
+    );
     if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+      return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    }
+    else {
+      FW_ASSERT(
+        _msgStatus == Os::Queue::OP_OK,
+        static_cast<FwAssertArgType>(_msgStatus)
+      );
     }
 
     // Reset to beginning of buffer
@@ -316,65 +444,83 @@ Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::doDisp
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMINITIALQUEUED_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle signals to internal state machines
-        case INTERNAL_STATE_MACHINE_SIGNAL:
-            this->smDispatch(_msg);
-            break;
 
-        default:
-            return MSG_DISPATCH_ERROR;
+      // Handle signals to internal state machines
+      case INTERNAL_STATE_MACHINE_SIGNAL:
+        this->smDispatch(_msg);
+        break;
+
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for dispatching current messages
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for dispatching current messages
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::dispatchCurrentMessages() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmInitialQueuedComponentBase ::
+    dispatchCurrentMessages()
+  {
     // Dispatch all current messages unless ERROR or EXIT occur
     const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
     MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
     for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+      messageStatus = this->doDispatch();
+      if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+        break;
+      }
     }
     return messageStatus;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Calls for messages received on typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Calls for messages received on typed input ports
+  // ----------------------------------------------------------------------
 
-void SmInitialQueuedComponentBase ::m_p_schedIn_in(Fw::PassiveComponentBase* callComp,
-                                                   FwIndexType portNum,
-                                                   U32 context) {
+  void SmInitialQueuedComponentBase ::
+    m_p_schedIn_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 context
+    )
+  {
     FW_ASSERT(callComp);
     SmInitialQueuedComponentBase* compPtr = static_cast<SmInitialQueuedComponentBase*>(callComp);
-    compPtr->schedIn_handlerBase(portNum, context);
-}
+    compPtr->schedIn_handlerBase(
+      portNum,
+      context
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for state machine dispatch
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for state machine dispatch
+  // ----------------------------------------------------------------------
 
-void SmInitialQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
+  void SmInitialQueuedComponentBase ::
+    smDispatch(Fw::SerialBufferBase& buffer)
+  {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -383,61 +529,62 @@ void SmInitialQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-        case SmId::basic1: {
-            const FppTest_SmInitialQueued_Basic::Signal signal =
-                static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-            break;
-        }
-        case SmId::basic2: {
-            const FppTest_SmInitialQueued_Basic::Signal signal =
-                static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-            break;
-        }
-        case SmId::choice: {
-            const FppTest_SmInitialQueued_Choice::Signal signal =
-                static_cast<FppTest_SmInitialQueued_Choice::Signal>(storedSignal);
-            this->FppTest_SmInitialQueued_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
-            break;
-        }
-        case SmId::nested: {
-            const FppTest_SmInitialQueued_Nested::Signal signal =
-                static_cast<FppTest_SmInitialQueued_Nested::Signal>(storedSignal);
-            this->FppTest_SmInitialQueued_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
-            break;
-        }
-        case SmId::smInitialBasic1: {
-            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
-            break;
-        }
-        case SmId::smInitialBasic2: {
-            const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
-            this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
-            break;
-        }
-        case SmId::smInitialChoice: {
-            const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
-            this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
-            break;
-        }
-        case SmId::smInitialNested: {
-            const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
-            this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-            break;
+      case SmId::basic1: {
+        const FppTest_SmInitialQueued_Basic::Signal signal = static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+        break;
+      }
+      case SmId::basic2: {
+        const FppTest_SmInitialQueued_Basic::Signal signal = static_cast<FppTest_SmInitialQueued_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitialQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+        break;
+      }
+      case SmId::choice: {
+        const FppTest_SmInitialQueued_Choice::Signal signal = static_cast<FppTest_SmInitialQueued_Choice::Signal>(storedSignal);
+        this->FppTest_SmInitialQueued_Choice_smDispatch(buffer, this->m_stateMachine_choice, signal);
+        break;
+      }
+      case SmId::nested: {
+        const FppTest_SmInitialQueued_Nested::Signal signal = static_cast<FppTest_SmInitialQueued_Nested::Signal>(storedSignal);
+        this->FppTest_SmInitialQueued_Nested_smDispatch(buffer, this->m_stateMachine_nested, signal);
+        break;
+      }
+      case SmId::smInitialBasic1: {
+        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic1, signal);
+        break;
+      }
+      case SmId::smInitialBasic2: {
+        const FppTest_SmInitial_Basic::Signal signal = static_cast<FppTest_SmInitial_Basic::Signal>(storedSignal);
+        this->FppTest_SmInitial_Basic_smDispatch(buffer, this->m_stateMachine_smInitialBasic2, signal);
+        break;
+      }
+      case SmId::smInitialChoice: {
+        const FppTest_SmInitial_Choice::Signal signal = static_cast<FppTest_SmInitial_Choice::Signal>(storedSignal);
+        this->FppTest_SmInitial_Choice_smDispatch(buffer, this->m_stateMachine_smInitialChoice, signal);
+        break;
+      }
+      case SmId::smInitialNested: {
+        const FppTest_SmInitial_Nested::Signal signal = static_cast<FppTest_SmInitial_Nested::Signal>(storedSignal);
+        this->FppTest_SmInitial_Nested_smDispatch(buffer, this->m_stateMachine_smInitialNested, signal);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        break;
     }
-}
+  }
 
-void SmInitialQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
-                                                             FwEnumStoreType& smId,
-                                                             FwEnumStoreType& signal) {
+  void SmInitialQueuedComponentBase ::
+    deserializeSmIdAndSignal(
+        Fw::SerialBufferBase& buffer,
+        FwEnumStoreType& smId,
+        FwEnumStoreType& signal
+    )
+  {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status =
+      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -447,69 +594,90 @@ void SmInitialQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBas
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmInitialQueuedComponentBase ::FppTest_SmInitial_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                       FppTest_SmInitial_Basic& sm,
-                                                                       FppTest_SmInitial_Basic::Signal signal) {
+  void SmInitialQueuedComponentBase ::
+    FppTest_SmInitial_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitial_Basic& sm,
+        FppTest_SmInitial_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialQueuedComponentBase ::FppTest_SmInitial_Choice_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmInitial_Choice& sm,
-                                                                        FppTest_SmInitial_Choice::Signal signal) {
+  void SmInitialQueuedComponentBase ::
+    FppTest_SmInitial_Choice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitial_Choice& sm,
+        FppTest_SmInitial_Choice::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialQueuedComponentBase ::FppTest_SmInitial_Nested_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmInitial_Nested& sm,
-                                                                        FppTest_SmInitial_Nested::Signal signal) {
+  void SmInitialQueuedComponentBase ::
+    FppTest_SmInitial_Nested_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitial_Nested& sm,
+        FppTest_SmInitial_Nested::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialQueuedComponentBase ::FppTest_SmInitialQueued_Basic_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmInitialQueued_Basic& sm,
-    FppTest_SmInitialQueued_Basic::Signal signal) {
+  void SmInitialQueuedComponentBase ::
+    FppTest_SmInitialQueued_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitialQueued_Basic& sm,
+        FppTest_SmInitialQueued_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialQueuedComponentBase ::FppTest_SmInitialQueued_Choice_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmInitialQueued_Choice& sm,
-    FppTest_SmInitialQueued_Choice::Signal signal) {
+  void SmInitialQueuedComponentBase ::
+    FppTest_SmInitialQueued_Choice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitialQueued_Choice& sm,
+        FppTest_SmInitialQueued_Choice::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmInitialQueuedComponentBase ::FppTest_SmInitialQueued_Nested_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmInitialQueued_Nested& sm,
-    FppTest_SmInitialQueued_Nested::Signal signal) {
+  void SmInitialQueuedComponentBase ::
+    FppTest_SmInitialQueued_Nested_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmInitialQueued_Nested& sm,
+        FppTest_SmInitialQueued_Nested::Signal signal
+    )
+  {
     switch (signal) {
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-}  // namespace FppTest
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
@@ -13,610 +13,935 @@
 
 namespace FppTest {
 
-namespace {
+  namespace {
 
-// Constant definitions for the state machine signal buffer
-namespace SmSignalBuffer {
+    // Constant definitions for the state machine signal buffer
+    namespace SmSignalBuffer {
 
-// Union for computing the max size of a signal type
-union SignalTypeUnion {
-    BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
-    BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
-    BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
-    BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
-    BYTE size_of_U32[sizeof(U32)];
-    BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(
-        FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
-};
+      // Union for computing the max size of a signal type
+      union SignalTypeUnion {
+        BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
+        BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
+        BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
+        BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
+        BYTE size_of_U32[sizeof(U32)];
+        BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
+      };
 
-// The serialized size
-static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
+      // The serialized size
+      static constexpr FwSizeType SERIALIZED_SIZE =
+        2 * sizeof(FwEnumStoreType) +
+        sizeof(SignalTypeUnion);
 
-}  // namespace SmSignalBuffer
-
-enum MsgTypeEnum {
-    SMSTATEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    INTERNAL_STATE_MACHINE_SIGNAL,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    // Size of buffer for internal state machine signals
-    // The internal SmSignalBuffer stores the state machine id, the
-    // signal id, and the signal data
-    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
-
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
     }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    enum MsgTypeEnum {
+      SMSTATEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      INTERNAL_STATE_MACHINE_SIGNAL,
+    };
 
-// ----------------------------------------------------------------------
-// Types for internal state machines
-// ----------------------------------------------------------------------
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      // Size of buffer for internal state machine signals
+      // The internal SmSignalBuffer stores the state machine id, the
+      // signal id, and the signal data
+      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+    };
 
-SmStateActiveComponentBase::FppTest_SmState_Basic ::FppTest_SmState_Basic(SmStateActiveComponentBase& component)
-    : m_component(component) {}
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-void SmStateActiveComponentBase::FppTest_SmState_Basic ::init(SmStateActiveComponentBase::SmId smId) {
+      public:
+
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
+
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
+
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Types for internal state machines
+  // ----------------------------------------------------------------------
+
+  SmStateActiveComponentBase::FppTest_SmState_Basic ::
+    FppTest_SmState_Basic(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
+
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_Basic ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Basic ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Basic ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_Basic ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_Basic_action_a(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::FppTest_SmState_BasicGuard(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
+    FppTest_SmState_BasicGuard(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicGuard_action_a(this->getId(), signal);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::guard_g(Signal signal) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmState_BasicGuard_guard_g(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::FppTest_SmState_BasicGuardString(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
+    FppTest_SmState_BasicGuardString(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::action_a(Signal signal,
-                                                                             const Fw::StringBase& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
+    action_a(
+        Signal signal,
+        const Fw::StringBase& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardString_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::guard_g(Signal signal,
-                                                                            const Fw::StringBase& value) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
+    guard_g(
+        Signal signal,
+        const Fw::StringBase& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardString_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::FppTest_SmState_BasicGuardTestAbsType(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    FppTest_SmState_BasicGuardTestAbsType(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestAbsType& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestAbsType_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestAbsType& value) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestAbsType& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestAbsType_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::FppTest_SmState_BasicGuardTestArray(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    FppTest_SmState_BasicGuardTestArray(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestArray& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestArray& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestArray_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestArray& value) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestArray& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestArray_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::FppTest_SmState_BasicGuardTestEnum(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    FppTest_SmState_BasicGuardTestEnum(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestEnum& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestEnum& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestEnum_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestEnum& value) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestEnum& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestEnum_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::FppTest_SmState_BasicGuardTestStruct(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    FppTest_SmState_BasicGuardTestStruct(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestStruct& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestStruct& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestStruct_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestStruct& value) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestStruct& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestStruct_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::FppTest_SmState_BasicGuardU32(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
+    FppTest_SmState_BasicGuardU32(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::action_a(Signal signal, U32 value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardU32_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::guard_g(Signal signal, U32 value) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
+    guard_g(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardU32_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::FppTest_SmState_BasicInternal(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
+    FppTest_SmState_BasicInternal(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicInternal_action_a(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::FppTest_SmState_BasicSelf(SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
+    FppTest_SmState_BasicSelf(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicSelf_action_a(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicString ::FppTest_SmState_BasicString(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicString ::
+    FppTest_SmState_BasicString(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicString ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicString ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicString ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicString ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicString ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicString ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicString_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicString ::action_b(Signal signal, const Fw::StringBase& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicString ::
+    action_b(
+        Signal signal,
+        const Fw::StringBase& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicString_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::FppTest_SmState_BasicTestAbsType(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
+    FppTest_SmState_BasicTestAbsType(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::action_b(
-    Signal signal,
-    const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestAbsType& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::FppTest_SmState_BasicTestArray(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
+    FppTest_SmState_BasicTestArray(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestArray_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::action_b(Signal signal,
-                                                                           const FppTest::SmHarness::TestArray& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestArray& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestArray_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::FppTest_SmState_BasicTestEnum(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
+    FppTest_SmState_BasicTestEnum(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestEnum_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::action_b(Signal signal,
-                                                                          const FppTest::SmHarness::TestEnum& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestEnum& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestEnum_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::FppTest_SmState_BasicTestStruct(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
+    FppTest_SmState_BasicTestStruct(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestStruct_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::action_b(
-    Signal signal,
-    const FppTest::SmHarness::TestStruct& value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestStruct& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestStruct_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::FppTest_SmState_BasicU32(SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
+    FppTest_SmState_BasicU32(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicU32_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::action_b(Signal signal, U32 value) {
+  void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
+    action_b(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmState_BasicU32_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_Internal ::FppTest_SmState_Internal(SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_Internal ::
+    FppTest_SmState_Internal(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_Internal ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_Internal ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Internal ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Internal ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_Internal ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_Internal ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_Internal_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::init(SmStateActiveComponentBase::SmId smId) {
+  void SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToChild ::FppTest_SmState_StateToChild(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    FppTest_SmState_StateToChild(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChild ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_exitS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_exitS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_enterS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_enterS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_enterS3(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::FppTest_SmState_StateToChoice(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    FppTest_SmState_StateToChoice(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_exitS1(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_exitS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_exitS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS1(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS1(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS3(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS4(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS4(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS4(this->getId(), signal);
-}
+  }
 
-bool SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::guard_g(Signal signal) const {
+  bool SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmState_StateToChoice_guard_g(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::FppTest_SmState_StateToSelf(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    FppTest_SmState_StateToSelf(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_exitS1(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_exitS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_exitS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_enterS1(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    action_enterS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS1(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_enterS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_enterS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS3(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToState ::FppTest_SmState_StateToState(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    FppTest_SmState_StateToState(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToState ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_exitS1(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_exitS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_exitS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS1(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_enterS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS1(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS2(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS3(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS3(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS4(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_enterS4(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS4(this->getId(), signal);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS5(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
+    action_enterS5(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS5(this->getId(), signal);
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::FppTest_SmStateActive_Basic(
-    SmStateActiveComponentBase& component)
-    : m_component(component) {}
+  SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
+    FppTest_SmStateActive_Basic(SmStateActiveComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::init(SmStateActiveComponentBase::SmId smId) {
+  }
+
+  void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
+    init(SmStateActiveComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::getId() const {
+  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
+    getId() const
+  {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::action_a(Signal signal) {
+  void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmStateActive_Basic_action_a(this->getId(), signal);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
 
-void SmStateActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+  void SmStateActiveComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -648,17 +973,23 @@ void SmStateActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType in
     this->m_stateMachine_smStateStateToState.init(SmId::smStateStateToState);
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-SmStateActiveComponentBase ::SmStateActiveComponentBase(const char* compName)
-    : Fw::ActiveComponentBase(compName),
+  SmStateActiveComponentBase ::
+    SmStateActiveComponentBase(const char* compName) :
+      Fw::ActiveComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_smStateBasic1(*this),
@@ -683,775 +1014,998 @@ SmStateActiveComponentBase ::SmStateActiveComponentBase(const char* compName)
       m_stateMachine_smStateStateToChild(*this),
       m_stateMachine_smStateStateToChoice(*this),
       m_stateMachine_smStateStateToSelf(*this),
-      m_stateMachine_smStateStateToState(*this) {}
+      m_stateMachine_smStateStateToState(*this)
+  {
 
-SmStateActiveComponentBase ::~SmStateActiveComponentBase() {}
+  }
 
-// ----------------------------------------------------------------------
-// State getter functions
-// ----------------------------------------------------------------------
+  SmStateActiveComponentBase ::
+    ~SmStateActiveComponentBase()
+  {
 
-SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::basic1_getState() const {
+  }
+
+  // ----------------------------------------------------------------------
+  // State getter functions
+  // ----------------------------------------------------------------------
+
+  SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::
+    basic1_getState() const
+  {
     return this->m_stateMachine_basic1.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::basic2_getState() const {
+  SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::
+    basic2_getState() const
+  {
     return this->m_stateMachine_basic2.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::smStateBasic1_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::
+    smStateBasic1_getState() const
+  {
     return this->m_stateMachine_smStateBasic1.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::smStateBasic2_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::
+    smStateBasic2_getState() const
+  {
     return this->m_stateMachine_smStateBasic2.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuard::State SmStateActiveComponentBase ::smStateBasicGuard_getState()
-    const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuard::State SmStateActiveComponentBase ::
+    smStateBasicGuard_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuard.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardString::State
-SmStateActiveComponentBase ::smStateBasicGuardString_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardString::State SmStateActiveComponentBase ::
+    smStateBasicGuardString_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardString.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType::State
-SmStateActiveComponentBase ::smStateBasicGuardTestAbsType_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType::State SmStateActiveComponentBase ::
+    smStateBasicGuardTestAbsType_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestAbsType.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray::State
-SmStateActiveComponentBase ::smStateBasicGuardTestArray_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray::State SmStateActiveComponentBase ::
+    smStateBasicGuardTestArray_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestArray.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum::State
-SmStateActiveComponentBase ::smStateBasicGuardTestEnum_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum::State SmStateActiveComponentBase ::
+    smStateBasicGuardTestEnum_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestEnum.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct::State
-SmStateActiveComponentBase ::smStateBasicGuardTestStruct_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct::State SmStateActiveComponentBase ::
+    smStateBasicGuardTestStruct_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestStruct.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32::State
-SmStateActiveComponentBase ::smStateBasicGuardU32_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32::State SmStateActiveComponentBase ::
+    smStateBasicGuardU32_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardU32.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicInternal::State
-SmStateActiveComponentBase ::smStateBasicInternal_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicInternal::State SmStateActiveComponentBase ::
+    smStateBasicInternal_getState() const
+  {
     return this->m_stateMachine_smStateBasicInternal.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicSelf::State SmStateActiveComponentBase ::smStateBasicSelf_getState()
-    const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicSelf::State SmStateActiveComponentBase ::
+    smStateBasicSelf_getState() const
+  {
     return this->m_stateMachine_smStateBasicSelf.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicString::State
-SmStateActiveComponentBase ::smStateBasicString_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicString::State SmStateActiveComponentBase ::
+    smStateBasicString_getState() const
+  {
     return this->m_stateMachine_smStateBasicString.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType::State
-SmStateActiveComponentBase ::smStateBasicTestAbsType_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType::State SmStateActiveComponentBase ::
+    smStateBasicTestAbsType_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestAbsType.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestArray::State
-SmStateActiveComponentBase ::smStateBasicTestArray_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestArray::State SmStateActiveComponentBase ::
+    smStateBasicTestArray_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestArray.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum::State
-SmStateActiveComponentBase ::smStateBasicTestEnum_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum::State SmStateActiveComponentBase ::
+    smStateBasicTestEnum_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestEnum.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct::State
-SmStateActiveComponentBase ::smStateBasicTestStruct_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct::State SmStateActiveComponentBase ::
+    smStateBasicTestStruct_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestStruct.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_BasicU32::State SmStateActiveComponentBase ::smStateBasicU32_getState()
-    const {
+  SmStateActiveComponentBase::FppTest_SmState_BasicU32::State SmStateActiveComponentBase ::
+    smStateBasicU32_getState() const
+  {
     return this->m_stateMachine_smStateBasicU32.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_Internal::State SmStateActiveComponentBase ::smStateInternal_getState()
-    const {
+  SmStateActiveComponentBase::FppTest_SmState_Internal::State SmStateActiveComponentBase ::
+    smStateInternal_getState() const
+  {
     return this->m_stateMachine_smStateInternal.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_Polymorphism::State
-SmStateActiveComponentBase ::smStatePolymorphism_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_Polymorphism::State SmStateActiveComponentBase ::
+    smStatePolymorphism_getState() const
+  {
     return this->m_stateMachine_smStatePolymorphism.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToChild::State
-SmStateActiveComponentBase ::smStateStateToChild_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_StateToChild::State SmStateActiveComponentBase ::
+    smStateStateToChild_getState() const
+  {
     return this->m_stateMachine_smStateStateToChild.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToChoice::State
-SmStateActiveComponentBase ::smStateStateToChoice_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_StateToChoice::State SmStateActiveComponentBase ::
+    smStateStateToChoice_getState() const
+  {
     return this->m_stateMachine_smStateStateToChoice.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToSelf::State
-SmStateActiveComponentBase ::smStateStateToSelf_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_StateToSelf::State SmStateActiveComponentBase ::
+    smStateStateToSelf_getState() const
+  {
     return this->m_stateMachine_smStateStateToSelf.getState();
-}
+  }
 
-SmStateActiveComponentBase::FppTest_SmState_StateToState::State
-SmStateActiveComponentBase ::smStateStateToState_getState() const {
+  SmStateActiveComponentBase::FppTest_SmState_StateToState::State SmStateActiveComponentBase ::
+    smStateStateToState_getState() const
+  {
     return this->m_stateMachine_smStateStateToState.getState();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Signal send functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Signal send functions
+  // ----------------------------------------------------------------------
 
-void SmStateActiveComponentBase ::basic1_sendSignal_s() {
+  void SmStateActiveComponentBase ::
+    basic1_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic1, static_cast<FwEnumStoreType>(FppTest_SmStateActive_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic1_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::basic2_sendSignal_s() {
+  void SmStateActiveComponentBase ::
+    basic2_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic2, static_cast<FwEnumStoreType>(FppTest_SmStateActive_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic2_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasic1_sendSignal_s() {
+  void SmStateActiveComponentBase ::
+    smStateBasic1_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic1, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic1_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasic2_sendSignal_s() {
+  void SmStateActiveComponentBase ::
+    smStateBasic2_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic2, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic2_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuard_sendSignal_s() {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuard_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicGuard_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardString,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardString_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestAbsType_sendSignal_s(
-    const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestAbsType_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestArray,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestArray_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestEnum,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestEnum_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestStruct_sendSignal_s(
-    const FppTest::SmHarness::TestStruct& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestStruct,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestStruct_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardU32_sendSignal_s(U32 value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardU32,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardU32_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicInternal_sendSignal_s() {
+  void SmStateActiveComponentBase ::
+    smStateBasicInternal_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicInternal,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicInternal, static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicInternal_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicSelf_sendSignal_s() {
+  void SmStateActiveComponentBase ::
+    smStateBasicSelf_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicSelf_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicString_sendSignal_s(const Fw::StringBase& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicString_sendSignal_s(const Fw::StringBase& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 200);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicString_sendSignal_s1(const Fw::StringBase& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicString_sendSignal_s1(const Fw::StringBase& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 100);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestAbsType,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestAbsType_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestArray,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestArray_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestEnum,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestEnum_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestStruct,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestStruct_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateBasicU32_sendSignal_s(U32 value) {
+  void SmStateActiveComponentBase ::
+    smStateBasicU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicU32_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateInternal_sendSignal_S1_internal() {
+  void SmStateActiveComponentBase ::
+    smStateInternal_sendSignal_S1_internal()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
+    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateInternal_sendSignal_S2_to_S3() {
+  void SmStateActiveComponentBase ::
+    smStateInternal_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStatePolymorphism_sendSignal_poly() {
+  void SmStateActiveComponentBase ::
+    smStatePolymorphism_sendSignal_poly()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStatePolymorphism_sendSignal_S2_to_S3() {
+  void SmStateActiveComponentBase ::
+    smStatePolymorphism_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToChild_sendSignal_S1_to_S2() {
+  void SmStateActiveComponentBase ::
+    smStateStateToChild_sendSignal_S1_to_S2()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToChild_sendSignal_S2_to_S3() {
+  void SmStateActiveComponentBase ::
+    smStateStateToChild_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToChoice_sendSignal_S1_to_S4() {
+  void SmStateActiveComponentBase ::
+    smStateStateToChoice_sendSignal_S1_to_S4()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToChoice_sendSignal_S1_to_C() {
+  void SmStateActiveComponentBase ::
+    smStateStateToChoice_sendSignal_S1_to_C()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToChoice_sendSignal_S2_to_S3() {
+  void SmStateActiveComponentBase ::
+    smStateStateToChoice_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToSelf_sendSignal_S1_to_S1() {
+  void SmStateActiveComponentBase ::
+    smStateStateToSelf_sendSignal_S1_to_S1()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToSelf_sendSignal_S2_to_S3() {
+  void SmStateActiveComponentBase ::
+    smStateStateToSelf_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToState_sendSignal_S1_to_S4() {
+  void SmStateActiveComponentBase ::
+    smStateStateToState_sendSignal_S1_to_S4()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToState_sendSignal_S1_to_S5() {
+  void SmStateActiveComponentBase ::
+    smStateStateToState_sendSignal_S1_to_S5()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
+    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateActiveComponentBase ::smStateStateToState_sendSignal_S2_to_S3() {
+  void SmStateActiveComponentBase ::
+    smStateStateToState_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmStateActiveComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmStateActiveComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
-    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::BLOCKING,
+      _priority
+    );
+    FW_ASSERT(
+      _msgStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(_msgStatus)
+    );
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMSTATEACTIVE_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle signals to internal state machines
-        case INTERNAL_STATE_MACHINE_SIGNAL:
-            this->smDispatch(_msg);
-            break;
 
-        default:
-            return MSG_DISPATCH_ERROR;
+      // Handle signals to internal state machines
+      case INTERNAL_STATE_MACHINE_SIGNAL:
+        this->smDispatch(_msg);
+        break;
+
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Send signal helper functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Send signal helper functions
+  // ----------------------------------------------------------------------
 
-void SmStateActiveComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    sendSignalStart(
+        SmId smId,
+        FwEnumStoreType signal,
+        Fw::SerialBufferBase& buffer
+    )
+  {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmStateActiveComponentBase ::basic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    basic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::basic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    basic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        // Deserialize the state machine ID and signal
-        FwEnumStoreType smId;
-        FwEnumStoreType signal;
-        SmStateActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Call the overflow hook
-        this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+      // Deserialize the state machine ID and signal
+      FwEnumStoreType smId;
+      FwEnumStoreType signal;
+      SmStateActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Continue execution
-        return;
+      // Call the overflow hook
+      this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+
+      // Continue execution
+      return;
+
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateActiveComponentBase ::smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for state machine dispatch
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for state machine dispatch
+  // ----------------------------------------------------------------------
 
-void SmStateActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
+  void SmStateActiveComponentBase ::
+    smDispatch(Fw::SerialBufferBase& buffer)
+  {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -1460,170 +2014,147 @@ void SmStateActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-        case SmId::basic1: {
-            const FppTest_SmStateActive_Basic::Signal signal =
-                static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
-            this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-            break;
-        }
-        case SmId::basic2: {
-            const FppTest_SmStateActive_Basic::Signal signal =
-                static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
-            this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-            break;
-        }
-        case SmId::smStateBasic1: {
-            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
-            break;
-        }
-        case SmId::smStateBasic2: {
-            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
-            break;
-        }
-        case SmId::smStateBasicGuard: {
-            const FppTest_SmState_BasicGuard::Signal signal =
-                static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardString: {
-            const FppTest_SmState_BasicGuardString::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString,
-                                                              signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestAbsType: {
-            const FppTest_SmState_BasicGuardTestAbsType::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(
-                buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestArray: {
-            const FppTest_SmState_BasicGuardTestArray::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestArray_smDispatch(
-                buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestEnum: {
-            const FppTest_SmState_BasicGuardTestEnum::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum,
-                                                                signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestStruct: {
-            const FppTest_SmState_BasicGuardTestStruct::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestStruct_smDispatch(
-                buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardU32: {
-            const FppTest_SmState_BasicGuardU32::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
-            break;
-        }
-        case SmId::smStateBasicInternal: {
-            const FppTest_SmState_BasicInternal::Signal signal =
-                static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
-            this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
-            break;
-        }
-        case SmId::smStateBasicSelf: {
-            const FppTest_SmState_BasicSelf::Signal signal =
-                static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
-            this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
-            break;
-        }
-        case SmId::smStateBasicString: {
-            const FppTest_SmState_BasicString::Signal signal =
-                static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
-            this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
-            break;
-        }
-        case SmId::smStateBasicTestAbsType: {
-            const FppTest_SmState_BasicTestAbsType::Signal signal =
-                static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType,
-                                                              signal);
-            break;
-        }
-        case SmId::smStateBasicTestArray: {
-            const FppTest_SmState_BasicTestArray::Signal signal =
-                static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
-            break;
-        }
-        case SmId::smStateBasicTestEnum: {
-            const FppTest_SmState_BasicTestEnum::Signal signal =
-                static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
-            break;
-        }
-        case SmId::smStateBasicTestStruct: {
-            const FppTest_SmState_BasicTestStruct::Signal signal =
-                static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct,
-                                                             signal);
-            break;
-        }
-        case SmId::smStateBasicU32: {
-            const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
-            this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
-            break;
-        }
-        case SmId::smStateInternal: {
-            const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
-            this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
-            break;
-        }
-        case SmId::smStatePolymorphism: {
-            const FppTest_SmState_Polymorphism::Signal signal =
-                static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
-            this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
-            break;
-        }
-        case SmId::smStateStateToChild: {
-            const FppTest_SmState_StateToChild::Signal signal =
-                static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
-            this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
-            break;
-        }
-        case SmId::smStateStateToChoice: {
-            const FppTest_SmState_StateToChoice::Signal signal =
-                static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
-            this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
-            break;
-        }
-        case SmId::smStateStateToSelf: {
-            const FppTest_SmState_StateToSelf::Signal signal =
-                static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
-            this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
-            break;
-        }
-        case SmId::smStateStateToState: {
-            const FppTest_SmState_StateToState::Signal signal =
-                static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
-            this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-            break;
+      case SmId::basic1: {
+        const FppTest_SmStateActive_Basic::Signal signal = static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
+        this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+        break;
+      }
+      case SmId::basic2: {
+        const FppTest_SmStateActive_Basic::Signal signal = static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
+        this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+        break;
+      }
+      case SmId::smStateBasic1: {
+        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
+        break;
+      }
+      case SmId::smStateBasic2: {
+        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
+        break;
+      }
+      case SmId::smStateBasicGuard: {
+        const FppTest_SmState_BasicGuard::Signal signal = static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardString: {
+        const FppTest_SmState_BasicGuardString::Signal signal = static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestAbsType: {
+        const FppTest_SmState_BasicGuardTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestArray: {
+        const FppTest_SmState_BasicGuardTestArray::Signal signal = static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestEnum: {
+        const FppTest_SmState_BasicGuardTestEnum::Signal signal = static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestStruct: {
+        const FppTest_SmState_BasicGuardTestStruct::Signal signal = static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardU32: {
+        const FppTest_SmState_BasicGuardU32::Signal signal = static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
+        break;
+      }
+      case SmId::smStateBasicInternal: {
+        const FppTest_SmState_BasicInternal::Signal signal = static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
+        this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
+        break;
+      }
+      case SmId::smStateBasicSelf: {
+        const FppTest_SmState_BasicSelf::Signal signal = static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
+        this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
+        break;
+      }
+      case SmId::smStateBasicString: {
+        const FppTest_SmState_BasicString::Signal signal = static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
+        this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
+        break;
+      }
+      case SmId::smStateBasicTestAbsType: {
+        const FppTest_SmState_BasicTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType, signal);
+        break;
+      }
+      case SmId::smStateBasicTestArray: {
+        const FppTest_SmState_BasicTestArray::Signal signal = static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
+        break;
+      }
+      case SmId::smStateBasicTestEnum: {
+        const FppTest_SmState_BasicTestEnum::Signal signal = static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
+        break;
+      }
+      case SmId::smStateBasicTestStruct: {
+        const FppTest_SmState_BasicTestStruct::Signal signal = static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct, signal);
+        break;
+      }
+      case SmId::smStateBasicU32: {
+        const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
+        this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
+        break;
+      }
+      case SmId::smStateInternal: {
+        const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
+        this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
+        break;
+      }
+      case SmId::smStatePolymorphism: {
+        const FppTest_SmState_Polymorphism::Signal signal = static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
+        this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
+        break;
+      }
+      case SmId::smStateStateToChild: {
+        const FppTest_SmState_StateToChild::Signal signal = static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
+        this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
+        break;
+      }
+      case SmId::smStateStateToChoice: {
+        const FppTest_SmState_StateToChoice::Signal signal = static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
+        this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
+        break;
+      }
+      case SmId::smStateStateToSelf: {
+        const FppTest_SmState_StateToSelf::Signal signal = static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
+        this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
+        break;
+      }
+      case SmId::smStateStateToState: {
+        const FppTest_SmState_StateToState::Signal signal = static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
+        this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
-                                                           FwEnumStoreType& smId,
-                                                           FwEnumStoreType& signal) {
+  void SmStateActiveComponentBase ::
+    deserializeSmIdAndSignal(
+        Fw::SerialBufferBase& buffer,
+        FwEnumStoreType& smId,
+        FwEnumStoreType& signal
+    )
+  {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status =
+      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -1633,560 +2164,607 @@ void SmStateActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase&
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                   FppTest_SmState_Basic& sm,
-                                                                   FppTest_SmState_Basic::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_Basic& sm,
+        FppTest_SmState_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicGuard_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmState_BasicGuard& sm,
-                                                                        FppTest_SmState_BasicGuard::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicGuard_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuard& sm,
+        FppTest_SmState_BasicGuard::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuard::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuard::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardString_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardString& sm,
-    FppTest_SmState_BasicGuardString::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicGuardString_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardString& sm,
+        FppTest_SmState_BasicGuardString::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardString::Signal::s: {
-            // Deserialize the data
-            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardString::Signal::s: {
+        // Deserialize the data
+        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestAbsType_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestAbsType& sm,
-    FppTest_SmState_BasicGuardTestAbsType::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicGuardTestAbsType_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestAbsType& sm,
+        FppTest_SmState_BasicGuardTestAbsType::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestAbsType value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestAbsType value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestArray_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestArray& sm,
-    FppTest_SmState_BasicGuardTestArray::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicGuardTestArray_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestArray& sm,
+        FppTest_SmState_BasicGuardTestArray::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestArray::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestArray value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestArray::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestArray value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestEnum_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestEnum& sm,
-    FppTest_SmState_BasicGuardTestEnum::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicGuardTestEnum_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestEnum& sm,
+        FppTest_SmState_BasicGuardTestEnum::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestEnum value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestEnum value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestStruct_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestStruct& sm,
-    FppTest_SmState_BasicGuardTestStruct::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicGuardTestStruct_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestStruct& sm,
+        FppTest_SmState_BasicGuardTestStruct::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestStruct value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestStruct value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardU32_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardU32& sm,
-    FppTest_SmState_BasicGuardU32::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicGuardU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardU32& sm,
+        FppTest_SmState_BasicGuardU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicInternal_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicInternal& sm,
-    FppTest_SmState_BasicInternal::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicInternal_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicInternal& sm,
+        FppTest_SmState_BasicInternal::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicInternal::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicInternal::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicSelf_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                       FppTest_SmState_BasicSelf& sm,
-                                                                       FppTest_SmState_BasicSelf::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicSelf_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicSelf& sm,
+        FppTest_SmState_BasicSelf::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicSelf::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicSelf::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicString_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                         FppTest_SmState_BasicString& sm,
-                                                                         FppTest_SmState_BasicString::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicString_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicString& sm,
+        FppTest_SmState_BasicString::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicString::Signal::s: {
-            // Deserialize the data
-            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
-            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        case FppTest_SmState_BasicString::Signal::s1: {
-            // Deserialize the data
-            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
-            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s1
-            sm.sendSignal_s1(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicString::Signal::s: {
+        // Deserialize the data
+        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
+        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      case FppTest_SmState_BasicString::Signal::s1: {
+        // Deserialize the data
+        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
+        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s1
+        sm.sendSignal_s1(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicTestAbsType_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestAbsType& sm,
-    FppTest_SmState_BasicTestAbsType::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicTestAbsType_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestAbsType& sm,
+        FppTest_SmState_BasicTestAbsType::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestAbsType::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestAbsType value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestAbsType::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestAbsType value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicTestArray_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestArray& sm,
-    FppTest_SmState_BasicTestArray::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicTestArray_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestArray& sm,
+        FppTest_SmState_BasicTestArray::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestArray::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestArray value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestArray::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestArray value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicTestEnum_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestEnum& sm,
-    FppTest_SmState_BasicTestEnum::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicTestEnum_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestEnum& sm,
+        FppTest_SmState_BasicTestEnum::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestEnum::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestEnum value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestEnum::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestEnum value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicTestStruct_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestStruct& sm,
-    FppTest_SmState_BasicTestStruct::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicTestStruct_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestStruct& sm,
+        FppTest_SmState_BasicTestStruct::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestStruct::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestStruct value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestStruct::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestStruct value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                      FppTest_SmState_BasicU32& sm,
-                                                                      FppTest_SmState_BasicU32::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_BasicU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicU32& sm,
+        FppTest_SmState_BasicU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_Internal_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                      FppTest_SmState_Internal& sm,
-                                                                      FppTest_SmState_Internal::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_Internal_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_Internal& sm,
+        FppTest_SmState_Internal::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_Internal::Signal::S1_internal: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_internal
-            sm.sendSignal_S1_internal();
-            break;
-        }
-        case FppTest_SmState_Internal::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_Internal::Signal::S1_internal: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_internal
+        sm.sendSignal_S1_internal();
+        break;
+      }
+      case FppTest_SmState_Internal::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_Polymorphism_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                          FppTest_SmState_Polymorphism& sm,
-                                                                          FppTest_SmState_Polymorphism::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_Polymorphism_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_Polymorphism& sm,
+        FppTest_SmState_Polymorphism::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_Polymorphism::Signal::poly: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and poly
-            sm.sendSignal_poly();
-            break;
-        }
-        case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_Polymorphism::Signal::poly: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and poly
+        sm.sendSignal_poly();
+        break;
+      }
+      case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_StateToChild_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                          FppTest_SmState_StateToChild& sm,
-                                                                          FppTest_SmState_StateToChild::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_StateToChild_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToChild& sm,
+        FppTest_SmState_StateToChild::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S2
-            sm.sendSignal_S1_to_S2();
-            break;
-        }
-        case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S2
+        sm.sendSignal_S1_to_S2();
+        break;
+      }
+      case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_StateToChoice_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_StateToChoice& sm,
-    FppTest_SmState_StateToChoice::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_StateToChoice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToChoice& sm,
+        FppTest_SmState_StateToChoice::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S4
-            sm.sendSignal_S1_to_S4();
-            break;
-        }
-        case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_C
-            sm.sendSignal_S1_to_C();
-            break;
-        }
-        case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S4
+        sm.sendSignal_S1_to_S4();
+        break;
+      }
+      case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_C
+        sm.sendSignal_S1_to_C();
+        break;
+      }
+      case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_StateToSelf_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                         FppTest_SmState_StateToSelf& sm,
-                                                                         FppTest_SmState_StateToSelf::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_StateToSelf_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToSelf& sm,
+        FppTest_SmState_StateToSelf::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S1
-            sm.sendSignal_S1_to_S1();
-            break;
-        }
-        case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S1
+        sm.sendSignal_S1_to_S1();
+        break;
+      }
+      case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmState_StateToState_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                          FppTest_SmState_StateToState& sm,
-                                                                          FppTest_SmState_StateToState::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmState_StateToState_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToState& sm,
+        FppTest_SmState_StateToState::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToState::Signal::S1_to_S4: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S4
-            sm.sendSignal_S1_to_S4();
-            break;
-        }
-        case FppTest_SmState_StateToState::Signal::S1_to_S5: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S5
-            sm.sendSignal_S1_to_S5();
-            break;
-        }
-        case FppTest_SmState_StateToState::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToState::Signal::S1_to_S4: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S4
+        sm.sendSignal_S1_to_S4();
+        break;
+      }
+      case FppTest_SmState_StateToState::Signal::S1_to_S5: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S5
+        sm.sendSignal_S1_to_S5();
+        break;
+      }
+      case FppTest_SmState_StateToState::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateActiveComponentBase ::FppTest_SmStateActive_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                         FppTest_SmStateActive_Basic& sm,
-                                                                         FppTest_SmStateActive_Basic::Signal signal) {
+  void SmStateActiveComponentBase ::
+    FppTest_SmStateActive_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmStateActive_Basic& sm,
+        FppTest_SmStateActive_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmStateActive_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmStateActive_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-}  // namespace FppTest
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
@@ -13,942 +13,610 @@
 
 namespace FppTest {
 
-  namespace {
+namespace {
 
-    // Constant definitions for the state machine signal buffer
-    namespace SmSignalBuffer {
+// Constant definitions for the state machine signal buffer
+namespace SmSignalBuffer {
 
-      // Union for computing the max size of a signal type
-      union SignalTypeUnion {
-        BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
-        BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
-        BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
-        BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
-        BYTE size_of_U32[sizeof(U32)];
-        BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
-      };
+// Union for computing the max size of a signal type
+union SignalTypeUnion {
+    BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
+    BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
+    BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
+    BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
+    BYTE size_of_U32[sizeof(U32)];
+    BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(
+        FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
+};
 
-      // The serialized size
-      static constexpr FwSizeType SERIALIZED_SIZE =
-        2 * sizeof(FwEnumStoreType) +
-        sizeof(SignalTypeUnion);
+// The serialized size
+static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
 
+}  // namespace SmSignalBuffer
+
+enum MsgTypeEnum {
+    SMSTATEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    INTERNAL_STATE_MACHINE_SIGNAL,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    // Size of buffer for internal state machine signals
+    // The internal SmSignalBuffer stores the state machine id, the
+    // signal id, and the signal data
+    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+    };
+
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
     }
 
-    enum MsgTypeEnum {
-      SMSTATEACTIVE_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      INTERNAL_STATE_MACHINE_SIGNAL,
-    };
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      // Size of buffer for internal state machine signals
-      // The internal SmSignalBuffer stores the state machine id, the
-      // signal id, and the signal data
-      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-    };
+// ----------------------------------------------------------------------
+// Types for internal state machines
+// ----------------------------------------------------------------------
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+SmStateActiveComponentBase::FppTest_SmState_Basic ::FppTest_SmState_Basic(SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-      public:
-
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
-
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
-
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Types for internal state machines
-  // ----------------------------------------------------------------------
-
-  SmStateActiveComponentBase::FppTest_SmState_Basic ::
-    FppTest_SmState_Basic(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
-
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_Basic ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_Basic ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Basic ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Basic ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_Basic ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
-    FppTest_SmState_BasicGuard(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::FppTest_SmState_BasicGuard(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicGuard_action_a(this->getId(), signal);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::
-    guard_g(Signal signal) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_BasicGuard ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmState_BasicGuard_guard_g(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
-    FppTest_SmState_BasicGuardString(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::FppTest_SmState_BasicGuardString(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
-    action_a(
-        Signal signal,
-        const Fw::StringBase& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::action_a(Signal signal,
+                                                                             const Fw::StringBase& value) {
     this->m_component.FppTest_SmState_BasicGuardString_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::
-    guard_g(
-        Signal signal,
-        const Fw::StringBase& value
-    ) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardString ::guard_g(Signal signal,
+                                                                            const Fw::StringBase& value) const {
     return this->m_component.FppTest_SmState_BasicGuardString_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    FppTest_SmState_BasicGuardTestAbsType(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::FppTest_SmState_BasicGuardTestAbsType(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestAbsType& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestAbsType& value) {
     this->m_component.FppTest_SmState_BasicGuardTestAbsType_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestAbsType& value
-    ) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestAbsType& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestAbsType_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    FppTest_SmState_BasicGuardTestArray(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::FppTest_SmState_BasicGuardTestArray(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestArray& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestArray& value) {
     this->m_component.FppTest_SmState_BasicGuardTestArray_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestArray& value
-    ) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestArray& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestArray_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    FppTest_SmState_BasicGuardTestEnum(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::FppTest_SmState_BasicGuardTestEnum(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestEnum& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestEnum& value) {
     this->m_component.FppTest_SmState_BasicGuardTestEnum_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestEnum& value
-    ) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestEnum& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestEnum_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    FppTest_SmState_BasicGuardTestStruct(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::FppTest_SmState_BasicGuardTestStruct(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestStruct& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestStruct& value) {
     this->m_component.FppTest_SmState_BasicGuardTestStruct_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestStruct& value
-    ) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestStruct& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestStruct_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
-    FppTest_SmState_BasicGuardU32(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::FppTest_SmState_BasicGuardU32(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmState_BasicGuardU32_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::
-    guard_g(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32 ::guard_g(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmState_BasicGuardU32_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
-    FppTest_SmState_BasicInternal(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::FppTest_SmState_BasicInternal(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicInternal ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicInternal_action_a(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
-    FppTest_SmState_BasicSelf(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::FppTest_SmState_BasicSelf(SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicSelf ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicSelf_action_a(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicString ::
-    FppTest_SmState_BasicString(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicString ::FppTest_SmState_BasicString(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicString ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicString ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicString ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicString ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicString ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicString ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicString_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicString ::
-    action_b(
-        Signal signal,
-        const Fw::StringBase& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicString ::action_b(Signal signal, const Fw::StringBase& value) {
     this->m_component.FppTest_SmState_BasicString_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
-    FppTest_SmState_BasicTestAbsType(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::FppTest_SmState_BasicTestAbsType(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestAbsType& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType ::action_b(
+    Signal signal,
+    const FppTest::SmHarness::TestAbsType& value) {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
-    FppTest_SmState_BasicTestArray(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::FppTest_SmState_BasicTestArray(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestArray_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestArray& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestArray ::action_b(Signal signal,
+                                                                           const FppTest::SmHarness::TestArray& value) {
     this->m_component.FppTest_SmState_BasicTestArray_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
-    FppTest_SmState_BasicTestEnum(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::FppTest_SmState_BasicTestEnum(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestEnum_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestEnum& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum ::action_b(Signal signal,
+                                                                          const FppTest::SmHarness::TestEnum& value) {
     this->m_component.FppTest_SmState_BasicTestEnum_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
-    FppTest_SmState_BasicTestStruct(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::FppTest_SmState_BasicTestStruct(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestStruct_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestStruct& value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct ::action_b(
+    Signal signal,
+    const FppTest::SmHarness::TestStruct& value) {
     this->m_component.FppTest_SmState_BasicTestStruct_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
-    FppTest_SmState_BasicU32(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::FppTest_SmState_BasicU32(SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicU32_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::
-    action_b(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmStateActiveComponentBase::FppTest_SmState_BasicU32 ::action_b(Signal signal, U32 value) {
     this->m_component.FppTest_SmState_BasicU32_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_Internal ::
-    FppTest_SmState_Internal(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_Internal ::FppTest_SmState_Internal(SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_Internal ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_Internal ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Internal ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Internal ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_Internal ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_Internal ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_Internal_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_Polymorphism ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    FppTest_SmState_StateToChild(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToChild ::FppTest_SmState_StateToChild(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChild ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    action_exitS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    action_exitS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    action_enterS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::
-    action_enterS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChild ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_enterS3(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    FppTest_SmState_StateToChoice(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::FppTest_SmState_StateToChoice(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_exitS1(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_exitS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_exitS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS1(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS1(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS3(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS4(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::action_enterS4(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS4(this->getId(), signal);
-  }
+}
 
-  bool SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::
-    guard_g(Signal signal) const
-  {
+bool SmStateActiveComponentBase::FppTest_SmState_StateToChoice ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmState_StateToChoice_guard_g(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    FppTest_SmState_StateToSelf(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::FppTest_SmState_StateToSelf(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    action_exitS1(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    action_exitS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    action_exitS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    action_enterS1(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_enterS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS1(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    action_enterS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::
-    action_enterS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToSelf ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS3(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    FppTest_SmState_StateToState(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToState ::FppTest_SmState_StateToState(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmState_StateToState ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_exitS1(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_exitS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_exitS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_enterS1(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS1(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_enterS2(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_enterS3(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS3(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_enterS4(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS4(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS4(this->getId(), signal);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmState_StateToState ::
-    action_enterS5(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmState_StateToState ::action_enterS5(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS5(this->getId(), signal);
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
-    FppTest_SmStateActive_Basic(SmStateActiveComponentBase& component) :
-      m_component(component)
-  {
+SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::FppTest_SmStateActive_Basic(
+    SmStateActiveComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
-    init(SmStateActiveComponentBase::SmId smId)
-  {
+void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::init(SmStateActiveComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
-    getId() const
-  {
+SmStateActiveComponentBase::SmId SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::getId() const {
     return static_cast<SmStateActiveComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::
-    action_a(Signal signal)
-  {
+void SmStateActiveComponentBase::FppTest_SmStateActive_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmStateActive_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
 
-  void SmStateActiveComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+void SmStateActiveComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::ActiveComponentBase::init(instance);
 
@@ -980,23 +648,17 @@ namespace FppTest {
     this->m_stateMachine_smStateStateToState.init(SmId::smStateStateToState);
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  SmStateActiveComponentBase ::
-    SmStateActiveComponentBase(const char* compName) :
-      Fw::ActiveComponentBase(compName),
+SmStateActiveComponentBase ::SmStateActiveComponentBase(const char* compName)
+    : Fw::ActiveComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_smStateBasic1(*this),
@@ -1021,998 +683,775 @@ namespace FppTest {
       m_stateMachine_smStateStateToChild(*this),
       m_stateMachine_smStateStateToChoice(*this),
       m_stateMachine_smStateStateToSelf(*this),
-      m_stateMachine_smStateStateToState(*this)
-  {
+      m_stateMachine_smStateStateToState(*this) {}
 
-  }
+SmStateActiveComponentBase ::~SmStateActiveComponentBase() {}
 
-  SmStateActiveComponentBase ::
-    ~SmStateActiveComponentBase()
-  {
+// ----------------------------------------------------------------------
+// State getter functions
+// ----------------------------------------------------------------------
 
-  }
-
-  // ----------------------------------------------------------------------
-  // State getter functions
-  // ----------------------------------------------------------------------
-
-  SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::
-    basic1_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::basic1_getState() const {
     return this->m_stateMachine_basic1.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::
-    basic2_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmStateActive_Basic::State SmStateActiveComponentBase ::basic2_getState() const {
     return this->m_stateMachine_basic2.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::
-    smStateBasic1_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::smStateBasic1_getState() const {
     return this->m_stateMachine_smStateBasic1.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::
-    smStateBasic2_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_Basic::State SmStateActiveComponentBase ::smStateBasic2_getState() const {
     return this->m_stateMachine_smStateBasic2.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuard::State SmStateActiveComponentBase ::
-    smStateBasicGuard_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuard::State SmStateActiveComponentBase ::smStateBasicGuard_getState()
+    const {
     return this->m_stateMachine_smStateBasicGuard.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardString::State SmStateActiveComponentBase ::
-    smStateBasicGuardString_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardString::State
+SmStateActiveComponentBase ::smStateBasicGuardString_getState() const {
     return this->m_stateMachine_smStateBasicGuardString.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType::State SmStateActiveComponentBase ::
-    smStateBasicGuardTestAbsType_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestAbsType::State
+SmStateActiveComponentBase ::smStateBasicGuardTestAbsType_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestAbsType.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray::State SmStateActiveComponentBase ::
-    smStateBasicGuardTestArray_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestArray::State
+SmStateActiveComponentBase ::smStateBasicGuardTestArray_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestArray.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum::State SmStateActiveComponentBase ::
-    smStateBasicGuardTestEnum_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestEnum::State
+SmStateActiveComponentBase ::smStateBasicGuardTestEnum_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestEnum.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct::State SmStateActiveComponentBase ::
-    smStateBasicGuardTestStruct_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardTestStruct::State
+SmStateActiveComponentBase ::smStateBasicGuardTestStruct_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestStruct.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32::State SmStateActiveComponentBase ::
-    smStateBasicGuardU32_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicGuardU32::State
+SmStateActiveComponentBase ::smStateBasicGuardU32_getState() const {
     return this->m_stateMachine_smStateBasicGuardU32.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicInternal::State SmStateActiveComponentBase ::
-    smStateBasicInternal_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicInternal::State
+SmStateActiveComponentBase ::smStateBasicInternal_getState() const {
     return this->m_stateMachine_smStateBasicInternal.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicSelf::State SmStateActiveComponentBase ::
-    smStateBasicSelf_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicSelf::State SmStateActiveComponentBase ::smStateBasicSelf_getState()
+    const {
     return this->m_stateMachine_smStateBasicSelf.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicString::State SmStateActiveComponentBase ::
-    smStateBasicString_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicString::State
+SmStateActiveComponentBase ::smStateBasicString_getState() const {
     return this->m_stateMachine_smStateBasicString.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType::State SmStateActiveComponentBase ::
-    smStateBasicTestAbsType_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestAbsType::State
+SmStateActiveComponentBase ::smStateBasicTestAbsType_getState() const {
     return this->m_stateMachine_smStateBasicTestAbsType.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestArray::State SmStateActiveComponentBase ::
-    smStateBasicTestArray_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestArray::State
+SmStateActiveComponentBase ::smStateBasicTestArray_getState() const {
     return this->m_stateMachine_smStateBasicTestArray.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum::State SmStateActiveComponentBase ::
-    smStateBasicTestEnum_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestEnum::State
+SmStateActiveComponentBase ::smStateBasicTestEnum_getState() const {
     return this->m_stateMachine_smStateBasicTestEnum.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct::State SmStateActiveComponentBase ::
-    smStateBasicTestStruct_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicTestStruct::State
+SmStateActiveComponentBase ::smStateBasicTestStruct_getState() const {
     return this->m_stateMachine_smStateBasicTestStruct.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_BasicU32::State SmStateActiveComponentBase ::
-    smStateBasicU32_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_BasicU32::State SmStateActiveComponentBase ::smStateBasicU32_getState()
+    const {
     return this->m_stateMachine_smStateBasicU32.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_Internal::State SmStateActiveComponentBase ::
-    smStateInternal_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_Internal::State SmStateActiveComponentBase ::smStateInternal_getState()
+    const {
     return this->m_stateMachine_smStateInternal.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_Polymorphism::State SmStateActiveComponentBase ::
-    smStatePolymorphism_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_Polymorphism::State
+SmStateActiveComponentBase ::smStatePolymorphism_getState() const {
     return this->m_stateMachine_smStatePolymorphism.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToChild::State SmStateActiveComponentBase ::
-    smStateStateToChild_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToChild::State
+SmStateActiveComponentBase ::smStateStateToChild_getState() const {
     return this->m_stateMachine_smStateStateToChild.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToChoice::State SmStateActiveComponentBase ::
-    smStateStateToChoice_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToChoice::State
+SmStateActiveComponentBase ::smStateStateToChoice_getState() const {
     return this->m_stateMachine_smStateStateToChoice.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToSelf::State SmStateActiveComponentBase ::
-    smStateStateToSelf_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToSelf::State
+SmStateActiveComponentBase ::smStateStateToSelf_getState() const {
     return this->m_stateMachine_smStateStateToSelf.getState();
-  }
+}
 
-  SmStateActiveComponentBase::FppTest_SmState_StateToState::State SmStateActiveComponentBase ::
-    smStateStateToState_getState() const
-  {
+SmStateActiveComponentBase::FppTest_SmState_StateToState::State
+SmStateActiveComponentBase ::smStateStateToState_getState() const {
     return this->m_stateMachine_smStateStateToState.getState();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Signal send functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Signal send functions
+// ----------------------------------------------------------------------
 
-  void SmStateActiveComponentBase ::
-    basic1_sendSignal_s()
-  {
+void SmStateActiveComponentBase ::basic1_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic1, static_cast<FwEnumStoreType>(FppTest_SmStateActive_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic1_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    basic2_sendSignal_s()
-  {
+void SmStateActiveComponentBase ::basic2_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic2, static_cast<FwEnumStoreType>(FppTest_SmStateActive_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic2_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasic1_sendSignal_s()
-  {
+void SmStateActiveComponentBase ::smStateBasic1_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic1, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic1_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasic2_sendSignal_s()
-  {
+void SmStateActiveComponentBase ::smStateBasic2_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic2, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic2_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuard_sendSignal_s()
-  {
+void SmStateActiveComponentBase ::smStateBasicGuard_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s),
+                          buffer);
     // Send the message and handle overflow
     this->smStateBasicGuard_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardString,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardString_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestAbsType_sendSignal_s(
+    const FppTest::SmHarness::TestAbsType& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestAbsType_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestArray,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestArray_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestEnum,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestEnum_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestStruct_sendSignal_s(
+    const FppTest::SmHarness::TestStruct& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestStruct,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestStruct_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardU32_sendSignal_s(U32 value)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardU32,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardU32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicInternal_sendSignal_s()
-  {
+void SmStateActiveComponentBase ::smStateBasicInternal_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicInternal, static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicInternal,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicInternal_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicSelf_sendSignal_s()
-  {
+void SmStateActiveComponentBase ::smStateBasicSelf_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s),
+                          buffer);
     // Send the message and handle overflow
     this->smStateBasicSelf_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicString_sendSignal_s(const Fw::StringBase& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicString_sendSignal_s(const Fw::StringBase& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicString,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 200);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicString_sendSignal_s1(const Fw::StringBase& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicString_sendSignal_s1(const Fw::StringBase& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smStateBasicString,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 100);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestAbsType,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestAbsType_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestArray,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestArray_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestEnum,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestEnum_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestStruct,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestStruct_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicU32_sendSignal_s(U32 value)
-  {
+void SmStateActiveComponentBase ::smStateBasicU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s),
+                          buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicU32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateInternal_sendSignal_S1_internal()
-  {
+void SmStateActiveComponentBase ::smStateInternal_sendSignal_S1_internal() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
+    this->sendSignalStart(SmId::smStateInternal,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateInternal_sendSignal_S2_to_S3()
-  {
+void SmStateActiveComponentBase ::smStateInternal_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateInternal,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStatePolymorphism_sendSignal_poly()
-  {
+void SmStateActiveComponentBase ::smStatePolymorphism_sendSignal_poly() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStatePolymorphism_sendSignal_S2_to_S3()
-  {
+void SmStateActiveComponentBase ::smStatePolymorphism_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToChild_sendSignal_S1_to_S2()
-  {
+void SmStateActiveComponentBase ::smStateStateToChild_sendSignal_S1_to_S2() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToChild_sendSignal_S2_to_S3()
-  {
+void SmStateActiveComponentBase ::smStateStateToChild_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToChoice_sendSignal_S1_to_S4()
-  {
+void SmStateActiveComponentBase ::smStateStateToChoice_sendSignal_S1_to_S4() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToChoice_sendSignal_S1_to_C()
-  {
+void SmStateActiveComponentBase ::smStateStateToChoice_sendSignal_S1_to_C() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToChoice_sendSignal_S2_to_S3()
-  {
+void SmStateActiveComponentBase ::smStateStateToChoice_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToSelf_sendSignal_S1_to_S1()
-  {
+void SmStateActiveComponentBase ::smStateStateToSelf_sendSignal_S1_to_S1() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToSelf_sendSignal_S2_to_S3()
-  {
+void SmStateActiveComponentBase ::smStateStateToSelf_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToState_sendSignal_S1_to_S4()
-  {
+void SmStateActiveComponentBase ::smStateStateToState_sendSignal_S1_to_S4() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToState_sendSignal_S1_to_S5()
-  {
+void SmStateActiveComponentBase ::smStateStateToState_sendSignal_S1_to_S5() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
+    this->sendSignalStart(SmId::smStateStateToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToState_sendSignal_S2_to_S3()
-  {
+void SmStateActiveComponentBase ::smStateStateToState_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmStateActiveComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmStateActiveComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::BLOCKING,
-      _priority
-    );
-    FW_ASSERT(
-      _msgStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(_msgStatus)
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::BLOCKING, _priority);
+    FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
 
     // Reset to beginning of buffer
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMSTATEACTIVE_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
+        // Handle signals to internal state machines
+        case INTERNAL_STATE_MACHINE_SIGNAL:
+            this->smDispatch(_msg);
+            break;
 
-      // Handle signals to internal state machines
-      case INTERNAL_STATE_MACHINE_SIGNAL:
-        this->smDispatch(_msg);
-        break;
-
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Send signal helper functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Send signal helper functions
+// ----------------------------------------------------------------------
 
-  void SmStateActiveComponentBase ::
-    sendSignalStart(
-        SmId smId,
-        FwEnumStoreType signal,
-        Fw::SerialBufferBase& buffer
-    )
-  {
+void SmStateActiveComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    basic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::basic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    basic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::basic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
+        // Deserialize the state machine ID and signal
+        FwEnumStoreType smId;
+        FwEnumStoreType signal;
+        SmStateActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-      // Deserialize the state machine ID and signal
-      FwEnumStoreType smId;
-      FwEnumStoreType signal;
-      SmStateActiveComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
+        // Call the overflow hook
+        this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
 
-      // Call the overflow hook
-      this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
-
-      // Continue execution
-      return;
-
+        // Continue execution
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateActiveComponentBase ::
-    smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for state machine dispatch
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for state machine dispatch
+// ----------------------------------------------------------------------
 
-  void SmStateActiveComponentBase ::
-    smDispatch(Fw::SerialBufferBase& buffer)
-  {
+void SmStateActiveComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -2021,147 +1460,170 @@ namespace FppTest {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-      case SmId::basic1: {
-        const FppTest_SmStateActive_Basic::Signal signal = static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
-        this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-        break;
-      }
-      case SmId::basic2: {
-        const FppTest_SmStateActive_Basic::Signal signal = static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
-        this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-        break;
-      }
-      case SmId::smStateBasic1: {
-        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
-        break;
-      }
-      case SmId::smStateBasic2: {
-        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
-        break;
-      }
-      case SmId::smStateBasicGuard: {
-        const FppTest_SmState_BasicGuard::Signal signal = static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardString: {
-        const FppTest_SmState_BasicGuardString::Signal signal = static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestAbsType: {
-        const FppTest_SmState_BasicGuardTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestArray: {
-        const FppTest_SmState_BasicGuardTestArray::Signal signal = static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestEnum: {
-        const FppTest_SmState_BasicGuardTestEnum::Signal signal = static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestStruct: {
-        const FppTest_SmState_BasicGuardTestStruct::Signal signal = static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardU32: {
-        const FppTest_SmState_BasicGuardU32::Signal signal = static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
-        break;
-      }
-      case SmId::smStateBasicInternal: {
-        const FppTest_SmState_BasicInternal::Signal signal = static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
-        this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
-        break;
-      }
-      case SmId::smStateBasicSelf: {
-        const FppTest_SmState_BasicSelf::Signal signal = static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
-        this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
-        break;
-      }
-      case SmId::smStateBasicString: {
-        const FppTest_SmState_BasicString::Signal signal = static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
-        this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
-        break;
-      }
-      case SmId::smStateBasicTestAbsType: {
-        const FppTest_SmState_BasicTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType, signal);
-        break;
-      }
-      case SmId::smStateBasicTestArray: {
-        const FppTest_SmState_BasicTestArray::Signal signal = static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
-        break;
-      }
-      case SmId::smStateBasicTestEnum: {
-        const FppTest_SmState_BasicTestEnum::Signal signal = static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
-        break;
-      }
-      case SmId::smStateBasicTestStruct: {
-        const FppTest_SmState_BasicTestStruct::Signal signal = static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct, signal);
-        break;
-      }
-      case SmId::smStateBasicU32: {
-        const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
-        this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
-        break;
-      }
-      case SmId::smStateInternal: {
-        const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
-        this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
-        break;
-      }
-      case SmId::smStatePolymorphism: {
-        const FppTest_SmState_Polymorphism::Signal signal = static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
-        this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
-        break;
-      }
-      case SmId::smStateStateToChild: {
-        const FppTest_SmState_StateToChild::Signal signal = static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
-        this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
-        break;
-      }
-      case SmId::smStateStateToChoice: {
-        const FppTest_SmState_StateToChoice::Signal signal = static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
-        this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
-        break;
-      }
-      case SmId::smStateStateToSelf: {
-        const FppTest_SmState_StateToSelf::Signal signal = static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
-        this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
-        break;
-      }
-      case SmId::smStateStateToState: {
-        const FppTest_SmState_StateToState::Signal signal = static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
-        this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-        break;
+        case SmId::basic1: {
+            const FppTest_SmStateActive_Basic::Signal signal =
+                static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
+            this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+            break;
+        }
+        case SmId::basic2: {
+            const FppTest_SmStateActive_Basic::Signal signal =
+                static_cast<FppTest_SmStateActive_Basic::Signal>(storedSignal);
+            this->FppTest_SmStateActive_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+            break;
+        }
+        case SmId::smStateBasic1: {
+            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
+            break;
+        }
+        case SmId::smStateBasic2: {
+            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
+            break;
+        }
+        case SmId::smStateBasicGuard: {
+            const FppTest_SmState_BasicGuard::Signal signal =
+                static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardString: {
+            const FppTest_SmState_BasicGuardString::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString,
+                                                              signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestAbsType: {
+            const FppTest_SmState_BasicGuardTestAbsType::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(
+                buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestArray: {
+            const FppTest_SmState_BasicGuardTestArray::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestArray_smDispatch(
+                buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestEnum: {
+            const FppTest_SmState_BasicGuardTestEnum::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum,
+                                                                signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestStruct: {
+            const FppTest_SmState_BasicGuardTestStruct::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestStruct_smDispatch(
+                buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardU32: {
+            const FppTest_SmState_BasicGuardU32::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
+            break;
+        }
+        case SmId::smStateBasicInternal: {
+            const FppTest_SmState_BasicInternal::Signal signal =
+                static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
+            this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
+            break;
+        }
+        case SmId::smStateBasicSelf: {
+            const FppTest_SmState_BasicSelf::Signal signal =
+                static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
+            this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
+            break;
+        }
+        case SmId::smStateBasicString: {
+            const FppTest_SmState_BasicString::Signal signal =
+                static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
+            this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
+            break;
+        }
+        case SmId::smStateBasicTestAbsType: {
+            const FppTest_SmState_BasicTestAbsType::Signal signal =
+                static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType,
+                                                              signal);
+            break;
+        }
+        case SmId::smStateBasicTestArray: {
+            const FppTest_SmState_BasicTestArray::Signal signal =
+                static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
+            break;
+        }
+        case SmId::smStateBasicTestEnum: {
+            const FppTest_SmState_BasicTestEnum::Signal signal =
+                static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
+            break;
+        }
+        case SmId::smStateBasicTestStruct: {
+            const FppTest_SmState_BasicTestStruct::Signal signal =
+                static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct,
+                                                             signal);
+            break;
+        }
+        case SmId::smStateBasicU32: {
+            const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
+            this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
+            break;
+        }
+        case SmId::smStateInternal: {
+            const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
+            this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
+            break;
+        }
+        case SmId::smStatePolymorphism: {
+            const FppTest_SmState_Polymorphism::Signal signal =
+                static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
+            this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
+            break;
+        }
+        case SmId::smStateStateToChild: {
+            const FppTest_SmState_StateToChild::Signal signal =
+                static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
+            this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
+            break;
+        }
+        case SmId::smStateStateToChoice: {
+            const FppTest_SmState_StateToChoice::Signal signal =
+                static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
+            this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
+            break;
+        }
+        case SmId::smStateStateToSelf: {
+            const FppTest_SmState_StateToSelf::Signal signal =
+                static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
+            this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
+            break;
+        }
+        case SmId::smStateStateToState: {
+            const FppTest_SmState_StateToState::Signal signal =
+                static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
+            this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+            break;
     }
-  }
+}
 
-  void SmStateActiveComponentBase ::
-    deserializeSmIdAndSignal(
-        Fw::SerialBufferBase& buffer,
-        FwEnumStoreType& smId,
-        FwEnumStoreType& signal
-    )
-  {
+void SmStateActiveComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
+                                                           FwEnumStoreType& smId,
+                                                           FwEnumStoreType& signal) {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status =
-      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -2171,607 +1633,560 @@ namespace FppTest {
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_Basic& sm,
-        FppTest_SmState_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicGuard_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuard& sm,
-        FppTest_SmState_BasicGuard::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuard::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicGuardString_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardString& sm,
-        FppTest_SmState_BasicGuardString::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardString::Signal::s: {
-        // Deserialize the data
-        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicGuardTestAbsType_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestAbsType& sm,
-        FppTest_SmState_BasicGuardTestAbsType::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicGuardTestArray_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestArray& sm,
-        FppTest_SmState_BasicGuardTestArray::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestArray::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicGuardTestEnum_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestEnum& sm,
-        FppTest_SmState_BasicGuardTestEnum::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicGuardTestStruct_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestStruct& sm,
-        FppTest_SmState_BasicGuardTestStruct::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicGuardU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardU32& sm,
-        FppTest_SmState_BasicGuardU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicInternal_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicInternal& sm,
-        FppTest_SmState_BasicInternal::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicInternal::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicSelf_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicSelf& sm,
-        FppTest_SmState_BasicSelf::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicSelf::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicString_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicString& sm,
-        FppTest_SmState_BasicString::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicString::Signal::s: {
-        // Deserialize the data
-        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
-        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      case FppTest_SmState_BasicString::Signal::s1: {
-        // Deserialize the data
-        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
-        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s1
-        sm.sendSignal_s1(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicTestAbsType_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestAbsType& sm,
-        FppTest_SmState_BasicTestAbsType::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestAbsType::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicTestArray_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestArray& sm,
-        FppTest_SmState_BasicTestArray::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestArray::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicTestEnum_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestEnum& sm,
-        FppTest_SmState_BasicTestEnum::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestEnum::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicTestStruct_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestStruct& sm,
-        FppTest_SmState_BasicTestStruct::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestStruct::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_BasicU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicU32& sm,
-        FppTest_SmState_BasicU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_Internal_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_Internal& sm,
-        FppTest_SmState_Internal::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_Internal::Signal::S1_internal: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_internal
-        sm.sendSignal_S1_internal();
-        break;
-      }
-      case FppTest_SmState_Internal::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_Polymorphism_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_Polymorphism& sm,
-        FppTest_SmState_Polymorphism::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_Polymorphism::Signal::poly: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and poly
-        sm.sendSignal_poly();
-        break;
-      }
-      case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_StateToChild_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToChild& sm,
-        FppTest_SmState_StateToChild::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S2
-        sm.sendSignal_S1_to_S2();
-        break;
-      }
-      case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_StateToChoice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToChoice& sm,
-        FppTest_SmState_StateToChoice::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S4
-        sm.sendSignal_S1_to_S4();
-        break;
-      }
-      case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_C
-        sm.sendSignal_S1_to_C();
-        break;
-      }
-      case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_StateToSelf_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToSelf& sm,
-        FppTest_SmState_StateToSelf::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S1
-        sm.sendSignal_S1_to_S1();
-        break;
-      }
-      case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmState_StateToState_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToState& sm,
-        FppTest_SmState_StateToState::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToState::Signal::S1_to_S4: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S4
-        sm.sendSignal_S1_to_S4();
-        break;
-      }
-      case FppTest_SmState_StateToState::Signal::S1_to_S5: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S5
-        sm.sendSignal_S1_to_S5();
-        break;
-      }
-      case FppTest_SmState_StateToState::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateActiveComponentBase ::
-    FppTest_SmStateActive_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmStateActive_Basic& sm,
-        FppTest_SmStateActive_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmStateActive_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
 }
+
+void SmStateActiveComponentBase ::FppTest_SmState_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                   FppTest_SmState_Basic& sm,
+                                                                   FppTest_SmState_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicGuard_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmState_BasicGuard& sm,
+                                                                        FppTest_SmState_BasicGuard::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuard::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardString_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardString& sm,
+    FppTest_SmState_BasicGuardString::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardString::Signal::s: {
+            // Deserialize the data
+            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestAbsType_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestAbsType& sm,
+    FppTest_SmState_BasicGuardTestAbsType::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestAbsType value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestArray_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestArray& sm,
+    FppTest_SmState_BasicGuardTestArray::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestArray::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestArray value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestEnum_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestEnum& sm,
+    FppTest_SmState_BasicGuardTestEnum::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestEnum value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardTestStruct_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestStruct& sm,
+    FppTest_SmState_BasicGuardTestStruct::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestStruct value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicGuardU32_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardU32& sm,
+    FppTest_SmState_BasicGuardU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicInternal_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicInternal& sm,
+    FppTest_SmState_BasicInternal::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicInternal::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicSelf_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                       FppTest_SmState_BasicSelf& sm,
+                                                                       FppTest_SmState_BasicSelf::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicSelf::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicString_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                         FppTest_SmState_BasicString& sm,
+                                                                         FppTest_SmState_BasicString::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicString::Signal::s: {
+            // Deserialize the data
+            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
+            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        case FppTest_SmState_BasicString::Signal::s1: {
+            // Deserialize the data
+            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
+            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s1
+            sm.sendSignal_s1(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicTestAbsType_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestAbsType& sm,
+    FppTest_SmState_BasicTestAbsType::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestAbsType::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestAbsType value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicTestArray_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestArray& sm,
+    FppTest_SmState_BasicTestArray::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestArray::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestArray value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicTestEnum_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestEnum& sm,
+    FppTest_SmState_BasicTestEnum::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestEnum::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestEnum value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicTestStruct_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestStruct& sm,
+    FppTest_SmState_BasicTestStruct::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestStruct::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestStruct value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                      FppTest_SmState_BasicU32& sm,
+                                                                      FppTest_SmState_BasicU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_Internal_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                      FppTest_SmState_Internal& sm,
+                                                                      FppTest_SmState_Internal::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_Internal::Signal::S1_internal: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_internal
+            sm.sendSignal_S1_internal();
+            break;
+        }
+        case FppTest_SmState_Internal::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_Polymorphism_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                          FppTest_SmState_Polymorphism& sm,
+                                                                          FppTest_SmState_Polymorphism::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_Polymorphism::Signal::poly: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and poly
+            sm.sendSignal_poly();
+            break;
+        }
+        case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_StateToChild_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                          FppTest_SmState_StateToChild& sm,
+                                                                          FppTest_SmState_StateToChild::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S2
+            sm.sendSignal_S1_to_S2();
+            break;
+        }
+        case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_StateToChoice_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_StateToChoice& sm,
+    FppTest_SmState_StateToChoice::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S4
+            sm.sendSignal_S1_to_S4();
+            break;
+        }
+        case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_C
+            sm.sendSignal_S1_to_C();
+            break;
+        }
+        case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_StateToSelf_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                         FppTest_SmState_StateToSelf& sm,
+                                                                         FppTest_SmState_StateToSelf::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S1
+            sm.sendSignal_S1_to_S1();
+            break;
+        }
+        case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmState_StateToState_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                          FppTest_SmState_StateToState& sm,
+                                                                          FppTest_SmState_StateToState::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToState::Signal::S1_to_S4: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S4
+            sm.sendSignal_S1_to_S4();
+            break;
+        }
+        case FppTest_SmState_StateToState::Signal::S1_to_S5: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S5
+            sm.sendSignal_S1_to_S5();
+            break;
+        }
+        case FppTest_SmState_StateToState::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateActiveComponentBase ::FppTest_SmStateActive_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                         FppTest_SmStateActive_Basic& sm,
+                                                                         FppTest_SmStateActive_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmStateActive_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+}  // namespace FppTest

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
@@ -66,9 +66,8 @@ namespace FppTest {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
@@ -13,610 +13,935 @@
 
 namespace FppTest {
 
-namespace {
+  namespace {
 
-// Constant definitions for the state machine signal buffer
-namespace SmSignalBuffer {
+    // Constant definitions for the state machine signal buffer
+    namespace SmSignalBuffer {
 
-// Union for computing the max size of a signal type
-union SignalTypeUnion {
-    BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
-    BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
-    BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
-    BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
-    BYTE size_of_U32[sizeof(U32)];
-    BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(
-        FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
-};
+      // Union for computing the max size of a signal type
+      union SignalTypeUnion {
+        BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
+        BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
+        BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
+        BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
+        BYTE size_of_U32[sizeof(U32)];
+        BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
+      };
 
-// The serialized size
-static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
+      // The serialized size
+      static constexpr FwSizeType SERIALIZED_SIZE =
+        2 * sizeof(FwEnumStoreType) +
+        sizeof(SignalTypeUnion);
 
-}  // namespace SmSignalBuffer
-
-enum MsgTypeEnum {
-    SMSTATEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-    INTERNAL_STATE_MACHINE_SIGNAL,
-};
-
-// Get the max size by constructing a union of the async input, command, and
-// internal port serialization sizes
-union BuffUnion {
-    // Size of buffer for internal state machine signals
-    // The internal SmSignalBuffer stores the state machine id, the
-    // signal id, and the signal data
-    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-};
-
-// Define a message buffer class large enough to handle all the
-// asynchronous inputs to the component
-class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
-  public:
-    enum {
-        // Offset into data in buffer: Size of message ID and port number
-        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-        // Max data size
-        MAX_DATA_SIZE = sizeof(BuffUnion),
-        // Max message size: Size of message id + size of port + max data size
-        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-    };
-
-    ComponentIpcSerializableBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = sizeof(m_buff);
     }
 
-  private:
-    // Should be the max of all the input ports serialized sizes...
-    U8 m_buff[SERIALIZATION_SIZE];
-};
-}  // namespace
+    enum MsgTypeEnum {
+      SMSTATEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+      INTERNAL_STATE_MACHINE_SIGNAL,
+    };
 
-// ----------------------------------------------------------------------
-// Types for internal state machines
-// ----------------------------------------------------------------------
+    // Get the max size by constructing a union of the async input, command, and
+    // internal port serialization sizes
+    union BuffUnion {
+      // Size of buffer for internal state machine signals
+      // The internal SmSignalBuffer stores the state machine id, the
+      // signal id, and the signal data
+      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+    };
 
-SmStateQueuedComponentBase::FppTest_SmState_Basic ::FppTest_SmState_Basic(SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+    // Define a message buffer class large enough to handle all the
+    // asynchronous inputs to the component
+    class ComponentIpcSerializableBuffer :
+      public Fw::LinearBufferBase
+    {
 
-void SmStateQueuedComponentBase::FppTest_SmState_Basic ::init(SmStateQueuedComponentBase::SmId smId) {
+      public:
+
+        enum {
+          // Offset into data in buffer: Size of message ID and port number
+          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+          // Max data size
+          MAX_DATA_SIZE = sizeof(BuffUnion),
+          // Max message size: Size of message id + size of port + max data size
+          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+        };
+
+        ComponentIpcSerializableBuffer() {
+          this->m_buffAddr = m_buff;
+          this->m_capacity = sizeof(m_buff);
+        }
+
+      private:
+        // Should be the max of all the input ports serialized sizes...
+        U8 m_buff[SERIALIZATION_SIZE];
+
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Types for internal state machines
+  // ----------------------------------------------------------------------
+
+  SmStateQueuedComponentBase::FppTest_SmState_Basic ::
+    FppTest_SmState_Basic(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
+
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_Basic ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Basic ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Basic ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_Basic ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_Basic_action_a(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::FppTest_SmState_BasicGuard(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
+    FppTest_SmState_BasicGuard(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicGuard_action_a(this->getId(), signal);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::guard_g(Signal signal) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmState_BasicGuard_guard_g(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::FppTest_SmState_BasicGuardString(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
+    FppTest_SmState_BasicGuardString(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::action_a(Signal signal,
-                                                                             const Fw::StringBase& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
+    action_a(
+        Signal signal,
+        const Fw::StringBase& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardString_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::guard_g(Signal signal,
-                                                                            const Fw::StringBase& value) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
+    guard_g(
+        Signal signal,
+        const Fw::StringBase& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardString_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::FppTest_SmState_BasicGuardTestAbsType(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    FppTest_SmState_BasicGuardTestAbsType(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestAbsType& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestAbsType_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestAbsType& value) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestAbsType& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestAbsType_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::FppTest_SmState_BasicGuardTestArray(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    FppTest_SmState_BasicGuardTestArray(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestArray& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestArray& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestArray_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestArray& value) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestArray& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestArray_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::FppTest_SmState_BasicGuardTestEnum(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    FppTest_SmState_BasicGuardTestEnum(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestEnum& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestEnum& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestEnum_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestEnum& value) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestEnum& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestEnum_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::FppTest_SmState_BasicGuardTestStruct(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    FppTest_SmState_BasicGuardTestStruct(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::action_a(
-    Signal signal,
-    const FppTest::SmHarness::TestStruct& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    action_a(
+        Signal signal,
+        const FppTest::SmHarness::TestStruct& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardTestStruct_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::guard_g(
-    Signal signal,
-    const FppTest::SmHarness::TestStruct& value) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
+    guard_g(
+        Signal signal,
+        const FppTest::SmHarness::TestStruct& value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardTestStruct_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::FppTest_SmState_BasicGuardU32(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
+    FppTest_SmState_BasicGuardU32(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::action_a(Signal signal, U32 value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
+    action_a(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmState_BasicGuardU32_action_a(this->getId(), signal, value);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::guard_g(Signal signal, U32 value) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
+    guard_g(
+        Signal signal,
+        U32 value
+    ) const
+  {
     return this->m_component.FppTest_SmState_BasicGuardU32_guard_g(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::FppTest_SmState_BasicInternal(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
+    FppTest_SmState_BasicInternal(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicInternal_action_a(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::FppTest_SmState_BasicSelf(SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
+    FppTest_SmState_BasicSelf(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicSelf_action_a(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicString ::FppTest_SmState_BasicString(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
+    FppTest_SmState_BasicString(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicString ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicString_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::action_b(Signal signal, const Fw::StringBase& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
+    action_b(
+        Signal signal,
+        const Fw::StringBase& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicString_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::FppTest_SmState_BasicTestAbsType(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
+    FppTest_SmState_BasicTestAbsType(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::action_b(
-    Signal signal,
-    const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestAbsType& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::FppTest_SmState_BasicTestArray(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
+    FppTest_SmState_BasicTestArray(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestArray_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::action_b(Signal signal,
-                                                                           const FppTest::SmHarness::TestArray& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestArray& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestArray_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::FppTest_SmState_BasicTestEnum(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
+    FppTest_SmState_BasicTestEnum(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestEnum_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::action_b(Signal signal,
-                                                                          const FppTest::SmHarness::TestEnum& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestEnum& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestEnum_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::FppTest_SmState_BasicTestStruct(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
+    FppTest_SmState_BasicTestStruct(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicTestStruct_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::action_b(
-    Signal signal,
-    const FppTest::SmHarness::TestStruct& value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
+    action_b(
+        Signal signal,
+        const FppTest::SmHarness::TestStruct& value
+    )
+  {
     this->m_component.FppTest_SmState_BasicTestStruct_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::FppTest_SmState_BasicU32(SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
+    FppTest_SmState_BasicU32(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_BasicU32_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::action_b(Signal signal, U32 value) {
+  void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
+    action_b(
+        Signal signal,
+        U32 value
+    )
+  {
     this->m_component.FppTest_SmState_BasicU32_action_b(this->getId(), signal, value);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_Internal ::FppTest_SmState_Internal(SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_Internal ::
+    FppTest_SmState_Internal(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_Internal ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_Internal ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Internal ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Internal ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_Internal ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_Internal ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_Internal_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::init(SmStateQueuedComponentBase::SmId smId) {
+  void SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::FppTest_SmState_StateToChild(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    FppTest_SmState_StateToChild(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_exitS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_exitS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_enterS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_enterS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChild_action_enterS3(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::FppTest_SmState_StateToChoice(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    FppTest_SmState_StateToChoice(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_exitS1(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_exitS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_exitS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS1(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS1(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS3(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS4(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    action_enterS4(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS4(this->getId(), signal);
-}
+  }
 
-bool SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::guard_g(Signal signal) const {
+  bool SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
+    guard_g(Signal signal) const
+  {
     return this->m_component.FppTest_SmState_StateToChoice_guard_g(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::FppTest_SmState_StateToSelf(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    FppTest_SmState_StateToSelf(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_exitS1(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_exitS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_exitS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_enterS1(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    action_enterS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS1(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_enterS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_enterS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS3(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToState ::FppTest_SmState_StateToState(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    FppTest_SmState_StateToState(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToState ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_exitS1(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_exitS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_exitS1(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_exitS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_exitS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_exitS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_exitS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_exitS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_exitS3(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_a(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS1(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_enterS1(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS1(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS2(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_enterS2(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS2(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS3(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_enterS3(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS3(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS4(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_enterS4(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS4(this->getId(), signal);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS5(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
+    action_enterS5(Signal signal)
+  {
     this->m_component.FppTest_SmState_StateToState_action_enterS5(this->getId(), signal);
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::FppTest_SmStateQueued_Basic(
-    SmStateQueuedComponentBase& component)
-    : m_component(component) {}
+  SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
+    FppTest_SmStateQueued_Basic(SmStateQueuedComponentBase& component) :
+      m_component(component)
+  {
 
-void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::init(SmStateQueuedComponentBase::SmId smId) {
+  }
+
+  void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
+    init(SmStateQueuedComponentBase::SmId smId)
+  {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-}
+  }
 
-SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::getId() const {
+  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
+    getId() const
+  {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-}
+  }
 
-void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::action_a(Signal signal) {
+  void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
+    action_a(Signal signal)
+  {
     this->m_component.FppTest_SmStateQueued_Basic_action_a(this->getId(), signal);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Component initialization
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component initialization
+  // ----------------------------------------------------------------------
 
-void SmStateQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
+  void SmStateQueuedComponentBase ::
+    init(
+        FwSizeType queueDepth,
+        FwEnumStoreType instance
+    )
+  {
     // Initialize base class
     Fw::QueuedComponentBase::init(instance);
 
@@ -649,45 +974,67 @@ void SmStateQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType in
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port schedIn
-    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts()); port++) {
-        this->m_schedIn_InputPort[port].init();
-        this->m_schedIn_InputPort[port].addCallComp(this, m_p_schedIn_in);
-        this->m_schedIn_InputPort[port].setPortNum(port);
+    for (
+      FwIndexType port = 0;
+      port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts());
+      port++
+    ) {
+      this->m_schedIn_InputPort[port].init();
+      this->m_schedIn_InputPort[port].addCallComp(
+        this,
+        m_p_schedIn_in
+      );
+      this->m_schedIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-        Fw::ObjectName portName;
-        portName.format("%s_schedIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
-        this->m_schedIn_InputPort[port].setObjName(portName.toChar());
+      Fw::ObjectName portName;
+      portName.format(
+        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
+        this->m_objName.toChar(),
+        port
+      );
+      this->m_schedIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat =
-        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
-    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
-}
+    Os::Queue::Status qStat = this->createQueue(
+      queueDepth,
+      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
+    );
+    FW_ASSERT(
+      Os::Queue::Status::OP_OK == qStat,
+      static_cast<FwAssertArgType>(qStat)
+    );
+  }
 
 #if !FW_DIRECT_PORT_CALLS
 
-// ----------------------------------------------------------------------
-// Getters for typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Getters for typed input ports
+  // ----------------------------------------------------------------------
 
-Svc::InputSchedPort* SmStateQueuedComponentBase ::get_schedIn_InputPort(FwIndexType portNum) {
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+  Svc::InputSchedPort* SmStateQueuedComponentBase ::
+    get_schedIn_InputPort(FwIndexType portNum)
+  {
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     return &this->m_schedIn_InputPort[portNum];
-}
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Component construction and destruction
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component construction and destruction
+  // ----------------------------------------------------------------------
 
-SmStateQueuedComponentBase ::SmStateQueuedComponentBase(const char* compName)
-    : Fw::QueuedComponentBase(compName),
+  SmStateQueuedComponentBase ::
+    SmStateQueuedComponentBase(const char* compName) :
+      Fw::QueuedComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_smStateBasic1(*this),
@@ -712,509 +1059,602 @@ SmStateQueuedComponentBase ::SmStateQueuedComponentBase(const char* compName)
       m_stateMachine_smStateStateToChild(*this),
       m_stateMachine_smStateStateToChoice(*this),
       m_stateMachine_smStateStateToSelf(*this),
-      m_stateMachine_smStateStateToState(*this) {}
+      m_stateMachine_smStateStateToState(*this)
+  {
 
-SmStateQueuedComponentBase ::~SmStateQueuedComponentBase() {}
+  }
 
-// ----------------------------------------------------------------------
-// Port handler base-class functions for typed input ports
-//
-// Call these functions directly to bypass the corresponding ports
-// ----------------------------------------------------------------------
+  SmStateQueuedComponentBase ::
+    ~SmStateQueuedComponentBase()
+  {
 
-void SmStateQueuedComponentBase ::schedIn_handlerBase(FwIndexType portNum, U32 context) {
+  }
+
+  // ----------------------------------------------------------------------
+  // Port handler base-class functions for typed input ports
+  //
+  // Call these functions directly to bypass the corresponding ports
+  // ----------------------------------------------------------------------
+
+  void SmStateQueuedComponentBase ::
+    schedIn_handlerBase(
+        FwIndexType portNum,
+        U32 context
+    )
+  {
     // Make sure port number is valid
-    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
+    FW_ASSERT(
+      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
+      static_cast<FwAssertArgType>(portNum)
+    );
 
     // Call handler function
-    this->schedIn_handler(portNum, context);
-}
+    this->schedIn_handler(
+      portNum,
+      context
+    );
+  }
 
-// ----------------------------------------------------------------------
-// State getter functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // State getter functions
+  // ----------------------------------------------------------------------
 
-SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::basic1_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::
+    basic1_getState() const
+  {
     return this->m_stateMachine_basic1.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::basic2_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::
+    basic2_getState() const
+  {
     return this->m_stateMachine_basic2.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::smStateBasic1_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::
+    smStateBasic1_getState() const
+  {
     return this->m_stateMachine_smStateBasic1.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::smStateBasic2_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::
+    smStateBasic2_getState() const
+  {
     return this->m_stateMachine_smStateBasic2.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuard::State SmStateQueuedComponentBase ::smStateBasicGuard_getState()
-    const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuard::State SmStateQueuedComponentBase ::
+    smStateBasicGuard_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuard.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString::State
-SmStateQueuedComponentBase ::smStateBasicGuardString_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString::State SmStateQueuedComponentBase ::
+    smStateBasicGuardString_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardString.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType::State
-SmStateQueuedComponentBase ::smStateBasicGuardTestAbsType_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType::State SmStateQueuedComponentBase ::
+    smStateBasicGuardTestAbsType_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestAbsType.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray::State
-SmStateQueuedComponentBase ::smStateBasicGuardTestArray_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray::State SmStateQueuedComponentBase ::
+    smStateBasicGuardTestArray_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestArray.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum::State
-SmStateQueuedComponentBase ::smStateBasicGuardTestEnum_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum::State SmStateQueuedComponentBase ::
+    smStateBasicGuardTestEnum_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestEnum.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct::State
-SmStateQueuedComponentBase ::smStateBasicGuardTestStruct_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct::State SmStateQueuedComponentBase ::
+    smStateBasicGuardTestStruct_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardTestStruct.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32::State
-SmStateQueuedComponentBase ::smStateBasicGuardU32_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32::State SmStateQueuedComponentBase ::
+    smStateBasicGuardU32_getState() const
+  {
     return this->m_stateMachine_smStateBasicGuardU32.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicInternal::State
-SmStateQueuedComponentBase ::smStateBasicInternal_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicInternal::State SmStateQueuedComponentBase ::
+    smStateBasicInternal_getState() const
+  {
     return this->m_stateMachine_smStateBasicInternal.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicSelf::State SmStateQueuedComponentBase ::smStateBasicSelf_getState()
-    const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicSelf::State SmStateQueuedComponentBase ::
+    smStateBasicSelf_getState() const
+  {
     return this->m_stateMachine_smStateBasicSelf.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicString::State
-SmStateQueuedComponentBase ::smStateBasicString_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicString::State SmStateQueuedComponentBase ::
+    smStateBasicString_getState() const
+  {
     return this->m_stateMachine_smStateBasicString.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType::State
-SmStateQueuedComponentBase ::smStateBasicTestAbsType_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType::State SmStateQueuedComponentBase ::
+    smStateBasicTestAbsType_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestAbsType.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray::State
-SmStateQueuedComponentBase ::smStateBasicTestArray_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray::State SmStateQueuedComponentBase ::
+    smStateBasicTestArray_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestArray.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum::State
-SmStateQueuedComponentBase ::smStateBasicTestEnum_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum::State SmStateQueuedComponentBase ::
+    smStateBasicTestEnum_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestEnum.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct::State
-SmStateQueuedComponentBase ::smStateBasicTestStruct_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct::State SmStateQueuedComponentBase ::
+    smStateBasicTestStruct_getState() const
+  {
     return this->m_stateMachine_smStateBasicTestStruct.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_BasicU32::State SmStateQueuedComponentBase ::smStateBasicU32_getState()
-    const {
+  SmStateQueuedComponentBase::FppTest_SmState_BasicU32::State SmStateQueuedComponentBase ::
+    smStateBasicU32_getState() const
+  {
     return this->m_stateMachine_smStateBasicU32.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_Internal::State SmStateQueuedComponentBase ::smStateInternal_getState()
-    const {
+  SmStateQueuedComponentBase::FppTest_SmState_Internal::State SmStateQueuedComponentBase ::
+    smStateInternal_getState() const
+  {
     return this->m_stateMachine_smStateInternal.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_Polymorphism::State
-SmStateQueuedComponentBase ::smStatePolymorphism_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_Polymorphism::State SmStateQueuedComponentBase ::
+    smStatePolymorphism_getState() const
+  {
     return this->m_stateMachine_smStatePolymorphism.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToChild::State
-SmStateQueuedComponentBase ::smStateStateToChild_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_StateToChild::State SmStateQueuedComponentBase ::
+    smStateStateToChild_getState() const
+  {
     return this->m_stateMachine_smStateStateToChild.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToChoice::State
-SmStateQueuedComponentBase ::smStateStateToChoice_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_StateToChoice::State SmStateQueuedComponentBase ::
+    smStateStateToChoice_getState() const
+  {
     return this->m_stateMachine_smStateStateToChoice.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToSelf::State
-SmStateQueuedComponentBase ::smStateStateToSelf_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_StateToSelf::State SmStateQueuedComponentBase ::
+    smStateStateToSelf_getState() const
+  {
     return this->m_stateMachine_smStateStateToSelf.getState();
-}
+  }
 
-SmStateQueuedComponentBase::FppTest_SmState_StateToState::State
-SmStateQueuedComponentBase ::smStateStateToState_getState() const {
+  SmStateQueuedComponentBase::FppTest_SmState_StateToState::State SmStateQueuedComponentBase ::
+    smStateStateToState_getState() const
+  {
     return this->m_stateMachine_smStateStateToState.getState();
-}
+  }
 
-// ----------------------------------------------------------------------
-// Signal send functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Signal send functions
+  // ----------------------------------------------------------------------
 
-void SmStateQueuedComponentBase ::basic1_sendSignal_s() {
+  void SmStateQueuedComponentBase ::
+    basic1_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic1, static_cast<FwEnumStoreType>(FppTest_SmStateQueued_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic1_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::basic2_sendSignal_s() {
+  void SmStateQueuedComponentBase ::
+    basic2_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic2, static_cast<FwEnumStoreType>(FppTest_SmStateQueued_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic2_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasic1_sendSignal_s() {
+  void SmStateQueuedComponentBase ::
+    smStateBasic1_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic1, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic1_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasic2_sendSignal_s() {
+  void SmStateQueuedComponentBase ::
+    smStateBasic2_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic2, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic2_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuard_sendSignal_s() {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuard_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicGuard_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardString,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardString_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestAbsType_sendSignal_s(
-    const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestAbsType_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestArray,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestArray_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestEnum,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestEnum_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestStruct_sendSignal_s(
-    const FppTest::SmHarness::TestStruct& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestStruct,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestStruct_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardU32_sendSignal_s(U32 value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardU32,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardU32_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicInternal_sendSignal_s() {
+  void SmStateQueuedComponentBase ::
+    smStateBasicInternal_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicInternal,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicInternal, static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicInternal_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicSelf_sendSignal_s() {
+  void SmStateQueuedComponentBase ::
+    smStateBasicSelf_sendSignal_s()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicSelf_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicString_sendSignal_s(const Fw::StringBase& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicString_sendSignal_s(const Fw::StringBase& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 200);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicString_sendSignal_s1(const Fw::StringBase& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicString_sendSignal_s1(const Fw::StringBase& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 100);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestAbsType,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestAbsType_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestArray,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestArray_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestEnum,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestEnum_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestStruct,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestStruct_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicU32_sendSignal_s(U32 value) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicU32_sendSignal_s(U32 value)
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s),
-                          buffer);
+    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicU32_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateInternal_sendSignal_S1_internal() {
+  void SmStateQueuedComponentBase ::
+    smStateInternal_sendSignal_S1_internal()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
+    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateInternal_sendSignal_S2_to_S3() {
+  void SmStateQueuedComponentBase ::
+    smStateInternal_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStatePolymorphism_sendSignal_poly() {
+  void SmStateQueuedComponentBase ::
+    smStatePolymorphism_sendSignal_poly()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStatePolymorphism_sendSignal_S2_to_S3() {
+  void SmStateQueuedComponentBase ::
+    smStatePolymorphism_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToChild_sendSignal_S1_to_S2() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToChild_sendSignal_S1_to_S2()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToChild_sendSignal_S2_to_S3() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToChild_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignal_S1_to_S4() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToChoice_sendSignal_S1_to_S4()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignal_S1_to_C() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToChoice_sendSignal_S1_to_C()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignal_S2_to_S3() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToChoice_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToSelf_sendSignal_S1_to_S1() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToSelf_sendSignal_S1_to_S1()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToSelf_sendSignal_S2_to_S3() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToSelf_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToState_sendSignal_S1_to_S4() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToState_sendSignal_S1_to_S4()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToState_sendSignal_S1_to_S5() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToState_sendSignal_S1_to_S5()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
+    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-}
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToState_sendSignal_S2_to_S3() {
+  void SmStateQueuedComponentBase ::
+    smStateStateToState_sendSignal_S2_to_S3()
+  {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState,
-                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-}
+  }
 
-// ----------------------------------------------------------------------
-// Message dispatch functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Message dispatch functions
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::doDispatch() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::
+    doDispatch()
+  {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
+    Os::Queue::Status _msgStatus = this->m_queue.receive(
+      _msg,
+      Os::Queue::NONBLOCKING,
+      _priority
+    );
     if (Os::Queue::Status::EMPTY == _msgStatus) {
-        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    } else {
-        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
+      return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    }
+    else {
+      FW_ASSERT(
+        _msgStatus == Os::Queue::OP_OK,
+        static_cast<FwAssertArgType>(_msgStatus)
+      );
     }
 
     // Reset to beginning of buffer
@@ -1222,310 +1662,463 @@ Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::doDispat
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMSTATEQUEUED_COMPONENT_EXIT) {
-        return MSG_DISPATCH_EXIT;
+      return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
+    FW_ASSERT(
+      _deserStatus == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_deserStatus)
+    );
 
     switch (_msgType) {
-        // Handle signals to internal state machines
-        case INTERNAL_STATE_MACHINE_SIGNAL:
-            this->smDispatch(_msg);
-            break;
 
-        default:
-            return MSG_DISPATCH_ERROR;
+      // Handle signals to internal state machines
+      case INTERNAL_STATE_MACHINE_SIGNAL:
+        this->smDispatch(_msg);
+        break;
+
+      default:
+        return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for dispatching current messages
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for dispatching current messages
+  // ----------------------------------------------------------------------
 
-Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::dispatchCurrentMessages() {
+  Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::
+    dispatchCurrentMessages()
+  {
     // Dispatch all current messages unless ERROR or EXIT occur
     const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
     MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
     for (FwSizeType i = 0; i < currentMessageCount; i++) {
-        messageStatus = this->doDispatch();
-        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-            break;
-        }
+      messageStatus = this->doDispatch();
+      if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+        break;
+      }
     }
     return messageStatus;
-}
+  }
 
-// ----------------------------------------------------------------------
-// Calls for messages received on typed input ports
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Calls for messages received on typed input ports
+  // ----------------------------------------------------------------------
 
-void SmStateQueuedComponentBase ::m_p_schedIn_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum, U32 context) {
+  void SmStateQueuedComponentBase ::
+    m_p_schedIn_in(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 context
+    )
+  {
     FW_ASSERT(callComp);
     SmStateQueuedComponentBase* compPtr = static_cast<SmStateQueuedComponentBase*>(callComp);
-    compPtr->schedIn_handlerBase(portNum, context);
-}
+    compPtr->schedIn_handlerBase(
+      portNum,
+      context
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Send signal helper functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Send signal helper functions
+  // ----------------------------------------------------------------------
 
-void SmStateQueuedComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    sendSignalStart(
+        SmId smId,
+        FwEnumStoreType signal,
+        Fw::SerialBufferBase& buffer
+    )
+  {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmStateQueuedComponentBase ::basic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    basic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::basic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    basic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        this->incNumMsgDropped();
-        return;
+      this->incNumMsgDropped();
+      return;
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-        // Deserialize the state machine ID and signal
-        FwEnumStoreType smId;
-        FwEnumStoreType signal;
-        SmStateQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Call the overflow hook
-        this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+      // Deserialize the state machine ID and signal
+      FwEnumStoreType smId;
+      FwEnumStoreType signal;
+      SmStateQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-        // Continue execution
-        return;
+      // Call the overflow hook
+      this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
+
+      // Continue execution
+      return;
+
     }
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-void SmStateQueuedComponentBase ::smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
+  {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
-}
+    FW_ASSERT(
+      qStatus == Os::Queue::OP_OK,
+      static_cast<FwAssertArgType>(qStatus)
+    );
+  }
 
-// ----------------------------------------------------------------------
-// Helper functions for state machine dispatch
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Helper functions for state machine dispatch
+  // ----------------------------------------------------------------------
 
-void SmStateQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
+  void SmStateQueuedComponentBase ::
+    smDispatch(Fw::SerialBufferBase& buffer)
+  {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -1534,170 +2127,147 @@ void SmStateQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-        case SmId::basic1: {
-            const FppTest_SmStateQueued_Basic::Signal signal =
-                static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
-            this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-            break;
-        }
-        case SmId::basic2: {
-            const FppTest_SmStateQueued_Basic::Signal signal =
-                static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
-            this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-            break;
-        }
-        case SmId::smStateBasic1: {
-            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
-            break;
-        }
-        case SmId::smStateBasic2: {
-            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
-            break;
-        }
-        case SmId::smStateBasicGuard: {
-            const FppTest_SmState_BasicGuard::Signal signal =
-                static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardString: {
-            const FppTest_SmState_BasicGuardString::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString,
-                                                              signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestAbsType: {
-            const FppTest_SmState_BasicGuardTestAbsType::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(
-                buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestArray: {
-            const FppTest_SmState_BasicGuardTestArray::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestArray_smDispatch(
-                buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestEnum: {
-            const FppTest_SmState_BasicGuardTestEnum::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum,
-                                                                signal);
-            break;
-        }
-        case SmId::smStateBasicGuardTestStruct: {
-            const FppTest_SmState_BasicGuardTestStruct::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardTestStruct_smDispatch(
-                buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
-            break;
-        }
-        case SmId::smStateBasicGuardU32: {
-            const FppTest_SmState_BasicGuardU32::Signal signal =
-                static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
-            this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
-            break;
-        }
-        case SmId::smStateBasicInternal: {
-            const FppTest_SmState_BasicInternal::Signal signal =
-                static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
-            this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
-            break;
-        }
-        case SmId::smStateBasicSelf: {
-            const FppTest_SmState_BasicSelf::Signal signal =
-                static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
-            this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
-            break;
-        }
-        case SmId::smStateBasicString: {
-            const FppTest_SmState_BasicString::Signal signal =
-                static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
-            this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
-            break;
-        }
-        case SmId::smStateBasicTestAbsType: {
-            const FppTest_SmState_BasicTestAbsType::Signal signal =
-                static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType,
-                                                              signal);
-            break;
-        }
-        case SmId::smStateBasicTestArray: {
-            const FppTest_SmState_BasicTestArray::Signal signal =
-                static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
-            break;
-        }
-        case SmId::smStateBasicTestEnum: {
-            const FppTest_SmState_BasicTestEnum::Signal signal =
-                static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
-            break;
-        }
-        case SmId::smStateBasicTestStruct: {
-            const FppTest_SmState_BasicTestStruct::Signal signal =
-                static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
-            this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct,
-                                                             signal);
-            break;
-        }
-        case SmId::smStateBasicU32: {
-            const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
-            this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
-            break;
-        }
-        case SmId::smStateInternal: {
-            const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
-            this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
-            break;
-        }
-        case SmId::smStatePolymorphism: {
-            const FppTest_SmState_Polymorphism::Signal signal =
-                static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
-            this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
-            break;
-        }
-        case SmId::smStateStateToChild: {
-            const FppTest_SmState_StateToChild::Signal signal =
-                static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
-            this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
-            break;
-        }
-        case SmId::smStateStateToChoice: {
-            const FppTest_SmState_StateToChoice::Signal signal =
-                static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
-            this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
-            break;
-        }
-        case SmId::smStateStateToSelf: {
-            const FppTest_SmState_StateToSelf::Signal signal =
-                static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
-            this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
-            break;
-        }
-        case SmId::smStateStateToState: {
-            const FppTest_SmState_StateToState::Signal signal =
-                static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
-            this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-            break;
+      case SmId::basic1: {
+        const FppTest_SmStateQueued_Basic::Signal signal = static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
+        this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+        break;
+      }
+      case SmId::basic2: {
+        const FppTest_SmStateQueued_Basic::Signal signal = static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
+        this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+        break;
+      }
+      case SmId::smStateBasic1: {
+        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
+        break;
+      }
+      case SmId::smStateBasic2: {
+        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
+        break;
+      }
+      case SmId::smStateBasicGuard: {
+        const FppTest_SmState_BasicGuard::Signal signal = static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardString: {
+        const FppTest_SmState_BasicGuardString::Signal signal = static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestAbsType: {
+        const FppTest_SmState_BasicGuardTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestArray: {
+        const FppTest_SmState_BasicGuardTestArray::Signal signal = static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestEnum: {
+        const FppTest_SmState_BasicGuardTestEnum::Signal signal = static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardTestStruct: {
+        const FppTest_SmState_BasicGuardTestStruct::Signal signal = static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
+        break;
+      }
+      case SmId::smStateBasicGuardU32: {
+        const FppTest_SmState_BasicGuardU32::Signal signal = static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
+        this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
+        break;
+      }
+      case SmId::smStateBasicInternal: {
+        const FppTest_SmState_BasicInternal::Signal signal = static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
+        this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
+        break;
+      }
+      case SmId::smStateBasicSelf: {
+        const FppTest_SmState_BasicSelf::Signal signal = static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
+        this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
+        break;
+      }
+      case SmId::smStateBasicString: {
+        const FppTest_SmState_BasicString::Signal signal = static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
+        this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
+        break;
+      }
+      case SmId::smStateBasicTestAbsType: {
+        const FppTest_SmState_BasicTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType, signal);
+        break;
+      }
+      case SmId::smStateBasicTestArray: {
+        const FppTest_SmState_BasicTestArray::Signal signal = static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
+        break;
+      }
+      case SmId::smStateBasicTestEnum: {
+        const FppTest_SmState_BasicTestEnum::Signal signal = static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
+        break;
+      }
+      case SmId::smStateBasicTestStruct: {
+        const FppTest_SmState_BasicTestStruct::Signal signal = static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
+        this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct, signal);
+        break;
+      }
+      case SmId::smStateBasicU32: {
+        const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
+        this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
+        break;
+      }
+      case SmId::smStateInternal: {
+        const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
+        this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
+        break;
+      }
+      case SmId::smStatePolymorphism: {
+        const FppTest_SmState_Polymorphism::Signal signal = static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
+        this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
+        break;
+      }
+      case SmId::smStateStateToChild: {
+        const FppTest_SmState_StateToChild::Signal signal = static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
+        this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
+        break;
+      }
+      case SmId::smStateStateToChoice: {
+        const FppTest_SmState_StateToChoice::Signal signal = static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
+        this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
+        break;
+      }
+      case SmId::smStateStateToSelf: {
+        const FppTest_SmState_StateToSelf::Signal signal = static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
+        this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
+        break;
+      }
+      case SmId::smStateStateToState: {
+        const FppTest_SmState_StateToState::Signal signal = static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
+        this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
-                                                           FwEnumStoreType& smId,
-                                                           FwEnumStoreType& signal) {
+  void SmStateQueuedComponentBase ::
+    deserializeSmIdAndSignal(
+        Fw::SerialBufferBase& buffer,
+        FwEnumStoreType& smId,
+        FwEnumStoreType& signal
+    )
+  {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status =
+      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -1707,560 +2277,607 @@ void SmStateQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase&
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                   FppTest_SmState_Basic& sm,
-                                                                   FppTest_SmState_Basic::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_Basic& sm,
+        FppTest_SmState_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuard_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                        FppTest_SmState_BasicGuard& sm,
-                                                                        FppTest_SmState_BasicGuard::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicGuard_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuard& sm,
+        FppTest_SmState_BasicGuard::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuard::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuard::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardString_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardString& sm,
-    FppTest_SmState_BasicGuardString::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicGuardString_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardString& sm,
+        FppTest_SmState_BasicGuardString::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardString::Signal::s: {
-            // Deserialize the data
-            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(
-                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardString::Signal::s: {
+        // Deserialize the data
+        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestAbsType_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestAbsType& sm,
-    FppTest_SmState_BasicGuardTestAbsType::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicGuardTestAbsType_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestAbsType& sm,
+        FppTest_SmState_BasicGuardTestAbsType::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestAbsType value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestAbsType value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestArray_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestArray& sm,
-    FppTest_SmState_BasicGuardTestArray::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicGuardTestArray_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestArray& sm,
+        FppTest_SmState_BasicGuardTestArray::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestArray::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestArray value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestArray::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestArray value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestEnum_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestEnum& sm,
-    FppTest_SmState_BasicGuardTestEnum::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicGuardTestEnum_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestEnum& sm,
+        FppTest_SmState_BasicGuardTestEnum::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestEnum value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestEnum value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestStruct_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardTestStruct& sm,
-    FppTest_SmState_BasicGuardTestStruct::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicGuardTestStruct_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardTestStruct& sm,
+        FppTest_SmState_BasicGuardTestStruct::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestStruct value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestStruct value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardU32_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicGuardU32& sm,
-    FppTest_SmState_BasicGuardU32::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicGuardU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicGuardU32& sm,
+        FppTest_SmState_BasicGuardU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicGuardU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicGuardU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicInternal_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicInternal& sm,
-    FppTest_SmState_BasicInternal::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicInternal_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicInternal& sm,
+        FppTest_SmState_BasicInternal::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicInternal::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicInternal::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicSelf_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                       FppTest_SmState_BasicSelf& sm,
-                                                                       FppTest_SmState_BasicSelf::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicSelf_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicSelf& sm,
+        FppTest_SmState_BasicSelf::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicSelf::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicSelf::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicString_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                         FppTest_SmState_BasicString& sm,
-                                                                         FppTest_SmState_BasicString::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicString_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicString& sm,
+        FppTest_SmState_BasicString::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicString::Signal::s: {
-            // Deserialize the data
-            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
-            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        case FppTest_SmState_BasicString::Signal::s1: {
-            // Deserialize the data
-            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
-            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s1
-            sm.sendSignal_s1(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicString::Signal::s: {
+        // Deserialize the data
+        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
+        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      case FppTest_SmState_BasicString::Signal::s1: {
+        // Deserialize the data
+        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
+        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s1
+        sm.sendSignal_s1(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestAbsType_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestAbsType& sm,
-    FppTest_SmState_BasicTestAbsType::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicTestAbsType_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestAbsType& sm,
+        FppTest_SmState_BasicTestAbsType::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestAbsType::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestAbsType value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestAbsType::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestAbsType value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestArray_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestArray& sm,
-    FppTest_SmState_BasicTestArray::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicTestArray_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestArray& sm,
+        FppTest_SmState_BasicTestArray::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestArray::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestArray value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestArray::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestArray value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestEnum_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestEnum& sm,
-    FppTest_SmState_BasicTestEnum::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicTestEnum_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestEnum& sm,
+        FppTest_SmState_BasicTestEnum::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestEnum::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestEnum value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestEnum::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestEnum value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestStruct_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_BasicTestStruct& sm,
-    FppTest_SmState_BasicTestStruct::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicTestStruct_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicTestStruct& sm,
+        FppTest_SmState_BasicTestStruct::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicTestStruct::Signal::s: {
-            // Deserialize the data
-            FppTest::SmHarness::TestStruct value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicTestStruct::Signal::s: {
+        // Deserialize the data
+        FppTest::SmHarness::TestStruct value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                      FppTest_SmState_BasicU32& sm,
-                                                                      FppTest_SmState_BasicU32::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_BasicU32_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_BasicU32& sm,
+        FppTest_SmState_BasicU32::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_BasicU32::Signal::s: {
-            // Deserialize the data
-            U32 value;
-            const Fw::SerializeStatus status = buffer.deserializeTo(value);
-            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s(value);
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_BasicU32::Signal::s: {
+        // Deserialize the data
+        U32 value;
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s(value);
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_Internal_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                      FppTest_SmState_Internal& sm,
-                                                                      FppTest_SmState_Internal::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_Internal_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_Internal& sm,
+        FppTest_SmState_Internal::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_Internal::Signal::S1_internal: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_internal
-            sm.sendSignal_S1_internal();
-            break;
-        }
-        case FppTest_SmState_Internal::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_Internal::Signal::S1_internal: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_internal
+        sm.sendSignal_S1_internal();
+        break;
+      }
+      case FppTest_SmState_Internal::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_Polymorphism_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                          FppTest_SmState_Polymorphism& sm,
-                                                                          FppTest_SmState_Polymorphism::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_Polymorphism_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_Polymorphism& sm,
+        FppTest_SmState_Polymorphism::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_Polymorphism::Signal::poly: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and poly
-            sm.sendSignal_poly();
-            break;
-        }
-        case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_Polymorphism::Signal::poly: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and poly
+        sm.sendSignal_poly();
+        break;
+      }
+      case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_StateToChild_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                          FppTest_SmState_StateToChild& sm,
-                                                                          FppTest_SmState_StateToChild::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_StateToChild_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToChild& sm,
+        FppTest_SmState_StateToChild::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S2
-            sm.sendSignal_S1_to_S2();
-            break;
-        }
-        case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S2
+        sm.sendSignal_S1_to_S2();
+        break;
+      }
+      case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_StateToChoice_smDispatch(
-    Fw::SerialBufferBase& buffer,
-    FppTest_SmState_StateToChoice& sm,
-    FppTest_SmState_StateToChoice::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_StateToChoice_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToChoice& sm,
+        FppTest_SmState_StateToChoice::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S4
-            sm.sendSignal_S1_to_S4();
-            break;
-        }
-        case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_C
-            sm.sendSignal_S1_to_C();
-            break;
-        }
-        case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S4
+        sm.sendSignal_S1_to_S4();
+        break;
+      }
+      case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_C
+        sm.sendSignal_S1_to_C();
+        break;
+      }
+      case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_StateToSelf_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                         FppTest_SmState_StateToSelf& sm,
-                                                                         FppTest_SmState_StateToSelf::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_StateToSelf_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToSelf& sm,
+        FppTest_SmState_StateToSelf::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S1
-            sm.sendSignal_S1_to_S1();
-            break;
-        }
-        case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S1
+        sm.sendSignal_S1_to_S1();
+        break;
+      }
+      case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmState_StateToState_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                          FppTest_SmState_StateToState& sm,
-                                                                          FppTest_SmState_StateToState::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmState_StateToState_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmState_StateToState& sm,
+        FppTest_SmState_StateToState::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmState_StateToState::Signal::S1_to_S4: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S4
-            sm.sendSignal_S1_to_S4();
-            break;
-        }
-        case FppTest_SmState_StateToState::Signal::S1_to_S5: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S1_to_S5
-            sm.sendSignal_S1_to_S5();
-            break;
-        }
-        case FppTest_SmState_StateToState::Signal::S2_to_S3: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and S2_to_S3
-            sm.sendSignal_S2_to_S3();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmState_StateToState::Signal::S1_to_S4: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S4
+        sm.sendSignal_S1_to_S4();
+        break;
+      }
+      case FppTest_SmState_StateToState::Signal::S1_to_S5: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S1_to_S5
+        sm.sendSignal_S1_to_S5();
+        break;
+      }
+      case FppTest_SmState_StateToState::Signal::S2_to_S3: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and S2_to_S3
+        sm.sendSignal_S2_to_S3();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-void SmStateQueuedComponentBase ::FppTest_SmStateQueued_Basic_smDispatch(Fw::SerialBufferBase& buffer,
-                                                                         FppTest_SmStateQueued_Basic& sm,
-                                                                         FppTest_SmStateQueued_Basic::Signal signal) {
+  void SmStateQueuedComponentBase ::
+    FppTest_SmStateQueued_Basic_smDispatch(
+        Fw::SerialBufferBase& buffer,
+        FppTest_SmStateQueued_Basic& sm,
+        FppTest_SmStateQueued_Basic::Signal signal
+    )
+  {
     switch (signal) {
-        case FppTest_SmStateQueued_Basic::Signal::s: {
-            // Assert no data left in buffer
-            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
-                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-            // Call the sendSignal function for sm and s
-            sm.sendSignal_s();
-            break;
-        }
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-            break;
+      case FppTest_SmStateQueued_Basic::Signal::s: {
+        // Assert no data left in buffer
+        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+        // Call the sendSignal function for sm and s
+        sm.sendSignal_s();
+        break;
+      }
+      default:
+        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        break;
     }
-}
+  }
 
-}  // namespace FppTest
+}

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
@@ -66,9 +66,8 @@ namespace FppTest {
           SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
         };
 
-        ComponentIpcSerializableBuffer() {
-          this->m_buffAddr = m_buff;
-          this->m_capacity = sizeof(m_buff);
+        ComponentIpcSerializableBuffer() : Fw::LinearBufferBase(m_buff, sizeof(m_buff)) {
+
         }
 
       private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
@@ -13,942 +13,610 @@
 
 namespace FppTest {
 
-  namespace {
+namespace {
 
-    // Constant definitions for the state machine signal buffer
-    namespace SmSignalBuffer {
+// Constant definitions for the state machine signal buffer
+namespace SmSignalBuffer {
 
-      // Union for computing the max size of a signal type
-      union SignalTypeUnion {
-        BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
-        BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
-        BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
-        BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
-        BYTE size_of_U32[sizeof(U32)];
-        BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
-      };
+// Union for computing the max size of a signal type
+union SignalTypeUnion {
+    BYTE size_of_FppTest_SmHarness_TestAbsType[FppTest::SmHarness::TestAbsType::SERIALIZED_SIZE];
+    BYTE size_of_FppTest_SmHarness_TestArray[FppTest::SmHarness::TestArray::SERIALIZED_SIZE];
+    BYTE size_of_FppTest_SmHarness_TestEnum[FppTest::SmHarness::TestEnum::SERIALIZED_SIZE];
+    BYTE size_of_FppTest_SmHarness_TestStruct[FppTest::SmHarness::TestStruct::SERIALIZED_SIZE];
+    BYTE size_of_U32[sizeof(U32)];
+    BYTE size_of_string[Fw::StringBase::STATIC_SERIALIZED_SIZE(
+        FW_MAX(FW_MAX(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE), 200), 100))];
+};
 
-      // The serialized size
-      static constexpr FwSizeType SERIALIZED_SIZE =
-        2 * sizeof(FwEnumStoreType) +
-        sizeof(SignalTypeUnion);
+// The serialized size
+static constexpr FwSizeType SERIALIZED_SIZE = 2 * sizeof(FwEnumStoreType) + sizeof(SignalTypeUnion);
 
+}  // namespace SmSignalBuffer
+
+enum MsgTypeEnum {
+    SMSTATEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
+    INTERNAL_STATE_MACHINE_SIGNAL,
+};
+
+// Get the max size by constructing a union of the async input, command, and
+// internal port serialization sizes
+union BuffUnion {
+    // Size of buffer for internal state machine signals
+    // The internal SmSignalBuffer stores the state machine id, the
+    // signal id, and the signal data
+    BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
+};
+
+// Define a message buffer class large enough to handle all the
+// asynchronous inputs to the component
+class ComponentIpcSerializableBuffer : public Fw::LinearBufferBase {
+  public:
+    enum {
+        // Offset into data in buffer: Size of message ID and port number
+        DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
+        // Max data size
+        MAX_DATA_SIZE = sizeof(BuffUnion),
+        // Max message size: Size of message id + size of port + max data size
+        SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
+    };
+
+    ComponentIpcSerializableBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = sizeof(m_buff);
     }
 
-    enum MsgTypeEnum {
-      SMSTATEQUEUED_COMPONENT_EXIT = Fw::ActiveComponentBase::ACTIVE_COMPONENT_EXIT,
-      INTERNAL_STATE_MACHINE_SIGNAL,
-    };
+  private:
+    // Should be the max of all the input ports serialized sizes...
+    U8 m_buff[SERIALIZATION_SIZE];
+};
+}  // namespace
 
-    // Get the max size by constructing a union of the async input, command, and
-    // internal port serialization sizes
-    union BuffUnion {
-      // Size of buffer for internal state machine signals
-      // The internal SmSignalBuffer stores the state machine id, the
-      // signal id, and the signal data
-      BYTE internalSmBufferSize[SmSignalBuffer::SERIALIZED_SIZE];
-    };
+// ----------------------------------------------------------------------
+// Types for internal state machines
+// ----------------------------------------------------------------------
 
-    // Define a message buffer class large enough to handle all the
-    // asynchronous inputs to the component
-    class ComponentIpcSerializableBuffer :
-      public Fw::LinearBufferBase
-    {
+SmStateQueuedComponentBase::FppTest_SmState_Basic ::FppTest_SmState_Basic(SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-      public:
-
-        enum {
-          // Offset into data in buffer: Size of message ID and port number
-          DATA_OFFSET = sizeof(FwEnumStoreType) + sizeof(FwIndexType),
-          // Max data size
-          MAX_DATA_SIZE = sizeof(BuffUnion),
-          // Max message size: Size of message id + size of port + max data size
-          SERIALIZATION_SIZE = DATA_OFFSET + MAX_DATA_SIZE
-        };
-
-        Fw::Serializable::SizeType getCapacity() const {
-          return sizeof(m_buff);
-        }
-
-        U8* getBuffAddr() {
-          return m_buff;
-        }
-
-        const U8* getBuffAddr() const {
-          return m_buff;
-        }
-
-      private:
-        // Should be the max of all the input ports serialized sizes...
-        U8 m_buff[SERIALIZATION_SIZE];
-
-    };
-  }
-
-  // ----------------------------------------------------------------------
-  // Types for internal state machines
-  // ----------------------------------------------------------------------
-
-  SmStateQueuedComponentBase::FppTest_SmState_Basic ::
-    FppTest_SmState_Basic(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
-
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_Basic ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_Basic ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Basic ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Basic ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_Basic ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
-    FppTest_SmState_BasicGuard(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::FppTest_SmState_BasicGuard(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicGuard_action_a(this->getId(), signal);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::
-    guard_g(Signal signal) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuard ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmState_BasicGuard_guard_g(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
-    FppTest_SmState_BasicGuardString(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::FppTest_SmState_BasicGuardString(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
-    action_a(
-        Signal signal,
-        const Fw::StringBase& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::action_a(Signal signal,
+                                                                             const Fw::StringBase& value) {
     this->m_component.FppTest_SmState_BasicGuardString_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::
-    guard_g(
-        Signal signal,
-        const Fw::StringBase& value
-    ) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString ::guard_g(Signal signal,
+                                                                            const Fw::StringBase& value) const {
     return this->m_component.FppTest_SmState_BasicGuardString_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    FppTest_SmState_BasicGuardTestAbsType(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::FppTest_SmState_BasicGuardTestAbsType(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestAbsType& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestAbsType& value) {
     this->m_component.FppTest_SmState_BasicGuardTestAbsType_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestAbsType& value
-    ) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestAbsType& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestAbsType_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    FppTest_SmState_BasicGuardTestArray(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::FppTest_SmState_BasicGuardTestArray(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestArray& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestArray& value) {
     this->m_component.FppTest_SmState_BasicGuardTestArray_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestArray& value
-    ) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestArray& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestArray_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    FppTest_SmState_BasicGuardTestEnum(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::FppTest_SmState_BasicGuardTestEnum(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestEnum& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestEnum& value) {
     this->m_component.FppTest_SmState_BasicGuardTestEnum_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestEnum& value
-    ) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestEnum& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestEnum_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    FppTest_SmState_BasicGuardTestStruct(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::FppTest_SmState_BasicGuardTestStruct(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    action_a(
-        Signal signal,
-        const FppTest::SmHarness::TestStruct& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::action_a(
+    Signal signal,
+    const FppTest::SmHarness::TestStruct& value) {
     this->m_component.FppTest_SmState_BasicGuardTestStruct_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::
-    guard_g(
-        Signal signal,
-        const FppTest::SmHarness::TestStruct& value
-    ) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct ::guard_g(
+    Signal signal,
+    const FppTest::SmHarness::TestStruct& value) const {
     return this->m_component.FppTest_SmState_BasicGuardTestStruct_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
-    FppTest_SmState_BasicGuardU32(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::FppTest_SmState_BasicGuardU32(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
-    action_a(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::action_a(Signal signal, U32 value) {
     this->m_component.FppTest_SmState_BasicGuardU32_action_a(this->getId(), signal, value);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::
-    guard_g(
-        Signal signal,
-        U32 value
-    ) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32 ::guard_g(Signal signal, U32 value) const {
     return this->m_component.FppTest_SmState_BasicGuardU32_guard_g(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
-    FppTest_SmState_BasicInternal(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::FppTest_SmState_BasicInternal(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicInternal ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicInternal_action_a(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
-    FppTest_SmState_BasicSelf(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::FppTest_SmState_BasicSelf(SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicSelf ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicSelf_action_a(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
-    FppTest_SmState_BasicString(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicString ::FppTest_SmState_BasicString(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicString ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicString_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::
-    action_b(
-        Signal signal,
-        const Fw::StringBase& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicString ::action_b(Signal signal, const Fw::StringBase& value) {
     this->m_component.FppTest_SmState_BasicString_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
-    FppTest_SmState_BasicTestAbsType(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::FppTest_SmState_BasicTestAbsType(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestAbsType& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType ::action_b(
+    Signal signal,
+    const FppTest::SmHarness::TestAbsType& value) {
     this->m_component.FppTest_SmState_BasicTestAbsType_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
-    FppTest_SmState_BasicTestArray(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::FppTest_SmState_BasicTestArray(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestArray_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestArray& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray ::action_b(Signal signal,
+                                                                           const FppTest::SmHarness::TestArray& value) {
     this->m_component.FppTest_SmState_BasicTestArray_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
-    FppTest_SmState_BasicTestEnum(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::FppTest_SmState_BasicTestEnum(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestEnum_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestEnum& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum ::action_b(Signal signal,
+                                                                          const FppTest::SmHarness::TestEnum& value) {
     this->m_component.FppTest_SmState_BasicTestEnum_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
-    FppTest_SmState_BasicTestStruct(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::FppTest_SmState_BasicTestStruct(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicTestStruct_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::
-    action_b(
-        Signal signal,
-        const FppTest::SmHarness::TestStruct& value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct ::action_b(
+    Signal signal,
+    const FppTest::SmHarness::TestStruct& value) {
     this->m_component.FppTest_SmState_BasicTestStruct_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
-    FppTest_SmState_BasicU32(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::FppTest_SmState_BasicU32(SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_BasicU32_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::
-    action_b(
-        Signal signal,
-        U32 value
-    )
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_BasicU32 ::action_b(Signal signal, U32 value) {
     this->m_component.FppTest_SmState_BasicU32_action_b(this->getId(), signal, value);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_Internal ::
-    FppTest_SmState_Internal(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_Internal ::FppTest_SmState_Internal(SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_Internal ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_Internal ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Internal ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Internal ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_Internal ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_Internal ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_Internal_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_Polymorphism ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    FppTest_SmState_StateToChild(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::FppTest_SmState_StateToChild(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    action_exitS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    action_exitS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    action_enterS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::
-    action_enterS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChild ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChild_action_enterS3(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    FppTest_SmState_StateToChoice(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::FppTest_SmState_StateToChoice(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_exitS1(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_exitS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_exitS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS1(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS1(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS3(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    action_enterS4(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::action_enterS4(Signal signal) {
     this->m_component.FppTest_SmState_StateToChoice_action_enterS4(this->getId(), signal);
-  }
+}
 
-  bool SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::
-    guard_g(Signal signal) const
-  {
+bool SmStateQueuedComponentBase::FppTest_SmState_StateToChoice ::guard_g(Signal signal) const {
     return this->m_component.FppTest_SmState_StateToChoice_guard_g(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    FppTest_SmState_StateToSelf(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::FppTest_SmState_StateToSelf(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    action_exitS1(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    action_exitS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    action_exitS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    action_enterS1(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_enterS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS1(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    action_enterS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::
-    action_enterS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToSelf ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToSelf_action_enterS3(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    FppTest_SmState_StateToState(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToState ::FppTest_SmState_StateToState(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmState_StateToState ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_exitS1(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_exitS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_exitS1(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_exitS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_exitS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_exitS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_exitS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_exitS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_exitS3(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_a(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_a(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_enterS1(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS1(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS1(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_enterS2(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS2(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS2(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_enterS3(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS3(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS3(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_enterS4(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS4(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS4(this->getId(), signal);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::
-    action_enterS5(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmState_StateToState ::action_enterS5(Signal signal) {
     this->m_component.FppTest_SmState_StateToState_action_enterS5(this->getId(), signal);
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
-    FppTest_SmStateQueued_Basic(SmStateQueuedComponentBase& component) :
-      m_component(component)
-  {
+SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::FppTest_SmStateQueued_Basic(
+    SmStateQueuedComponentBase& component)
+    : m_component(component) {}
 
-  }
-
-  void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
-    init(SmStateQueuedComponentBase::SmId smId)
-  {
+void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::init(SmStateQueuedComponentBase::SmId smId) {
     this->initBase(static_cast<FwEnumStoreType>(smId));
-  }
+}
 
-  SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
-    getId() const
-  {
+SmStateQueuedComponentBase::SmId SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::getId() const {
     return static_cast<SmStateQueuedComponentBase::SmId>(this->m_id);
-  }
+}
 
-  void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::
-    action_a(Signal signal)
-  {
+void SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic ::action_a(Signal signal) {
     this->m_component.FppTest_SmStateQueued_Basic_action_a(this->getId(), signal);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Component initialization
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component initialization
+// ----------------------------------------------------------------------
 
-  void SmStateQueuedComponentBase ::
-    init(
-        FwSizeType queueDepth,
-        FwEnumStoreType instance
-    )
-  {
+void SmStateQueuedComponentBase ::init(FwSizeType queueDepth, FwEnumStoreType instance) {
     // Initialize base class
     Fw::QueuedComponentBase::init(instance);
 
@@ -981,67 +649,45 @@ namespace FppTest {
 
 #if !FW_DIRECT_PORT_CALLS
     // Connect input port schedIn
-    for (
-      FwIndexType port = 0;
-      port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts());
-      port++
-    ) {
-      this->m_schedIn_InputPort[port].init();
-      this->m_schedIn_InputPort[port].addCallComp(
-        this,
-        m_p_schedIn_in
-      );
-      this->m_schedIn_InputPort[port].setPortNum(port);
+    for (FwIndexType port = 0; port < static_cast<FwIndexType>(this->getNum_schedIn_InputPorts()); port++) {
+        this->m_schedIn_InputPort[port].init();
+        this->m_schedIn_InputPort[port].addCallComp(this, m_p_schedIn_in);
+        this->m_schedIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      Fw::ObjectName portName;
-      portName.format(
-        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
-        this->m_objName.toChar(),
-        port
-      );
-      this->m_schedIn_InputPort[port].setObjName(portName.toChar());
+        Fw::ObjectName portName;
+        portName.format("%s_schedIn_InputPort[%" PRI_FwIndexType "]", this->m_objName.toChar(), port);
+        this->m_schedIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
 
     // Create the queue
-    Os::Queue::Status qStat = this->createQueue(
-      queueDepth,
-      static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE)
-    );
-    FW_ASSERT(
-      Os::Queue::Status::OP_OK == qStat,
-      static_cast<FwAssertArgType>(qStat)
-    );
-  }
+    Os::Queue::Status qStat =
+        this->createQueue(queueDepth, static_cast<FwSizeType>(ComponentIpcSerializableBuffer::SERIALIZATION_SIZE));
+    FW_ASSERT(Os::Queue::Status::OP_OK == qStat, static_cast<FwAssertArgType>(qStat));
+}
 
 #if !FW_DIRECT_PORT_CALLS
 
-  // ----------------------------------------------------------------------
-  // Getters for typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Getters for typed input ports
+// ----------------------------------------------------------------------
 
-  Svc::InputSchedPort* SmStateQueuedComponentBase ::
-    get_schedIn_InputPort(FwIndexType portNum)
-  {
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+Svc::InputSchedPort* SmStateQueuedComponentBase ::get_schedIn_InputPort(FwIndexType portNum) {
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     return &this->m_schedIn_InputPort[portNum];
-  }
+}
 
 #endif
 
-  // ----------------------------------------------------------------------
-  // Component construction and destruction
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
 
-  SmStateQueuedComponentBase ::
-    SmStateQueuedComponentBase(const char* compName) :
-      Fw::QueuedComponentBase(compName),
+SmStateQueuedComponentBase ::SmStateQueuedComponentBase(const char* compName)
+    : Fw::QueuedComponentBase(compName),
       m_stateMachine_basic1(*this),
       m_stateMachine_basic2(*this),
       m_stateMachine_smStateBasic1(*this),
@@ -1066,602 +712,509 @@ namespace FppTest {
       m_stateMachine_smStateStateToChild(*this),
       m_stateMachine_smStateStateToChoice(*this),
       m_stateMachine_smStateStateToSelf(*this),
-      m_stateMachine_smStateStateToState(*this)
-  {
+      m_stateMachine_smStateStateToState(*this) {}
 
-  }
+SmStateQueuedComponentBase ::~SmStateQueuedComponentBase() {}
 
-  SmStateQueuedComponentBase ::
-    ~SmStateQueuedComponentBase()
-  {
+// ----------------------------------------------------------------------
+// Port handler base-class functions for typed input ports
+//
+// Call these functions directly to bypass the corresponding ports
+// ----------------------------------------------------------------------
 
-  }
-
-  // ----------------------------------------------------------------------
-  // Port handler base-class functions for typed input ports
-  //
-  // Call these functions directly to bypass the corresponding ports
-  // ----------------------------------------------------------------------
-
-  void SmStateQueuedComponentBase ::
-    schedIn_handlerBase(
-        FwIndexType portNum,
-        U32 context
-    )
-  {
+void SmStateQueuedComponentBase ::schedIn_handlerBase(FwIndexType portNum, U32 context) {
     // Make sure port number is valid
-    FW_ASSERT(
-      (0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()),
-      static_cast<FwAssertArgType>(portNum)
-    );
+    FW_ASSERT((0 <= portNum) && (portNum < this->getNum_schedIn_InputPorts()), static_cast<FwAssertArgType>(portNum));
 
     // Call handler function
-    this->schedIn_handler(
-      portNum,
-      context
-    );
-  }
+    this->schedIn_handler(portNum, context);
+}
 
-  // ----------------------------------------------------------------------
-  // State getter functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// State getter functions
+// ----------------------------------------------------------------------
 
-  SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::
-    basic1_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::basic1_getState() const {
     return this->m_stateMachine_basic1.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::
-    basic2_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmStateQueued_Basic::State SmStateQueuedComponentBase ::basic2_getState() const {
     return this->m_stateMachine_basic2.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::
-    smStateBasic1_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::smStateBasic1_getState() const {
     return this->m_stateMachine_smStateBasic1.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::
-    smStateBasic2_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_Basic::State SmStateQueuedComponentBase ::smStateBasic2_getState() const {
     return this->m_stateMachine_smStateBasic2.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuard::State SmStateQueuedComponentBase ::
-    smStateBasicGuard_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuard::State SmStateQueuedComponentBase ::smStateBasicGuard_getState()
+    const {
     return this->m_stateMachine_smStateBasicGuard.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString::State SmStateQueuedComponentBase ::
-    smStateBasicGuardString_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardString::State
+SmStateQueuedComponentBase ::smStateBasicGuardString_getState() const {
     return this->m_stateMachine_smStateBasicGuardString.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType::State SmStateQueuedComponentBase ::
-    smStateBasicGuardTestAbsType_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestAbsType::State
+SmStateQueuedComponentBase ::smStateBasicGuardTestAbsType_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestAbsType.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray::State SmStateQueuedComponentBase ::
-    smStateBasicGuardTestArray_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestArray::State
+SmStateQueuedComponentBase ::smStateBasicGuardTestArray_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestArray.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum::State SmStateQueuedComponentBase ::
-    smStateBasicGuardTestEnum_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestEnum::State
+SmStateQueuedComponentBase ::smStateBasicGuardTestEnum_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestEnum.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct::State SmStateQueuedComponentBase ::
-    smStateBasicGuardTestStruct_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardTestStruct::State
+SmStateQueuedComponentBase ::smStateBasicGuardTestStruct_getState() const {
     return this->m_stateMachine_smStateBasicGuardTestStruct.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32::State SmStateQueuedComponentBase ::
-    smStateBasicGuardU32_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicGuardU32::State
+SmStateQueuedComponentBase ::smStateBasicGuardU32_getState() const {
     return this->m_stateMachine_smStateBasicGuardU32.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicInternal::State SmStateQueuedComponentBase ::
-    smStateBasicInternal_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicInternal::State
+SmStateQueuedComponentBase ::smStateBasicInternal_getState() const {
     return this->m_stateMachine_smStateBasicInternal.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicSelf::State SmStateQueuedComponentBase ::
-    smStateBasicSelf_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicSelf::State SmStateQueuedComponentBase ::smStateBasicSelf_getState()
+    const {
     return this->m_stateMachine_smStateBasicSelf.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicString::State SmStateQueuedComponentBase ::
-    smStateBasicString_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicString::State
+SmStateQueuedComponentBase ::smStateBasicString_getState() const {
     return this->m_stateMachine_smStateBasicString.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType::State SmStateQueuedComponentBase ::
-    smStateBasicTestAbsType_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestAbsType::State
+SmStateQueuedComponentBase ::smStateBasicTestAbsType_getState() const {
     return this->m_stateMachine_smStateBasicTestAbsType.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray::State SmStateQueuedComponentBase ::
-    smStateBasicTestArray_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestArray::State
+SmStateQueuedComponentBase ::smStateBasicTestArray_getState() const {
     return this->m_stateMachine_smStateBasicTestArray.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum::State SmStateQueuedComponentBase ::
-    smStateBasicTestEnum_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestEnum::State
+SmStateQueuedComponentBase ::smStateBasicTestEnum_getState() const {
     return this->m_stateMachine_smStateBasicTestEnum.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct::State SmStateQueuedComponentBase ::
-    smStateBasicTestStruct_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicTestStruct::State
+SmStateQueuedComponentBase ::smStateBasicTestStruct_getState() const {
     return this->m_stateMachine_smStateBasicTestStruct.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_BasicU32::State SmStateQueuedComponentBase ::
-    smStateBasicU32_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_BasicU32::State SmStateQueuedComponentBase ::smStateBasicU32_getState()
+    const {
     return this->m_stateMachine_smStateBasicU32.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_Internal::State SmStateQueuedComponentBase ::
-    smStateInternal_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_Internal::State SmStateQueuedComponentBase ::smStateInternal_getState()
+    const {
     return this->m_stateMachine_smStateInternal.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_Polymorphism::State SmStateQueuedComponentBase ::
-    smStatePolymorphism_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_Polymorphism::State
+SmStateQueuedComponentBase ::smStatePolymorphism_getState() const {
     return this->m_stateMachine_smStatePolymorphism.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToChild::State SmStateQueuedComponentBase ::
-    smStateStateToChild_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToChild::State
+SmStateQueuedComponentBase ::smStateStateToChild_getState() const {
     return this->m_stateMachine_smStateStateToChild.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToChoice::State SmStateQueuedComponentBase ::
-    smStateStateToChoice_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToChoice::State
+SmStateQueuedComponentBase ::smStateStateToChoice_getState() const {
     return this->m_stateMachine_smStateStateToChoice.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToSelf::State SmStateQueuedComponentBase ::
-    smStateStateToSelf_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToSelf::State
+SmStateQueuedComponentBase ::smStateStateToSelf_getState() const {
     return this->m_stateMachine_smStateStateToSelf.getState();
-  }
+}
 
-  SmStateQueuedComponentBase::FppTest_SmState_StateToState::State SmStateQueuedComponentBase ::
-    smStateStateToState_getState() const
-  {
+SmStateQueuedComponentBase::FppTest_SmState_StateToState::State
+SmStateQueuedComponentBase ::smStateStateToState_getState() const {
     return this->m_stateMachine_smStateStateToState.getState();
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Signal send functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Signal send functions
+// ----------------------------------------------------------------------
 
-  void SmStateQueuedComponentBase ::
-    basic1_sendSignal_s()
-  {
+void SmStateQueuedComponentBase ::basic1_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic1, static_cast<FwEnumStoreType>(FppTest_SmStateQueued_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic1_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    basic2_sendSignal_s()
-  {
+void SmStateQueuedComponentBase ::basic2_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::basic2, static_cast<FwEnumStoreType>(FppTest_SmStateQueued_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->basic2_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasic1_sendSignal_s()
-  {
+void SmStateQueuedComponentBase ::smStateBasic1_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic1, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic1_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasic2_sendSignal_s()
-  {
+void SmStateQueuedComponentBase ::smStateBasic2_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasic2, static_cast<FwEnumStoreType>(FppTest_SmState_Basic::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasic2_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuard_sendSignal_s()
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuard_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuard, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuard::Signal::s),
+                          buffer);
     // Send the message and handle overflow
     this->smStateBasicGuard_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardString_sendSignal_s(const Fw::StringBase& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardString,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardString_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestAbsType_sendSignal_s(
+    const FppTest::SmHarness::TestAbsType& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestAbsType,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestAbsType_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestArray,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestArray_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestEnum,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestEnum_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestStruct_sendSignal_s(
+    const FppTest::SmHarness::TestStruct& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardTestStruct,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestStruct_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardU32_sendSignal_s(U32 value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicGuardU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicGuardU32,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardU32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicInternal_sendSignal_s()
-  {
+void SmStateQueuedComponentBase ::smStateBasicInternal_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicInternal, static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicInternal,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicInternal::Signal::s), buffer);
     // Send the message and handle overflow
     this->smStateBasicInternal_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicSelf_sendSignal_s()
-  {
+void SmStateQueuedComponentBase ::smStateBasicSelf_sendSignal_s() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicSelf, static_cast<FwEnumStoreType>(FppTest_SmState_BasicSelf::Signal::s),
+                          buffer);
     // Send the message and handle overflow
     this->smStateBasicSelf_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicString_sendSignal_s(const Fw::StringBase& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicString_sendSignal_s(const Fw::StringBase& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicString,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 200);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicString_sendSignal_s1(const Fw::StringBase& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicString_sendSignal_s1(const Fw::StringBase& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
+    this->sendSignalStart(SmId::smStateBasicString,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s1), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = value.serializeTo(buffer, 100);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestAbsType_sendSignal_s(const FppTest::SmHarness::TestAbsType& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestAbsType,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestAbsType_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestArray_sendSignal_s(const FppTest::SmHarness::TestArray& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestArray,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestArray_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestEnum_sendSignal_s(const FppTest::SmHarness::TestEnum& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestEnum,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestEnum_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestStruct_sendSignal_s(const FppTest::SmHarness::TestStruct& value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicTestStruct,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestStruct_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicU32_sendSignal_s(U32 value)
-  {
+void SmStateQueuedComponentBase ::smStateBasicU32_sendSignal_s(U32 value) {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s), buffer);
+    this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s),
+                          buffer);
     // Serialize the signal data
     const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicU32_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateInternal_sendSignal_S1_internal()
-  {
+void SmStateQueuedComponentBase ::smStateInternal_sendSignal_S1_internal() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
+    this->sendSignalStart(SmId::smStateInternal,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S1_internal), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateInternal_sendSignal_S2_to_S3()
-  {
+void SmStateQueuedComponentBase ::smStateInternal_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateInternal, static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateInternal,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Internal::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateInternal_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStatePolymorphism_sendSignal_poly()
-  {
+void SmStateQueuedComponentBase ::smStatePolymorphism_sendSignal_poly() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::poly), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStatePolymorphism_sendSignal_S2_to_S3()
-  {
+void SmStateQueuedComponentBase ::smStatePolymorphism_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStatePolymorphism, static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStatePolymorphism,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_Polymorphism::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStatePolymorphism_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToChild_sendSignal_S1_to_S2()
-  {
+void SmStateQueuedComponentBase ::smStateStateToChild_sendSignal_S1_to_S2() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S1_to_S2), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToChild_sendSignal_S2_to_S3()
-  {
+void SmStateQueuedComponentBase ::smStateStateToChild_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChild, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChild,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChild::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChild_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToChoice_sendSignal_S1_to_S4()
-  {
+void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignal_S1_to_S4() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToChoice_sendSignal_S1_to_C()
-  {
+void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignal_S1_to_C() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S1_to_C), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToChoice_sendSignal_S2_to_S3()
-  {
+void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToChoice, static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToChoice,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToChoice::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToChoice_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToSelf_sendSignal_S1_to_S1()
-  {
+void SmStateQueuedComponentBase ::smStateStateToSelf_sendSignal_S1_to_S1() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S1_to_S1), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToSelf_sendSignal_S2_to_S3()
-  {
+void SmStateQueuedComponentBase ::smStateStateToSelf_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToSelf, static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToSelf,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToSelf::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToSelf_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToState_sendSignal_S1_to_S4()
-  {
+void SmStateQueuedComponentBase ::smStateStateToState_sendSignal_S1_to_S4() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
+    this->sendSignalStart(SmId::smStateStateToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S4), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToState_sendSignal_S1_to_S5()
-  {
+void SmStateQueuedComponentBase ::smStateStateToState_sendSignal_S1_to_S5() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
+    this->sendSignalStart(SmId::smStateStateToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S1_to_S5), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToState_sendSignal_S2_to_S3()
-  {
+void SmStateQueuedComponentBase ::smStateStateToState_sendSignal_S2_to_S3() {
     ComponentIpcSerializableBuffer buffer;
     // Serialize the message type, port number, state ID, and signal
-    this->sendSignalStart(SmId::smStateStateToState, static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
+    this->sendSignalStart(SmId::smStateStateToState,
+                          static_cast<FwEnumStoreType>(FppTest_SmState_StateToState::Signal::S2_to_S3), buffer);
     // Send the message and handle overflow
     this->smStateStateToState_sendSignalFinish(buffer);
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Message dispatch functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Message dispatch functions
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::
-    doDispatch()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::doDispatch() {
     ComponentIpcSerializableBuffer _msg;
     FwQueuePriorityType _priority = 0;
 
-    Os::Queue::Status _msgStatus = this->m_queue.receive(
-      _msg,
-      Os::Queue::NONBLOCKING,
-      _priority
-    );
+    Os::Queue::Status _msgStatus = this->m_queue.receive(_msg, Os::Queue::NONBLOCKING, _priority);
     if (Os::Queue::Status::EMPTY == _msgStatus) {
-      return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
-    }
-    else {
-      FW_ASSERT(
-        _msgStatus == Os::Queue::OP_OK,
-        static_cast<FwAssertArgType>(_msgStatus)
-      );
+        return Fw::QueuedComponentBase::MSG_DISPATCH_EMPTY;
+    } else {
+        FW_ASSERT(_msgStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(_msgStatus));
     }
 
     // Reset to beginning of buffer
@@ -1669,463 +1222,310 @@ namespace FppTest {
 
     FwEnumStoreType _desMsg = 0;
     Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     MsgTypeEnum _msgType = static_cast<MsgTypeEnum>(_desMsg);
 
     if (_msgType == SMSTATEQUEUED_COMPONENT_EXIT) {
-      return MSG_DISPATCH_EXIT;
+        return MSG_DISPATCH_EXIT;
     }
 
     FwIndexType portNum = 0;
     _deserStatus = _msg.deserializeTo(portNum);
-    FW_ASSERT(
-      _deserStatus == Fw::FW_SERIALIZE_OK,
-      static_cast<FwAssertArgType>(_deserStatus)
-    );
+    FW_ASSERT(_deserStatus == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_deserStatus));
 
     switch (_msgType) {
+        // Handle signals to internal state machines
+        case INTERNAL_STATE_MACHINE_SIGNAL:
+            this->smDispatch(_msg);
+            break;
 
-      // Handle signals to internal state machines
-      case INTERNAL_STATE_MACHINE_SIGNAL:
-        this->smDispatch(_msg);
-        break;
-
-      default:
-        return MSG_DISPATCH_ERROR;
+        default:
+            return MSG_DISPATCH_ERROR;
     }
 
     return MSG_DISPATCH_OK;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for dispatching current messages
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for dispatching current messages
+// ----------------------------------------------------------------------
 
-  Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::
-    dispatchCurrentMessages()
-  {
+Fw::QueuedComponentBase::MsgDispatchStatus SmStateQueuedComponentBase ::dispatchCurrentMessages() {
     // Dispatch all current messages unless ERROR or EXIT occur
     const FwSizeType currentMessageCount = this->m_queue.getMessagesAvailable();
     MsgDispatchStatus messageStatus = MsgDispatchStatus::MSG_DISPATCH_EMPTY;
     for (FwSizeType i = 0; i < currentMessageCount; i++) {
-      messageStatus = this->doDispatch();
-      if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
-        break;
-      }
+        messageStatus = this->doDispatch();
+        if (messageStatus != QueuedComponentBase::MSG_DISPATCH_OK) {
+            break;
+        }
     }
     return messageStatus;
-  }
+}
 
-  // ----------------------------------------------------------------------
-  // Calls for messages received on typed input ports
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Calls for messages received on typed input ports
+// ----------------------------------------------------------------------
 
-  void SmStateQueuedComponentBase ::
-    m_p_schedIn_in(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 context
-    )
-  {
+void SmStateQueuedComponentBase ::m_p_schedIn_in(Fw::PassiveComponentBase* callComp, FwIndexType portNum, U32 context) {
     FW_ASSERT(callComp);
     SmStateQueuedComponentBase* compPtr = static_cast<SmStateQueuedComponentBase*>(callComp);
-    compPtr->schedIn_handlerBase(
-      portNum,
-      context
-    );
-  }
+    compPtr->schedIn_handlerBase(portNum, context);
+}
 
-  // ----------------------------------------------------------------------
-  // Send signal helper functions
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Send signal helper functions
+// ----------------------------------------------------------------------
 
-  void SmStateQueuedComponentBase ::
-    sendSignalStart(
-        SmId smId,
-        FwEnumStoreType signal,
-        Fw::SerialBufferBase& buffer
-    )
-  {
+void SmStateQueuedComponentBase ::sendSignalStart(SmId smId, FwEnumStoreType signal, Fw::SerialBufferBase& buffer) {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
     status = buffer.serializeFrom(static_cast<FwIndexType>(0));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
-    FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
     status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    basic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::basic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    basic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::basic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasic1_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 1, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasic2_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuard_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::BLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 2, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 3, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
-      this->incNumMsgDropped();
-      return;
+        this->incNumMsgDropped();
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 4, _block);
 
     if (qStatus == Os::Queue::Status::FULL) {
+        // Deserialize the state machine ID and signal
+        FwEnumStoreType smId;
+        FwEnumStoreType signal;
+        SmStateQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
 
-      // Deserialize the state machine ID and signal
-      FwEnumStoreType smId;
-      FwEnumStoreType signal;
-      SmStateQueuedComponentBase::deserializeSmIdAndSignal(buffer, smId, signal);
+        // Call the overflow hook
+        this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
 
-      // Call the overflow hook
-      this->smStateBasicGuardTestAbsType_stateMachineOverflowHook(static_cast<SmId>(smId), signal, buffer);
-
-      // Continue execution
-      return;
-
+        // Continue execution
+        return;
     }
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicGuardU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicString_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestAbsType_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestArray_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestEnum_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicTestStruct_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateBasicU32_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateInternal_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStatePolymorphism_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateStateToChild_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateStateToChoice_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateStateToSelf_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  void SmStateQueuedComponentBase ::
-    smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smStateStateToState_sendSignalFinish(Fw::LinearBufferBase& buffer) {
     // Send message
     Os::Queue::BlockingType _block = Os::Queue::NONBLOCKING;
     Os::Queue::Status qStatus = this->m_queue.send(buffer, 0, _block);
 
-    FW_ASSERT(
-      qStatus == Os::Queue::OP_OK,
-      static_cast<FwAssertArgType>(qStatus)
-    );
-  }
+    FW_ASSERT(qStatus == Os::Queue::OP_OK, static_cast<FwAssertArgType>(qStatus));
+}
 
-  // ----------------------------------------------------------------------
-  // Helper functions for state machine dispatch
-  // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Helper functions for state machine dispatch
+// ----------------------------------------------------------------------
 
-  void SmStateQueuedComponentBase ::
-    smDispatch(Fw::SerialBufferBase& buffer)
-  {
+void SmStateQueuedComponentBase ::smDispatch(Fw::SerialBufferBase& buffer) {
     // Deserialize the state machine ID and signal
     FwEnumStoreType storedSmId;
     FwEnumStoreType storedSignal;
@@ -2134,147 +1534,170 @@ namespace FppTest {
     // Select the target state machine instance
     const SmId smId = static_cast<SmId>(storedSmId);
     switch (smId) {
-      case SmId::basic1: {
-        const FppTest_SmStateQueued_Basic::Signal signal = static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
-        this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
-        break;
-      }
-      case SmId::basic2: {
-        const FppTest_SmStateQueued_Basic::Signal signal = static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
-        this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
-        break;
-      }
-      case SmId::smStateBasic1: {
-        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
-        break;
-      }
-      case SmId::smStateBasic2: {
-        const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
-        this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
-        break;
-      }
-      case SmId::smStateBasicGuard: {
-        const FppTest_SmState_BasicGuard::Signal signal = static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardString: {
-        const FppTest_SmState_BasicGuardString::Signal signal = static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestAbsType: {
-        const FppTest_SmState_BasicGuardTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestArray: {
-        const FppTest_SmState_BasicGuardTestArray::Signal signal = static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestEnum: {
-        const FppTest_SmState_BasicGuardTestEnum::Signal signal = static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardTestStruct: {
-        const FppTest_SmState_BasicGuardTestStruct::Signal signal = static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
-        break;
-      }
-      case SmId::smStateBasicGuardU32: {
-        const FppTest_SmState_BasicGuardU32::Signal signal = static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
-        this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
-        break;
-      }
-      case SmId::smStateBasicInternal: {
-        const FppTest_SmState_BasicInternal::Signal signal = static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
-        this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
-        break;
-      }
-      case SmId::smStateBasicSelf: {
-        const FppTest_SmState_BasicSelf::Signal signal = static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
-        this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
-        break;
-      }
-      case SmId::smStateBasicString: {
-        const FppTest_SmState_BasicString::Signal signal = static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
-        this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
-        break;
-      }
-      case SmId::smStateBasicTestAbsType: {
-        const FppTest_SmState_BasicTestAbsType::Signal signal = static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType, signal);
-        break;
-      }
-      case SmId::smStateBasicTestArray: {
-        const FppTest_SmState_BasicTestArray::Signal signal = static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
-        break;
-      }
-      case SmId::smStateBasicTestEnum: {
-        const FppTest_SmState_BasicTestEnum::Signal signal = static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
-        break;
-      }
-      case SmId::smStateBasicTestStruct: {
-        const FppTest_SmState_BasicTestStruct::Signal signal = static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
-        this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct, signal);
-        break;
-      }
-      case SmId::smStateBasicU32: {
-        const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
-        this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
-        break;
-      }
-      case SmId::smStateInternal: {
-        const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
-        this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
-        break;
-      }
-      case SmId::smStatePolymorphism: {
-        const FppTest_SmState_Polymorphism::Signal signal = static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
-        this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
-        break;
-      }
-      case SmId::smStateStateToChild: {
-        const FppTest_SmState_StateToChild::Signal signal = static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
-        this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
-        break;
-      }
-      case SmId::smStateStateToChoice: {
-        const FppTest_SmState_StateToChoice::Signal signal = static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
-        this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
-        break;
-      }
-      case SmId::smStateStateToSelf: {
-        const FppTest_SmState_StateToSelf::Signal signal = static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
-        this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
-        break;
-      }
-      case SmId::smStateStateToState: {
-        const FppTest_SmState_StateToState::Signal signal = static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
-        this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
-        break;
+        case SmId::basic1: {
+            const FppTest_SmStateQueued_Basic::Signal signal =
+                static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
+            this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic1, signal);
+            break;
+        }
+        case SmId::basic2: {
+            const FppTest_SmStateQueued_Basic::Signal signal =
+                static_cast<FppTest_SmStateQueued_Basic::Signal>(storedSignal);
+            this->FppTest_SmStateQueued_Basic_smDispatch(buffer, this->m_stateMachine_basic2, signal);
+            break;
+        }
+        case SmId::smStateBasic1: {
+            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic1, signal);
+            break;
+        }
+        case SmId::smStateBasic2: {
+            const FppTest_SmState_Basic::Signal signal = static_cast<FppTest_SmState_Basic::Signal>(storedSignal);
+            this->FppTest_SmState_Basic_smDispatch(buffer, this->m_stateMachine_smStateBasic2, signal);
+            break;
+        }
+        case SmId::smStateBasicGuard: {
+            const FppTest_SmState_BasicGuard::Signal signal =
+                static_cast<FppTest_SmState_BasicGuard::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuard_smDispatch(buffer, this->m_stateMachine_smStateBasicGuard, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardString: {
+            const FppTest_SmState_BasicGuardString::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardString::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardString_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardString,
+                                                              signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestAbsType: {
+            const FppTest_SmState_BasicGuardTestAbsType::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestAbsType::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestAbsType_smDispatch(
+                buffer, this->m_stateMachine_smStateBasicGuardTestAbsType, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestArray: {
+            const FppTest_SmState_BasicGuardTestArray::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestArray::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestArray_smDispatch(
+                buffer, this->m_stateMachine_smStateBasicGuardTestArray, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestEnum: {
+            const FppTest_SmState_BasicGuardTestEnum::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestEnum::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardTestEnum,
+                                                                signal);
+            break;
+        }
+        case SmId::smStateBasicGuardTestStruct: {
+            const FppTest_SmState_BasicGuardTestStruct::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardTestStruct::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardTestStruct_smDispatch(
+                buffer, this->m_stateMachine_smStateBasicGuardTestStruct, signal);
+            break;
+        }
+        case SmId::smStateBasicGuardU32: {
+            const FppTest_SmState_BasicGuardU32::Signal signal =
+                static_cast<FppTest_SmState_BasicGuardU32::Signal>(storedSignal);
+            this->FppTest_SmState_BasicGuardU32_smDispatch(buffer, this->m_stateMachine_smStateBasicGuardU32, signal);
+            break;
+        }
+        case SmId::smStateBasicInternal: {
+            const FppTest_SmState_BasicInternal::Signal signal =
+                static_cast<FppTest_SmState_BasicInternal::Signal>(storedSignal);
+            this->FppTest_SmState_BasicInternal_smDispatch(buffer, this->m_stateMachine_smStateBasicInternal, signal);
+            break;
+        }
+        case SmId::smStateBasicSelf: {
+            const FppTest_SmState_BasicSelf::Signal signal =
+                static_cast<FppTest_SmState_BasicSelf::Signal>(storedSignal);
+            this->FppTest_SmState_BasicSelf_smDispatch(buffer, this->m_stateMachine_smStateBasicSelf, signal);
+            break;
+        }
+        case SmId::smStateBasicString: {
+            const FppTest_SmState_BasicString::Signal signal =
+                static_cast<FppTest_SmState_BasicString::Signal>(storedSignal);
+            this->FppTest_SmState_BasicString_smDispatch(buffer, this->m_stateMachine_smStateBasicString, signal);
+            break;
+        }
+        case SmId::smStateBasicTestAbsType: {
+            const FppTest_SmState_BasicTestAbsType::Signal signal =
+                static_cast<FppTest_SmState_BasicTestAbsType::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestAbsType_smDispatch(buffer, this->m_stateMachine_smStateBasicTestAbsType,
+                                                              signal);
+            break;
+        }
+        case SmId::smStateBasicTestArray: {
+            const FppTest_SmState_BasicTestArray::Signal signal =
+                static_cast<FppTest_SmState_BasicTestArray::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestArray_smDispatch(buffer, this->m_stateMachine_smStateBasicTestArray, signal);
+            break;
+        }
+        case SmId::smStateBasicTestEnum: {
+            const FppTest_SmState_BasicTestEnum::Signal signal =
+                static_cast<FppTest_SmState_BasicTestEnum::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestEnum_smDispatch(buffer, this->m_stateMachine_smStateBasicTestEnum, signal);
+            break;
+        }
+        case SmId::smStateBasicTestStruct: {
+            const FppTest_SmState_BasicTestStruct::Signal signal =
+                static_cast<FppTest_SmState_BasicTestStruct::Signal>(storedSignal);
+            this->FppTest_SmState_BasicTestStruct_smDispatch(buffer, this->m_stateMachine_smStateBasicTestStruct,
+                                                             signal);
+            break;
+        }
+        case SmId::smStateBasicU32: {
+            const FppTest_SmState_BasicU32::Signal signal = static_cast<FppTest_SmState_BasicU32::Signal>(storedSignal);
+            this->FppTest_SmState_BasicU32_smDispatch(buffer, this->m_stateMachine_smStateBasicU32, signal);
+            break;
+        }
+        case SmId::smStateInternal: {
+            const FppTest_SmState_Internal::Signal signal = static_cast<FppTest_SmState_Internal::Signal>(storedSignal);
+            this->FppTest_SmState_Internal_smDispatch(buffer, this->m_stateMachine_smStateInternal, signal);
+            break;
+        }
+        case SmId::smStatePolymorphism: {
+            const FppTest_SmState_Polymorphism::Signal signal =
+                static_cast<FppTest_SmState_Polymorphism::Signal>(storedSignal);
+            this->FppTest_SmState_Polymorphism_smDispatch(buffer, this->m_stateMachine_smStatePolymorphism, signal);
+            break;
+        }
+        case SmId::smStateStateToChild: {
+            const FppTest_SmState_StateToChild::Signal signal =
+                static_cast<FppTest_SmState_StateToChild::Signal>(storedSignal);
+            this->FppTest_SmState_StateToChild_smDispatch(buffer, this->m_stateMachine_smStateStateToChild, signal);
+            break;
+        }
+        case SmId::smStateStateToChoice: {
+            const FppTest_SmState_StateToChoice::Signal signal =
+                static_cast<FppTest_SmState_StateToChoice::Signal>(storedSignal);
+            this->FppTest_SmState_StateToChoice_smDispatch(buffer, this->m_stateMachine_smStateStateToChoice, signal);
+            break;
+        }
+        case SmId::smStateStateToSelf: {
+            const FppTest_SmState_StateToSelf::Signal signal =
+                static_cast<FppTest_SmState_StateToSelf::Signal>(storedSignal);
+            this->FppTest_SmState_StateToSelf_smDispatch(buffer, this->m_stateMachine_smStateStateToSelf, signal);
+            break;
+        }
+        case SmId::smStateStateToState: {
+            const FppTest_SmState_StateToState::Signal signal =
+                static_cast<FppTest_SmState_StateToState::Signal>(storedSignal);
+            this->FppTest_SmState_StateToState_smDispatch(buffer, this->m_stateMachine_smStateStateToState, signal);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+            break;
     }
-  }
+}
 
-  void SmStateQueuedComponentBase ::
-    deserializeSmIdAndSignal(
-        Fw::SerialBufferBase& buffer,
-        FwEnumStoreType& smId,
-        FwEnumStoreType& signal
-    )
-  {
+void SmStateQueuedComponentBase ::deserializeSmIdAndSignal(Fw::SerialBufferBase& buffer,
+                                                           FwEnumStoreType& smId,
+                                                           FwEnumStoreType& signal) {
     // Move deserialization beyond the message type and port number
-    Fw::SerializeStatus status =
-      buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
+    Fw::SerializeStatus status = buffer.moveDeserToOffset(ComponentIpcSerializableBuffer::DATA_OFFSET);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
@@ -2284,607 +1707,560 @@ namespace FppTest {
     // Deserialize the signal
     status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_Basic& sm,
-        FppTest_SmState_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicGuard_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuard& sm,
-        FppTest_SmState_BasicGuard::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuard::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicGuardString_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardString& sm,
-        FppTest_SmState_BasicGuardString::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardString::Signal::s: {
-        // Deserialize the data
-        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicGuardTestAbsType_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestAbsType& sm,
-        FppTest_SmState_BasicGuardTestAbsType::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicGuardTestArray_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestArray& sm,
-        FppTest_SmState_BasicGuardTestArray::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestArray::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicGuardTestEnum_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestEnum& sm,
-        FppTest_SmState_BasicGuardTestEnum::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicGuardTestStruct_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardTestStruct& sm,
-        FppTest_SmState_BasicGuardTestStruct::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicGuardU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicGuardU32& sm,
-        FppTest_SmState_BasicGuardU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicGuardU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicInternal_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicInternal& sm,
-        FppTest_SmState_BasicInternal::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicInternal::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicSelf_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicSelf& sm,
-        FppTest_SmState_BasicSelf::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicSelf::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicString_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicString& sm,
-        FppTest_SmState_BasicString::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicString::Signal::s: {
-        // Deserialize the data
-        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
-        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      case FppTest_SmState_BasicString::Signal::s1: {
-        // Deserialize the data
-        char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
-        Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s1
-        sm.sendSignal_s1(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicTestAbsType_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestAbsType& sm,
-        FppTest_SmState_BasicTestAbsType::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestAbsType::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicTestArray_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestArray& sm,
-        FppTest_SmState_BasicTestArray::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestArray::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicTestEnum_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestEnum& sm,
-        FppTest_SmState_BasicTestEnum::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestEnum::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicTestStruct_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicTestStruct& sm,
-        FppTest_SmState_BasicTestStruct::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicTestStruct::Signal::s: {
-        // Deserialize the data
-        FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_BasicU32_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_BasicU32& sm,
-        FppTest_SmState_BasicU32::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_BasicU32::Signal::s: {
-        // Deserialize the data
-        U32 value;
-        const Fw::SerializeStatus status = buffer.deserializeTo(value);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s(value);
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_Internal_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_Internal& sm,
-        FppTest_SmState_Internal::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_Internal::Signal::S1_internal: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_internal
-        sm.sendSignal_S1_internal();
-        break;
-      }
-      case FppTest_SmState_Internal::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_Polymorphism_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_Polymorphism& sm,
-        FppTest_SmState_Polymorphism::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_Polymorphism::Signal::poly: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and poly
-        sm.sendSignal_poly();
-        break;
-      }
-      case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_StateToChild_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToChild& sm,
-        FppTest_SmState_StateToChild::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S2
-        sm.sendSignal_S1_to_S2();
-        break;
-      }
-      case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_StateToChoice_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToChoice& sm,
-        FppTest_SmState_StateToChoice::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S4
-        sm.sendSignal_S1_to_S4();
-        break;
-      }
-      case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_C
-        sm.sendSignal_S1_to_C();
-        break;
-      }
-      case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_StateToSelf_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToSelf& sm,
-        FppTest_SmState_StateToSelf::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S1
-        sm.sendSignal_S1_to_S1();
-        break;
-      }
-      case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmState_StateToState_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmState_StateToState& sm,
-        FppTest_SmState_StateToState::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmState_StateToState::Signal::S1_to_S4: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S4
-        sm.sendSignal_S1_to_S4();
-        break;
-      }
-      case FppTest_SmState_StateToState::Signal::S1_to_S5: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S1_to_S5
-        sm.sendSignal_S1_to_S5();
-        break;
-      }
-      case FppTest_SmState_StateToState::Signal::S2_to_S3: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and S2_to_S3
-        sm.sendSignal_S2_to_S3();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
-  void SmStateQueuedComponentBase ::
-    FppTest_SmStateQueued_Basic_smDispatch(
-        Fw::SerialBufferBase& buffer,
-        FppTest_SmStateQueued_Basic& sm,
-        FppTest_SmStateQueued_Basic::Signal signal
-    )
-  {
-    switch (signal) {
-      case FppTest_SmStateQueued_Basic::Signal::s: {
-        // Assert no data left in buffer
-        FW_ASSERT(buffer.getDeserializeSizeLeft() == 0, static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
-        // Call the sendSignal function for sm and s
-        sm.sendSignal_s();
-        break;
-      }
-      default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
-        break;
-    }
-  }
-
 }
+
+void SmStateQueuedComponentBase ::FppTest_SmState_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                   FppTest_SmState_Basic& sm,
+                                                                   FppTest_SmState_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuard_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                        FppTest_SmState_BasicGuard& sm,
+                                                                        FppTest_SmState_BasicGuard::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuard::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardString_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardString& sm,
+    FppTest_SmState_BasicGuardString::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardString::Signal::s: {
+            // Deserialize the data
+            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(
+                static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestAbsType_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestAbsType& sm,
+    FppTest_SmState_BasicGuardTestAbsType::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestAbsType value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestArray_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestArray& sm,
+    FppTest_SmState_BasicGuardTestArray::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestArray::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestArray value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestEnum_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestEnum& sm,
+    FppTest_SmState_BasicGuardTestEnum::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestEnum value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardTestStruct_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardTestStruct& sm,
+    FppTest_SmState_BasicGuardTestStruct::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestStruct value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicGuardU32_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicGuardU32& sm,
+    FppTest_SmState_BasicGuardU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicGuardU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicInternal_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicInternal& sm,
+    FppTest_SmState_BasicInternal::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicInternal::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicSelf_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                       FppTest_SmState_BasicSelf& sm,
+                                                                       FppTest_SmState_BasicSelf::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicSelf::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicString_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                         FppTest_SmState_BasicString& sm,
+                                                                         FppTest_SmState_BasicString::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicString::Signal::s: {
+            // Deserialize the data
+            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(200)];
+            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        case FppTest_SmState_BasicString::Signal::s1: {
+            // Deserialize the data
+            char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(100)];
+            Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s1
+            sm.sendSignal_s1(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestAbsType_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestAbsType& sm,
+    FppTest_SmState_BasicTestAbsType::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestAbsType::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestAbsType value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestArray_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestArray& sm,
+    FppTest_SmState_BasicTestArray::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestArray::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestArray value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestEnum_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestEnum& sm,
+    FppTest_SmState_BasicTestEnum::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestEnum::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestEnum value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicTestStruct_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_BasicTestStruct& sm,
+    FppTest_SmState_BasicTestStruct::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicTestStruct::Signal::s: {
+            // Deserialize the data
+            FppTest::SmHarness::TestStruct value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_BasicU32_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                      FppTest_SmState_BasicU32& sm,
+                                                                      FppTest_SmState_BasicU32::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_BasicU32::Signal::s: {
+            // Deserialize the data
+            U32 value;
+            const Fw::SerializeStatus status = buffer.deserializeTo(value);
+            FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s(value);
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_Internal_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                      FppTest_SmState_Internal& sm,
+                                                                      FppTest_SmState_Internal::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_Internal::Signal::S1_internal: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_internal
+            sm.sendSignal_S1_internal();
+            break;
+        }
+        case FppTest_SmState_Internal::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_Polymorphism_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                          FppTest_SmState_Polymorphism& sm,
+                                                                          FppTest_SmState_Polymorphism::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_Polymorphism::Signal::poly: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and poly
+            sm.sendSignal_poly();
+            break;
+        }
+        case FppTest_SmState_Polymorphism::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_StateToChild_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                          FppTest_SmState_StateToChild& sm,
+                                                                          FppTest_SmState_StateToChild::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToChild::Signal::S1_to_S2: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S2
+            sm.sendSignal_S1_to_S2();
+            break;
+        }
+        case FppTest_SmState_StateToChild::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_StateToChoice_smDispatch(
+    Fw::SerialBufferBase& buffer,
+    FppTest_SmState_StateToChoice& sm,
+    FppTest_SmState_StateToChoice::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToChoice::Signal::S1_to_S4: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S4
+            sm.sendSignal_S1_to_S4();
+            break;
+        }
+        case FppTest_SmState_StateToChoice::Signal::S1_to_C: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_C
+            sm.sendSignal_S1_to_C();
+            break;
+        }
+        case FppTest_SmState_StateToChoice::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_StateToSelf_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                         FppTest_SmState_StateToSelf& sm,
+                                                                         FppTest_SmState_StateToSelf::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToSelf::Signal::S1_to_S1: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S1
+            sm.sendSignal_S1_to_S1();
+            break;
+        }
+        case FppTest_SmState_StateToSelf::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmState_StateToState_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                          FppTest_SmState_StateToState& sm,
+                                                                          FppTest_SmState_StateToState::Signal signal) {
+    switch (signal) {
+        case FppTest_SmState_StateToState::Signal::S1_to_S4: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S4
+            sm.sendSignal_S1_to_S4();
+            break;
+        }
+        case FppTest_SmState_StateToState::Signal::S1_to_S5: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S1_to_S5
+            sm.sendSignal_S1_to_S5();
+            break;
+        }
+        case FppTest_SmState_StateToState::Signal::S2_to_S3: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and S2_to_S3
+            sm.sendSignal_S2_to_S3();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+void SmStateQueuedComponentBase ::FppTest_SmStateQueued_Basic_smDispatch(Fw::SerialBufferBase& buffer,
+                                                                         FppTest_SmStateQueued_Basic& sm,
+                                                                         FppTest_SmStateQueued_Basic::Signal signal) {
+    switch (signal) {
+        case FppTest_SmStateQueued_Basic::Signal::s: {
+            // Assert no data left in buffer
+            FW_ASSERT(buffer.getDeserializeSizeLeft() == 0,
+                      static_cast<FwAssertArgType>(buffer.getDeserializeSizeLeft()));
+            // Call the sendSignal function for sm and s
+            sm.sendSignal_s();
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+            break;
+    }
+}
+
+}  // namespace FppTest

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
@@ -52,9 +52,8 @@ namespace Ports {
       // ----------------------------------------------------------------------
 
       //! Constructor
-      TypedPortBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = CAPACITY;
+      TypedPortBuffer() : Fw::LinearBufferBase(m_buff, CAPACITY) {
+
       }
 
     private:

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
@@ -22,271 +22,216 @@
 
 namespace Ports {
 
-  //! Serialization buffer for Typed port
-  //! A typed port
-  class TypedPortBuffer :
-    public Fw::LinearBufferBase
-  {
+//! Serialization buffer for Typed port
+//! A typed port
+class TypedPortBuffer : public Fw::LinearBufferBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Public constants for TypedPortBuffer
+    // ----------------------------------------------------------------------
 
-    public:
-
-      // ----------------------------------------------------------------------
-      // Public constants for TypedPortBuffer
-      // ----------------------------------------------------------------------
-
-      //! The buffer capacity. This is the sum of the static serialized
-      //! sizes of the port arguments.
-      static constexpr FwSizeType CAPACITY =
-        sizeof(U32) +
-        sizeof(F32) +
-        sizeof(U8) +
+    //! The buffer capacity. This is the sum of the static serialized
+    //! sizes of the port arguments.
+    static constexpr FwSizeType CAPACITY =
+        sizeof(U32) + sizeof(F32) + sizeof(U8) +
         Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-        E::SERIALIZED_SIZE +
-        A::SERIALIZED_SIZE +
-        S::SERIALIZED_SIZE;
+        E::SERIALIZED_SIZE + A::SERIALIZED_SIZE + S::SERIALIZED_SIZE;
 
-    public:
+  public:
+    // ----------------------------------------------------------------------
+    // Public member functions for TypedPortBuffer
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Public member functions for TypedPortBuffer
-      // ----------------------------------------------------------------------
+    //! Constructor
+    TypedPortBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = CAPACITY;
+    }
 
-      //! Get the capacity of the buffer
-      //! \return The capacity
-      Fw::Serializable::SizeType getCapacity() const override {
-        return CAPACITY;
-      }
+  private:
+    // ----------------------------------------------------------------------
+    // Private member variables
+    // ----------------------------------------------------------------------
 
-      //! Get the buffer address (non-const)
-      //! \return The buffer address
-      U8* getBuffAddr() override {
-        return m_buff;
-      }
+    U8 m_buff[CAPACITY];
+};
 
-      //! Get the buffer address (const)
-      //! \return The buffer address
-      const U8* getBuffAddr() const override {
-        return m_buff;
-      }
+//! Serializer for Typed port
+//! A typed port
+class TypedPortSerializer {
+  public:
+    // ----------------------------------------------------------------------
+    // Public constructors for TypedPortSerializer
+    // ----------------------------------------------------------------------
 
-    private:
+    //! Constructor
+    TypedPortSerializer();
 
-      // ----------------------------------------------------------------------
-      // Private member variables
-      // ----------------------------------------------------------------------
+  public:
+    // ----------------------------------------------------------------------
+    // Public member functions for TypedPortSerializer
+    // ----------------------------------------------------------------------
 
-      U8 m_buff[CAPACITY];
+    //! Deserialze port arguments into members
+    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    );
 
-  };
+  public:
+    // ----------------------------------------------------------------------
+    // Public static functions for TypedPortSerializer
+    // ----------------------------------------------------------------------
 
-  //! Serializer for Typed port
-  //! A typed port
-  class TypedPortSerializer {
+    //! Serialize port arguments into a buffer
+    static Fw::SerializeStatus serializePortArgs(U32 u32,                       //!< A U32
+                                                 F32 f32,                       //!< An F32
+                                                 bool b,                        //!< A boolean
+                                                 const Fw::StringBase& str1,    //!< A string
+                                                 const E& e,                    //!< An enum
+                                                 const A& a,                    //!< An array
+                                                 const S& s,                    //!< A struct
+                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    );
 
-    public:
+  private:
+    // ----------------------------------------------------------------------
+    // Private member variables for TypedPortSerializer
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Public constructors for TypedPortSerializer
-      // ----------------------------------------------------------------------
+    char m___fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
 
-      //! Constructor
-      TypedPortSerializer();
+  public:
+    // ----------------------------------------------------------------------
+    // Public member variables for TypedPortSerializer
+    // ----------------------------------------------------------------------
 
-    public:
-
-      // ----------------------------------------------------------------------
-      // Public member functions for TypedPortSerializer
-      // ----------------------------------------------------------------------
-
-      //! Deserialze port arguments into members
-      Fw::SerializeStatus deserializePortArgs(
-          Fw::SerialBufferBase& _buffer //!< The serial buffer
-      );
-
-    public:
-
-      // ----------------------------------------------------------------------
-      // Public static functions for TypedPortSerializer
-      // ----------------------------------------------------------------------
-
-      //! Serialize port arguments into a buffer
-      static Fw::SerializeStatus serializePortArgs(
-          U32 u32, //!< A U32
-          F32 f32, //!< An F32
-          bool b, //!< A boolean
-          const Fw::StringBase& str1, //!< A string
-          const E& e, //!< An enum
-          const A& a, //!< An array
-          const S& s, //!< A struct
-          Fw::SerialBufferBase& _buffer //!< The serial buffer
-      );
-
-    private:
-
-      // ----------------------------------------------------------------------
-      // Private member variables for TypedPortSerializer
-      // ----------------------------------------------------------------------
-
-      char m___fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-
-    public:
-
-      // ----------------------------------------------------------------------
-      // Public member variables for TypedPortSerializer
-      // ----------------------------------------------------------------------
-
-      U32 m_u32;
-      F32 m_f32;
-      bool m_b;
-      Fw::ExternalString m_str1;
-      E m_e;
-      A m_a;
-      S m_s;
-
-  };
+    U32 m_u32;
+    F32 m_f32;
+    bool m_b;
+    Fw::ExternalString m_str1;
+    E m_e;
+    A m_a;
+    S m_s;
+};
 
 #if !FW_DIRECT_PORT_CALLS
 
-  //! Input Typed port
-  //! A typed port
-  class InputTypedPort :
-    public Fw::InputPortBase
-  {
+//! Input Typed port
+//! A typed port
+class InputTypedPort : public Fw::InputPortBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Public types for InputTypedPort
+    // ----------------------------------------------------------------------
 
-    public:
+    //! The port callback function type
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
+                                FwIndexType portNum,
+                                U32 u32,
+                                F32 f32,
+                                bool b,
+                                const Fw::StringBase& str1,
+                                const E& e,
+                                const A& a,
+                                const S& s);
 
-      // ----------------------------------------------------------------------
-      // Public types for InputTypedPort
-      // ----------------------------------------------------------------------
+  public:
+    // ----------------------------------------------------------------------
+    // Public constructors for InputTypedPort
+    // ----------------------------------------------------------------------
 
-      //! The port callback function type
-      typedef void (*CompFuncPtr)(
-        Fw::PassiveComponentBase* callComp,
-        FwIndexType portNum,
-        U32 u32,
-        F32 f32,
-        bool b,
-        const Fw::StringBase& str1,
-        const E& e,
-        const A& a,
-        const S& s
-      );
+    //! Constructor
+    InputTypedPort();
 
-    public:
+  public:
+    // ----------------------------------------------------------------------
+    // Public member functions for InputTypedPort
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Public constructors for InputTypedPort
-      // ----------------------------------------------------------------------
+    //! Initialization function
+    void init();
 
-      //! Constructor
-      InputTypedPort();
+    //! Register a component
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
+    );
 
-    public:
+    //! Invoke a port interface
+    void invoke(U32 u32,                     //!< A U32
+                F32 f32,                     //!< An F32
+                bool b,                      //!< A boolean
+                const Fw::StringBase& str1,  //!< A string
+                const E& e,                  //!< An enum
+                const A& a,                  //!< An array
+                const S& s                   //!< A struct
+    );
 
-      // ----------------------------------------------------------------------
-      // Public member functions for InputTypedPort
-      // ----------------------------------------------------------------------
-
-      //! Initialization function
-      void init();
-
-      //! Register a component
-      void addCallComp(
-          Fw::PassiveComponentBase* callComp, //!< The containing component
-          CompFuncPtr funcPtr //!< The port callback function
-      );
-
-      //! Invoke a port interface
-      void invoke(
-          U32 u32, //!< A U32
-          F32 f32, //!< An F32
-          bool b, //!< A boolean
-          const Fw::StringBase& str1, //!< A string
-          const E& e, //!< An enum
-          const A& a, //!< An array
-          const S& s //!< A struct
-      );
-
-    private:
-
-      // ----------------------------------------------------------------------
-      // Private member functions for InputTypedPort
-      // ----------------------------------------------------------------------
+  private:
+    // ----------------------------------------------------------------------
+    // Private member functions for InputTypedPort
+    // ----------------------------------------------------------------------
 
 #if FW_PORT_SERIALIZATION == 1
 
-      //! Invoke the port with serialized arguments
-      //! \return The serialize status
-      Fw::SerializeStatus invokeSerial(
-          Fw::LinearBufferBase& _buffer //!< The serial buffer
-      );
+    //! Invoke the port with serialized arguments
+    //! \return The serialize status
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    );
 
 #endif
 
-    private:
+  private:
+    // ----------------------------------------------------------------------
+    // Private member variables for InputTypedPort
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Private member variables for InputTypedPort
-      // ----------------------------------------------------------------------
+    //! The pointer to the port callback function
+    CompFuncPtr m_func;
+};
 
-      //! The pointer to the port callback function
-      CompFuncPtr m_func;
+//! Output Typed port
+//! A typed port
+class OutputTypedPort : public Fw::OutputPortBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Public constructors for OutputTypedPort
+    // ----------------------------------------------------------------------
 
-  };
+    //! Constructor
+    OutputTypedPort();
 
-  //! Output Typed port
-  //! A typed port
-  class OutputTypedPort :
-    public Fw::OutputPortBase
-  {
+  public:
+    // ----------------------------------------------------------------------
+    // Public member functions for OutputTypedPort
+    // ----------------------------------------------------------------------
 
-    public:
+    //! Initialization function
+    void init();
 
-      // ----------------------------------------------------------------------
-      // Public constructors for OutputTypedPort
-      // ----------------------------------------------------------------------
+    //! Register an input port
+    void addCallPort(InputTypedPort* callPort  //!< The input port
+    );
 
-      //! Constructor
-      OutputTypedPort();
+    //! Invoke a port connection
+    void invoke(U32 u32,                     //!< A U32
+                F32 f32,                     //!< An F32
+                bool b,                      //!< A boolean
+                const Fw::StringBase& str1,  //!< A string
+                const E& e,                  //!< An enum
+                const A& a,                  //!< An array
+                const S& s                   //!< A struct
+    ) const;
 
-    public:
+  private:
+    // ----------------------------------------------------------------------
+    // Private member variables for OutputTypedPort
+    // ----------------------------------------------------------------------
 
-      // ----------------------------------------------------------------------
-      // Public member functions for OutputTypedPort
-      // ----------------------------------------------------------------------
-
-      //! Initialization function
-      void init();
-
-      //! Register an input port
-      void addCallPort(
-          InputTypedPort* callPort //!< The input port
-      );
-
-      //! Invoke a port connection
-      void invoke(
-          U32 u32, //!< A U32
-          F32 f32, //!< An F32
-          bool b, //!< A boolean
-          const Fw::StringBase& str1, //!< A string
-          const E& e, //!< An enum
-          const A& a, //!< An array
-          const S& s //!< A struct
-      ) const;
-
-    private:
-
-      // ----------------------------------------------------------------------
-      // Private member variables for OutputTypedPort
-      // ----------------------------------------------------------------------
-
-      //! The pointer to the input port
-      InputTypedPort* m_port;
-
-  };
+    //! The pointer to the input port
+    InputTypedPort* m_port;
+};
 
 #endif
 
-}
+}  // namespace Ports
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
@@ -22,216 +22,259 @@
 
 namespace Ports {
 
-//! Serialization buffer for Typed port
-//! A typed port
-class TypedPortBuffer : public Fw::LinearBufferBase {
-  public:
-    // ----------------------------------------------------------------------
-    // Public constants for TypedPortBuffer
-    // ----------------------------------------------------------------------
+  //! Serialization buffer for Typed port
+  //! A typed port
+  class TypedPortBuffer :
+    public Fw::LinearBufferBase
+  {
 
-    //! The buffer capacity. This is the sum of the static serialized
-    //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY =
-        sizeof(U32) + sizeof(F32) + sizeof(U8) +
+    public:
+
+      // ----------------------------------------------------------------------
+      // Public constants for TypedPortBuffer
+      // ----------------------------------------------------------------------
+
+      //! The buffer capacity. This is the sum of the static serialized
+      //! sizes of the port arguments.
+      static constexpr FwSizeType CAPACITY =
+        sizeof(U32) +
+        sizeof(F32) +
+        sizeof(U8) +
         Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-        E::SERIALIZED_SIZE + A::SERIALIZED_SIZE + S::SERIALIZED_SIZE;
+        E::SERIALIZED_SIZE +
+        A::SERIALIZED_SIZE +
+        S::SERIALIZED_SIZE;
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public member functions for TypedPortBuffer
-    // ----------------------------------------------------------------------
+    public:
 
-    //! Constructor
-    TypedPortBuffer() {
+      // ----------------------------------------------------------------------
+      // Public member functions for TypedPortBuffer
+      // ----------------------------------------------------------------------
+
+      //! Constructor
+      TypedPortBuffer() {
         this->m_buffAddr = m_buff;
         this->m_capacity = CAPACITY;
-    }
+      }
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member variables
-    // ----------------------------------------------------------------------
+    private:
 
-    U8 m_buff[CAPACITY];
-};
+      // ----------------------------------------------------------------------
+      // Private member variables
+      // ----------------------------------------------------------------------
 
-//! Serializer for Typed port
-//! A typed port
-class TypedPortSerializer {
-  public:
-    // ----------------------------------------------------------------------
-    // Public constructors for TypedPortSerializer
-    // ----------------------------------------------------------------------
+      U8 m_buff[CAPACITY];
 
-    //! Constructor
-    TypedPortSerializer();
+  };
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public member functions for TypedPortSerializer
-    // ----------------------------------------------------------------------
+  //! Serializer for Typed port
+  //! A typed port
+  class TypedPortSerializer {
 
-    //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
-    );
+    public:
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public static functions for TypedPortSerializer
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Public constructors for TypedPortSerializer
+      // ----------------------------------------------------------------------
 
-    //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(U32 u32,                       //!< A U32
-                                                 F32 f32,                       //!< An F32
-                                                 bool b,                        //!< A boolean
-                                                 const Fw::StringBase& str1,    //!< A string
-                                                 const E& e,                    //!< An enum
-                                                 const A& a,                    //!< An array
-                                                 const S& s,                    //!< A struct
-                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
-    );
+      //! Constructor
+      TypedPortSerializer();
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member variables for TypedPortSerializer
-    // ----------------------------------------------------------------------
+    public:
 
-    char m___fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+      // ----------------------------------------------------------------------
+      // Public member functions for TypedPortSerializer
+      // ----------------------------------------------------------------------
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public member variables for TypedPortSerializer
-    // ----------------------------------------------------------------------
+      //! Deserialze port arguments into members
+      Fw::SerializeStatus deserializePortArgs(
+          Fw::SerialBufferBase& _buffer //!< The serial buffer
+      );
 
-    U32 m_u32;
-    F32 m_f32;
-    bool m_b;
-    Fw::ExternalString m_str1;
-    E m_e;
-    A m_a;
-    S m_s;
-};
+    public:
+
+      // ----------------------------------------------------------------------
+      // Public static functions for TypedPortSerializer
+      // ----------------------------------------------------------------------
+
+      //! Serialize port arguments into a buffer
+      static Fw::SerializeStatus serializePortArgs(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const Fw::StringBase& str1, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s, //!< A struct
+          Fw::SerialBufferBase& _buffer //!< The serial buffer
+      );
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Private member variables for TypedPortSerializer
+      // ----------------------------------------------------------------------
+
+      char m___fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Public member variables for TypedPortSerializer
+      // ----------------------------------------------------------------------
+
+      U32 m_u32;
+      F32 m_f32;
+      bool m_b;
+      Fw::ExternalString m_str1;
+      E m_e;
+      A m_a;
+      S m_s;
+
+  };
 
 #if !FW_DIRECT_PORT_CALLS
 
-//! Input Typed port
-//! A typed port
-class InputTypedPort : public Fw::InputPortBase {
-  public:
-    // ----------------------------------------------------------------------
-    // Public types for InputTypedPort
-    // ----------------------------------------------------------------------
+  //! Input Typed port
+  //! A typed port
+  class InputTypedPort :
+    public Fw::InputPortBase
+  {
 
-    //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
-                                FwIndexType portNum,
-                                U32 u32,
-                                F32 f32,
-                                bool b,
-                                const Fw::StringBase& str1,
-                                const E& e,
-                                const A& a,
-                                const S& s);
+    public:
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public constructors for InputTypedPort
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Public types for InputTypedPort
+      // ----------------------------------------------------------------------
 
-    //! Constructor
-    InputTypedPort();
+      //! The port callback function type
+      typedef void (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        FwIndexType portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const Fw::StringBase& str1,
+        const E& e,
+        const A& a,
+        const S& s
+      );
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public member functions for InputTypedPort
-    // ----------------------------------------------------------------------
+    public:
 
-    //! Initialization function
-    void init();
+      // ----------------------------------------------------------------------
+      // Public constructors for InputTypedPort
+      // ----------------------------------------------------------------------
 
-    //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
-    );
+      //! Constructor
+      InputTypedPort();
 
-    //! Invoke a port interface
-    void invoke(U32 u32,                     //!< A U32
-                F32 f32,                     //!< An F32
-                bool b,                      //!< A boolean
-                const Fw::StringBase& str1,  //!< A string
-                const E& e,                  //!< An enum
-                const A& a,                  //!< An array
-                const S& s                   //!< A struct
-    );
+    public:
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member functions for InputTypedPort
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Public member functions for InputTypedPort
+      // ----------------------------------------------------------------------
+
+      //! Initialization function
+      void init();
+
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
+
+      //! Invoke a port interface
+      void invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const Fw::StringBase& str1, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Private member functions for InputTypedPort
+      // ----------------------------------------------------------------------
 
 #if FW_PORT_SERIALIZATION == 1
 
-    //! Invoke the port with serialized arguments
-    //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
-    );
+      //! Invoke the port with serialized arguments
+      //! \return The serialize status
+      Fw::SerializeStatus invokeSerial(
+          Fw::LinearBufferBase& _buffer //!< The serial buffer
+      );
 
 #endif
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member variables for InputTypedPort
-    // ----------------------------------------------------------------------
+    private:
 
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
-};
+      // ----------------------------------------------------------------------
+      // Private member variables for InputTypedPort
+      // ----------------------------------------------------------------------
 
-//! Output Typed port
-//! A typed port
-class OutputTypedPort : public Fw::OutputPortBase {
-  public:
-    // ----------------------------------------------------------------------
-    // Public constructors for OutputTypedPort
-    // ----------------------------------------------------------------------
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
 
-    //! Constructor
-    OutputTypedPort();
+  };
 
-  public:
-    // ----------------------------------------------------------------------
-    // Public member functions for OutputTypedPort
-    // ----------------------------------------------------------------------
+  //! Output Typed port
+  //! A typed port
+  class OutputTypedPort :
+    public Fw::OutputPortBase
+  {
 
-    //! Initialization function
-    void init();
+    public:
 
-    //! Register an input port
-    void addCallPort(InputTypedPort* callPort  //!< The input port
-    );
+      // ----------------------------------------------------------------------
+      // Public constructors for OutputTypedPort
+      // ----------------------------------------------------------------------
 
-    //! Invoke a port connection
-    void invoke(U32 u32,                     //!< A U32
-                F32 f32,                     //!< An F32
-                bool b,                      //!< A boolean
-                const Fw::StringBase& str1,  //!< A string
-                const E& e,                  //!< An enum
-                const A& a,                  //!< An array
-                const S& s                   //!< A struct
-    ) const;
+      //! Constructor
+      OutputTypedPort();
 
-  private:
-    // ----------------------------------------------------------------------
-    // Private member variables for OutputTypedPort
-    // ----------------------------------------------------------------------
+    public:
 
-    //! The pointer to the input port
-    InputTypedPort* m_port;
-};
+      // ----------------------------------------------------------------------
+      // Public member functions for OutputTypedPort
+      // ----------------------------------------------------------------------
+
+      //! Initialization function
+      void init();
+
+      //! Register an input port
+      void addCallPort(
+          InputTypedPort* callPort //!< The input port
+      );
+
+      //! Invoke a port connection
+      void invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const Fw::StringBase& str1, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      ) const;
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Private member variables for OutputTypedPort
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the input port
+      InputTypedPort* m_port;
+
+  };
 
 #endif
 
-}  // namespace Ports
+}
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
@@ -18,39 +18,50 @@
 
 //! Serialization buffer for AbsType port
 //! A port with abstract type parameters
-class AbsTypePortBuffer : public Fw::LinearBufferBase {
+class AbsTypePortBuffer :
+  public Fw::LinearBufferBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constants for AbsTypePortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY = T::SERIALIZED_SIZE + T::SERIALIZED_SIZE;
+    static constexpr FwSizeType CAPACITY =
+      T::SERIALIZED_SIZE +
+      T::SERIALIZED_SIZE;
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for AbsTypePortBuffer
     // ----------------------------------------------------------------------
 
     //! Constructor
     AbsTypePortBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = CAPACITY;
+      this->m_buffAddr = m_buff;
+      this->m_capacity = CAPACITY;
     }
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
+
 };
 
 //! Serializer for AbsType port
 //! A port with abstract type parameters
 class AbsTypePortSerializer {
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for AbsTypePortSerializer
     // ----------------------------------------------------------------------
@@ -59,48 +70,64 @@ class AbsTypePortSerializer {
     AbsTypePortSerializer();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for AbsTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public static functions for AbsTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(const T& t,
-                                                 T& tRef,
-                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(
+        const T& t,
+        T& tRef,
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member variables for AbsTypePortSerializer
     // ----------------------------------------------------------------------
 
     T m_t;
     T m_tRef;
+
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input AbsType port
 //! A port with abstract type parameters
-class InputAbsTypePort : public Fw::InputPortBase {
+class InputAbsTypePort :
+  public Fw::InputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public types for InputAbsTypePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum, const T& t, T& tRef);
+    typedef void (*CompFuncPtr)(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      const T& t,
+      T& tRef
+    );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for InputAbsTypePort
     // ----------------------------------------------------------------------
@@ -109,6 +136,7 @@ class InputAbsTypePort : public Fw::InputPortBase {
     InputAbsTypePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for InputAbsTypePort
     // ----------------------------------------------------------------------
@@ -117,14 +145,19 @@ class InputAbsTypePort : public Fw::InputPortBase {
     void init();
 
     //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
+    void addCallComp(
+        Fw::PassiveComponentBase* callComp, //!< The containing component
+        CompFuncPtr funcPtr //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(const T& t, T& tRef);
+    void invoke(
+        const T& t,
+        T& tRef
+    );
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member functions for InputAbsTypePort
     // ----------------------------------------------------------------------
@@ -133,24 +166,31 @@ class InputAbsTypePort : public Fw::InputPortBase {
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(
+        Fw::LinearBufferBase& _buffer //!< The serial buffer
     );
 
 #endif
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for InputAbsTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
+
 };
 
 //! Output AbsType port
 //! A port with abstract type parameters
-class OutputAbsTypePort : public Fw::OutputPortBase {
+class OutputAbsTypePort :
+  public Fw::OutputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for OutputAbsTypePort
     // ----------------------------------------------------------------------
@@ -159,6 +199,7 @@ class OutputAbsTypePort : public Fw::OutputPortBase {
     OutputAbsTypePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for OutputAbsTypePort
     // ----------------------------------------------------------------------
@@ -167,19 +208,25 @@ class OutputAbsTypePort : public Fw::OutputPortBase {
     void init();
 
     //! Register an input port
-    void addCallPort(InputAbsTypePort* callPort  //!< The input port
+    void addCallPort(
+        InputAbsTypePort* callPort //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(const T& t, T& tRef) const;
+    void invoke(
+        const T& t,
+        T& tRef
+    ) const;
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for OutputAbsTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputAbsTypePort* m_port;
+
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
@@ -41,9 +41,8 @@ class AbsTypePortBuffer :
     // ----------------------------------------------------------------------
 
     //! Constructor
-    AbsTypePortBuffer() {
-      this->m_buffAddr = m_buff;
-      this->m_capacity = CAPACITY;
+    AbsTypePortBuffer() : Fw::LinearBufferBase(m_buff, CAPACITY) {
+
     }
 
   private:

--- a/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
@@ -18,62 +18,39 @@
 
 //! Serialization buffer for AbsType port
 //! A port with abstract type parameters
-class AbsTypePortBuffer :
-  public Fw::LinearBufferBase
-{
-
+class AbsTypePortBuffer : public Fw::LinearBufferBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constants for AbsTypePortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY =
-      T::SERIALIZED_SIZE +
-      T::SERIALIZED_SIZE;
+    static constexpr FwSizeType CAPACITY = T::SERIALIZED_SIZE + T::SERIALIZED_SIZE;
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for AbsTypePortBuffer
     // ----------------------------------------------------------------------
 
-    //! Get the capacity of the buffer
-    //! \return The capacity
-    Fw::Serializable::SizeType getCapacity() const override {
-      return CAPACITY;
-    }
-
-    //! Get the buffer address (non-const)
-    //! \return The buffer address
-    U8* getBuffAddr() override {
-      return m_buff;
-    }
-
-    //! Get the buffer address (const)
-    //! \return The buffer address
-    const U8* getBuffAddr() const override {
-      return m_buff;
+    //! Constructor
+    AbsTypePortBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = CAPACITY;
     }
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
-
 };
 
 //! Serializer for AbsType port
 //! A port with abstract type parameters
 class AbsTypePortSerializer {
-
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for AbsTypePortSerializer
     // ----------------------------------------------------------------------
@@ -82,64 +59,48 @@ class AbsTypePortSerializer {
     AbsTypePortSerializer();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for AbsTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public static functions for AbsTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(
-        const T& t,
-        T& tRef,
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(const T& t,
+                                                 T& tRef,
+                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member variables for AbsTypePortSerializer
     // ----------------------------------------------------------------------
 
     T m_t;
     T m_tRef;
-
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input AbsType port
 //! A port with abstract type parameters
-class InputAbsTypePort :
-  public Fw::InputPortBase
-{
-
+class InputAbsTypePort : public Fw::InputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public types for InputAbsTypePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      const T& t,
-      T& tRef
-    );
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum, const T& t, T& tRef);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for InputAbsTypePort
     // ----------------------------------------------------------------------
@@ -148,7 +109,6 @@ class InputAbsTypePort :
     InputAbsTypePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for InputAbsTypePort
     // ----------------------------------------------------------------------
@@ -157,19 +117,14 @@ class InputAbsTypePort :
     void init();
 
     //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(
-        const T& t,
-        T& tRef
-    );
+    void invoke(const T& t, T& tRef);
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member functions for InputAbsTypePort
     // ----------------------------------------------------------------------
@@ -178,31 +133,24 @@ class InputAbsTypePort :
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(
-        Fw::LinearBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
     );
 
 #endif
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for InputAbsTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
-
 };
 
 //! Output AbsType port
 //! A port with abstract type parameters
-class OutputAbsTypePort :
-  public Fw::OutputPortBase
-{
-
+class OutputAbsTypePort : public Fw::OutputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for OutputAbsTypePort
     // ----------------------------------------------------------------------
@@ -211,7 +159,6 @@ class OutputAbsTypePort :
     OutputAbsTypePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for OutputAbsTypePort
     // ----------------------------------------------------------------------
@@ -220,25 +167,19 @@ class OutputAbsTypePort :
     void init();
 
     //! Register an input port
-    void addCallPort(
-        InputAbsTypePort* callPort //!< The input port
+    void addCallPort(InputAbsTypePort* callPort  //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(
-        const T& t,
-        T& tRef
-    ) const;
+    void invoke(const T& t, T& tRef) const;
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for OutputAbsTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputAbsTypePort* m_port;
-
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
@@ -17,69 +17,31 @@
 
 //! Serialization buffer for Empty port
 //! An empty port
-class EmptyPortBuffer :
-  public Fw::LinearBufferBase
-{
-
+class EmptyPortBuffer : public Fw::LinearBufferBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constants for EmptyPortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY =
-      0;
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Public member functions for EmptyPortBuffer
-    // ----------------------------------------------------------------------
-
-    //! Get the capacity of the buffer
-    //! \return The capacity
-    Fw::Serializable::SizeType getCapacity() const override {
-      return CAPACITY;
-    }
-
-    //! Get the buffer address (non-const)
-    //! \return The buffer address
-    U8* getBuffAddr() override {
-      return nullptr;
-    }
-
-    //! Get the buffer address (const)
-    //! \return The buffer address
-    const U8* getBuffAddr() const override {
-      return nullptr;
-    }
-
+    static constexpr FwSizeType CAPACITY = 0;
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input Empty port
 //! An empty port
-class InputEmptyPort :
-  public Fw::InputPortBase
-{
-
+class InputEmptyPort : public Fw::InputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public types for InputEmptyPort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum
-    );
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for InputEmptyPort
     // ----------------------------------------------------------------------
@@ -88,7 +50,6 @@ class InputEmptyPort :
     InputEmptyPort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for InputEmptyPort
     // ----------------------------------------------------------------------
@@ -97,16 +58,14 @@ class InputEmptyPort :
     void init();
 
     //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
     );
 
     //! Invoke a port interface
     void invoke();
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member functions for InputEmptyPort
     // ----------------------------------------------------------------------
@@ -115,31 +74,24 @@ class InputEmptyPort :
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(
-        Fw::LinearBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
     );
 
 #endif
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for InputEmptyPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
-
 };
 
 //! Output Empty port
 //! An empty port
-class OutputEmptyPort :
-  public Fw::OutputPortBase
-{
-
+class OutputEmptyPort : public Fw::OutputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for OutputEmptyPort
     // ----------------------------------------------------------------------
@@ -148,7 +100,6 @@ class OutputEmptyPort :
     OutputEmptyPort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for OutputEmptyPort
     // ----------------------------------------------------------------------
@@ -157,22 +108,19 @@ class OutputEmptyPort :
     void init();
 
     //! Register an input port
-    void addCallPort(
-        InputEmptyPort* callPort //!< The input port
+    void addCallPort(InputEmptyPort* callPort  //!< The input port
     );
 
     //! Invoke a port connection
     void invoke() const;
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for OutputEmptyPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputEmptyPort* m_port;
-
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
@@ -17,31 +17,45 @@
 
 //! Serialization buffer for Empty port
 //! An empty port
-class EmptyPortBuffer : public Fw::LinearBufferBase {
+class EmptyPortBuffer :
+  public Fw::LinearBufferBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constants for EmptyPortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY = 0;
+    static constexpr FwSizeType CAPACITY =
+      0;
+
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input Empty port
 //! An empty port
-class InputEmptyPort : public Fw::InputPortBase {
+class InputEmptyPort :
+  public Fw::InputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public types for InputEmptyPort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum);
+    typedef void (*CompFuncPtr)(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum
+    );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for InputEmptyPort
     // ----------------------------------------------------------------------
@@ -50,6 +64,7 @@ class InputEmptyPort : public Fw::InputPortBase {
     InputEmptyPort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for InputEmptyPort
     // ----------------------------------------------------------------------
@@ -58,14 +73,16 @@ class InputEmptyPort : public Fw::InputPortBase {
     void init();
 
     //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
+    void addCallComp(
+        Fw::PassiveComponentBase* callComp, //!< The containing component
+        CompFuncPtr funcPtr //!< The port callback function
     );
 
     //! Invoke a port interface
     void invoke();
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member functions for InputEmptyPort
     // ----------------------------------------------------------------------
@@ -74,24 +91,31 @@ class InputEmptyPort : public Fw::InputPortBase {
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(
+        Fw::LinearBufferBase& _buffer //!< The serial buffer
     );
 
 #endif
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for InputEmptyPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
+
 };
 
 //! Output Empty port
 //! An empty port
-class OutputEmptyPort : public Fw::OutputPortBase {
+class OutputEmptyPort :
+  public Fw::OutputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for OutputEmptyPort
     // ----------------------------------------------------------------------
@@ -100,6 +124,7 @@ class OutputEmptyPort : public Fw::OutputPortBase {
     OutputEmptyPort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for OutputEmptyPort
     // ----------------------------------------------------------------------
@@ -108,19 +133,22 @@ class OutputEmptyPort : public Fw::OutputPortBase {
     void init();
 
     //! Register an input port
-    void addCallPort(InputEmptyPort* callPort  //!< The input port
+    void addCallPort(
+        InputEmptyPort* callPort //!< The input port
     );
 
     //! Invoke a port connection
     void invoke() const;
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for OutputEmptyPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputEmptyPort* m_port;
+
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
@@ -32,6 +32,17 @@ class EmptyPortBuffer :
     static constexpr FwSizeType CAPACITY =
       0;
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Public member functions for EmptyPortBuffer
+    // ----------------------------------------------------------------------
+
+    //! Constructor
+    EmptyPortBuffer() : Fw::LinearBufferBase(nullptr, 0) {
+
+    }
+
 };
 
 #if !FW_DIRECT_PORT_CALLS

--- a/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
@@ -20,66 +20,40 @@
 
 //! Serialization buffer for FppType port
 //! A port with FPP type parameters
-class FppTypePortBuffer :
-  public Fw::LinearBufferBase
-{
-
+class FppTypePortBuffer : public Fw::LinearBufferBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constants for FppTypePortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY =
-      E::SERIALIZED_SIZE +
-      E::SERIALIZED_SIZE +
-      A::SERIALIZED_SIZE +
-      A::SERIALIZED_SIZE +
-      S::SERIALIZED_SIZE +
-      S::SERIALIZED_SIZE;
+    static constexpr FwSizeType CAPACITY = E::SERIALIZED_SIZE + E::SERIALIZED_SIZE + A::SERIALIZED_SIZE +
+                                           A::SERIALIZED_SIZE + S::SERIALIZED_SIZE + S::SERIALIZED_SIZE;
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for FppTypePortBuffer
     // ----------------------------------------------------------------------
 
-    //! Get the capacity of the buffer
-    //! \return The capacity
-    Fw::Serializable::SizeType getCapacity() const override {
-      return CAPACITY;
-    }
-
-    //! Get the buffer address (non-const)
-    //! \return The buffer address
-    U8* getBuffAddr() override {
-      return m_buff;
-    }
-
-    //! Get the buffer address (const)
-    //! \return The buffer address
-    const U8* getBuffAddr() const override {
-      return m_buff;
+    //! Constructor
+    FppTypePortBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = CAPACITY;
     }
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
-
 };
 
 //! Serializer for FppType port
 //! A port with FPP type parameters
 class FppTypePortSerializer {
-
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for FppTypePortSerializer
     // ----------------------------------------------------------------------
@@ -88,37 +62,32 @@ class FppTypePortSerializer {
     FppTypePortSerializer();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for FppTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public static functions for FppTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(
-        const E& e, //!< An enum
-                    //!< Line 2 of the comment
-        E& eRef, //!< An enum ref
-                 //!< Line 2 of the comment
-        const A& a, //!< An array
-        A& aRef, //!< An array ref
-        const S& s, //!< A struct
-        S& sRef, //!< A struct ref
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(const E& e,                    //!< An enum
+                                                                                //!< Line 2 of the comment
+                                                 E& eRef,                       //!< An enum ref
+                                                                                //!< Line 2 of the comment
+                                                 const A& a,                    //!< An array
+                                                 A& aRef,                       //!< An array ref
+                                                 const S& s,                    //!< A struct
+                                                 S& sRef,                       //!< A struct ref
+                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member variables for FppTypePortSerializer
     // ----------------------------------------------------------------------
@@ -129,37 +98,29 @@ class FppTypePortSerializer {
     A m_aRef;
     S m_s;
     S m_sRef;
-
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input FppType port
 //! A port with FPP type parameters
-class InputFppTypePort :
-  public Fw::InputPortBase
-{
-
+class InputFppTypePort : public Fw::InputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public types for InputFppTypePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      const E& e,
-      E& eRef,
-      const A& a,
-      A& aRef,
-      const S& s,
-      S& sRef
-    );
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
+                                FwIndexType portNum,
+                                const E& e,
+                                E& eRef,
+                                const A& a,
+                                A& aRef,
+                                const S& s,
+                                S& sRef);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for InputFppTypePort
     // ----------------------------------------------------------------------
@@ -168,7 +129,6 @@ class InputFppTypePort :
     InputFppTypePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for InputFppTypePort
     // ----------------------------------------------------------------------
@@ -177,25 +137,22 @@ class InputFppTypePort :
     void init();
 
     //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(
-        const E& e, //!< An enum
-                    //!< Line 2 of the comment
-        E& eRef, //!< An enum ref
-                 //!< Line 2 of the comment
-        const A& a, //!< An array
-        A& aRef, //!< An array ref
-        const S& s, //!< A struct
-        S& sRef //!< A struct ref
+    void invoke(const E& e,  //!< An enum
+                             //!< Line 2 of the comment
+                E& eRef,     //!< An enum ref
+                             //!< Line 2 of the comment
+                const A& a,  //!< An array
+                A& aRef,     //!< An array ref
+                const S& s,  //!< A struct
+                S& sRef      //!< A struct ref
     );
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member functions for InputFppTypePort
     // ----------------------------------------------------------------------
@@ -204,31 +161,24 @@ class InputFppTypePort :
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(
-        Fw::LinearBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
     );
 
 #endif
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for InputFppTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
-
 };
 
 //! Output FppType port
 //! A port with FPP type parameters
-class OutputFppTypePort :
-  public Fw::OutputPortBase
-{
-
+class OutputFppTypePort : public Fw::OutputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for OutputFppTypePort
     // ----------------------------------------------------------------------
@@ -237,7 +187,6 @@ class OutputFppTypePort :
     OutputFppTypePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for OutputFppTypePort
     // ----------------------------------------------------------------------
@@ -246,31 +195,27 @@ class OutputFppTypePort :
     void init();
 
     //! Register an input port
-    void addCallPort(
-        InputFppTypePort* callPort //!< The input port
+    void addCallPort(InputFppTypePort* callPort  //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(
-        const E& e, //!< An enum
-                    //!< Line 2 of the comment
-        E& eRef, //!< An enum ref
-                 //!< Line 2 of the comment
-        const A& a, //!< An array
-        A& aRef, //!< An array ref
-        const S& s, //!< A struct
-        S& sRef //!< A struct ref
+    void invoke(const E& e,  //!< An enum
+                             //!< Line 2 of the comment
+                E& eRef,     //!< An enum ref
+                             //!< Line 2 of the comment
+                const A& a,  //!< An array
+                A& aRef,     //!< An array ref
+                const S& s,  //!< A struct
+                S& sRef      //!< A struct ref
     ) const;
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for OutputFppTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputFppTypePort* m_port;
-
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
@@ -20,40 +20,54 @@
 
 //! Serialization buffer for FppType port
 //! A port with FPP type parameters
-class FppTypePortBuffer : public Fw::LinearBufferBase {
+class FppTypePortBuffer :
+  public Fw::LinearBufferBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constants for FppTypePortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY = E::SERIALIZED_SIZE + E::SERIALIZED_SIZE + A::SERIALIZED_SIZE +
-                                           A::SERIALIZED_SIZE + S::SERIALIZED_SIZE + S::SERIALIZED_SIZE;
+    static constexpr FwSizeType CAPACITY =
+      E::SERIALIZED_SIZE +
+      E::SERIALIZED_SIZE +
+      A::SERIALIZED_SIZE +
+      A::SERIALIZED_SIZE +
+      S::SERIALIZED_SIZE +
+      S::SERIALIZED_SIZE;
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for FppTypePortBuffer
     // ----------------------------------------------------------------------
 
     //! Constructor
     FppTypePortBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = CAPACITY;
+      this->m_buffAddr = m_buff;
+      this->m_capacity = CAPACITY;
     }
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
+
 };
 
 //! Serializer for FppType port
 //! A port with FPP type parameters
 class FppTypePortSerializer {
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for FppTypePortSerializer
     // ----------------------------------------------------------------------
@@ -62,32 +76,37 @@ class FppTypePortSerializer {
     FppTypePortSerializer();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for FppTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public static functions for FppTypePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(const E& e,                    //!< An enum
-                                                                                //!< Line 2 of the comment
-                                                 E& eRef,                       //!< An enum ref
-                                                                                //!< Line 2 of the comment
-                                                 const A& a,                    //!< An array
-                                                 A& aRef,                       //!< An array ref
-                                                 const S& s,                    //!< A struct
-                                                 S& sRef,                       //!< A struct ref
-                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(
+        const E& e, //!< An enum
+                    //!< Line 2 of the comment
+        E& eRef, //!< An enum ref
+                 //!< Line 2 of the comment
+        const A& a, //!< An array
+        A& aRef, //!< An array ref
+        const S& s, //!< A struct
+        S& sRef, //!< A struct ref
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member variables for FppTypePortSerializer
     // ----------------------------------------------------------------------
@@ -98,29 +117,37 @@ class FppTypePortSerializer {
     A m_aRef;
     S m_s;
     S m_sRef;
+
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input FppType port
 //! A port with FPP type parameters
-class InputFppTypePort : public Fw::InputPortBase {
+class InputFppTypePort :
+  public Fw::InputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public types for InputFppTypePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
-                                FwIndexType portNum,
-                                const E& e,
-                                E& eRef,
-                                const A& a,
-                                A& aRef,
-                                const S& s,
-                                S& sRef);
+    typedef void (*CompFuncPtr)(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      const E& e,
+      E& eRef,
+      const A& a,
+      A& aRef,
+      const S& s,
+      S& sRef
+    );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for InputFppTypePort
     // ----------------------------------------------------------------------
@@ -129,6 +156,7 @@ class InputFppTypePort : public Fw::InputPortBase {
     InputFppTypePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for InputFppTypePort
     // ----------------------------------------------------------------------
@@ -137,22 +165,25 @@ class InputFppTypePort : public Fw::InputPortBase {
     void init();
 
     //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
+    void addCallComp(
+        Fw::PassiveComponentBase* callComp, //!< The containing component
+        CompFuncPtr funcPtr //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(const E& e,  //!< An enum
-                             //!< Line 2 of the comment
-                E& eRef,     //!< An enum ref
-                             //!< Line 2 of the comment
-                const A& a,  //!< An array
-                A& aRef,     //!< An array ref
-                const S& s,  //!< A struct
-                S& sRef      //!< A struct ref
+    void invoke(
+        const E& e, //!< An enum
+                    //!< Line 2 of the comment
+        E& eRef, //!< An enum ref
+                 //!< Line 2 of the comment
+        const A& a, //!< An array
+        A& aRef, //!< An array ref
+        const S& s, //!< A struct
+        S& sRef //!< A struct ref
     );
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member functions for InputFppTypePort
     // ----------------------------------------------------------------------
@@ -161,24 +192,31 @@ class InputFppTypePort : public Fw::InputPortBase {
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(
+        Fw::LinearBufferBase& _buffer //!< The serial buffer
     );
 
 #endif
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for InputFppTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
+
 };
 
 //! Output FppType port
 //! A port with FPP type parameters
-class OutputFppTypePort : public Fw::OutputPortBase {
+class OutputFppTypePort :
+  public Fw::OutputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for OutputFppTypePort
     // ----------------------------------------------------------------------
@@ -187,6 +225,7 @@ class OutputFppTypePort : public Fw::OutputPortBase {
     OutputFppTypePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for OutputFppTypePort
     // ----------------------------------------------------------------------
@@ -195,27 +234,31 @@ class OutputFppTypePort : public Fw::OutputPortBase {
     void init();
 
     //! Register an input port
-    void addCallPort(InputFppTypePort* callPort  //!< The input port
+    void addCallPort(
+        InputFppTypePort* callPort //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(const E& e,  //!< An enum
-                             //!< Line 2 of the comment
-                E& eRef,     //!< An enum ref
-                             //!< Line 2 of the comment
-                const A& a,  //!< An array
-                A& aRef,     //!< An array ref
-                const S& s,  //!< A struct
-                S& sRef      //!< A struct ref
+    void invoke(
+        const E& e, //!< An enum
+                    //!< Line 2 of the comment
+        E& eRef, //!< An enum ref
+                 //!< Line 2 of the comment
+        const A& a, //!< An array
+        A& aRef, //!< An array ref
+        const S& s, //!< A struct
+        S& sRef //!< A struct ref
     ) const;
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for OutputFppTypePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputFppTypePort* m_port;
+
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
@@ -47,9 +47,8 @@ class FppTypePortBuffer :
     // ----------------------------------------------------------------------
 
     //! Constructor
-    FppTypePortBuffer() {
-      this->m_buffAddr = m_buff;
-      this->m_capacity = CAPACITY;
+    FppTypePortBuffer() : Fw::LinearBufferBase(m_buff, CAPACITY) {
+
     }
 
   private:

--- a/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
@@ -17,39 +17,49 @@
 
 //! Serialization buffer for KwdName port
 //! A port with a keyword name
-class KwdNamePortBuffer : public Fw::LinearBufferBase {
+class KwdNamePortBuffer :
+  public Fw::LinearBufferBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constants for KwdNamePortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY = sizeof(U32);
+    static constexpr FwSizeType CAPACITY =
+      sizeof(U32);
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for KwdNamePortBuffer
     // ----------------------------------------------------------------------
 
     //! Constructor
     KwdNamePortBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = CAPACITY;
+      this->m_buffAddr = m_buff;
+      this->m_capacity = CAPACITY;
     }
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
+
 };
 
 //! Serializer for KwdName port
 //! A port with a keyword name
 class KwdNamePortSerializer {
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for KwdNamePortSerializer
     // ----------------------------------------------------------------------
@@ -58,46 +68,61 @@ class KwdNamePortSerializer {
     KwdNamePortSerializer();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for KwdNamePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public static functions for KwdNamePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(U32& time,
-                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(
+        U32& time,
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member variables for KwdNamePortSerializer
     // ----------------------------------------------------------------------
 
     U32 m_time;
+
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input KwdName port
 //! A port with a keyword name
-class InputKwdNamePort : public Fw::InputPortBase {
+class InputKwdNamePort :
+  public Fw::InputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public types for InputKwdNamePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum, U32& time);
+    typedef void (*CompFuncPtr)(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32& time
+    );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for InputKwdNamePort
     // ----------------------------------------------------------------------
@@ -106,6 +131,7 @@ class InputKwdNamePort : public Fw::InputPortBase {
     InputKwdNamePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for InputKwdNamePort
     // ----------------------------------------------------------------------
@@ -114,14 +140,16 @@ class InputKwdNamePort : public Fw::InputPortBase {
     void init();
 
     //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
+    void addCallComp(
+        Fw::PassiveComponentBase* callComp, //!< The containing component
+        CompFuncPtr funcPtr //!< The port callback function
     );
 
     //! Invoke a port interface
     void invoke(U32& time);
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member functions for InputKwdNamePort
     // ----------------------------------------------------------------------
@@ -130,24 +158,31 @@ class InputKwdNamePort : public Fw::InputPortBase {
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(
+        Fw::LinearBufferBase& _buffer //!< The serial buffer
     );
 
 #endif
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for InputKwdNamePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
+
 };
 
 //! Output KwdName port
 //! A port with a keyword name
-class OutputKwdNamePort : public Fw::OutputPortBase {
+class OutputKwdNamePort :
+  public Fw::OutputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for OutputKwdNamePort
     // ----------------------------------------------------------------------
@@ -156,6 +191,7 @@ class OutputKwdNamePort : public Fw::OutputPortBase {
     OutputKwdNamePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for OutputKwdNamePort
     // ----------------------------------------------------------------------
@@ -164,19 +200,22 @@ class OutputKwdNamePort : public Fw::OutputPortBase {
     void init();
 
     //! Register an input port
-    void addCallPort(InputKwdNamePort* callPort  //!< The input port
+    void addCallPort(
+        InputKwdNamePort* callPort //!< The input port
     );
 
     //! Invoke a port connection
     void invoke(U32& time) const;
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for OutputKwdNamePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputKwdNamePort* m_port;
+
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
@@ -39,9 +39,8 @@ class KwdNamePortBuffer :
     // ----------------------------------------------------------------------
 
     //! Constructor
-    KwdNamePortBuffer() {
-      this->m_buffAddr = m_buff;
-      this->m_capacity = CAPACITY;
+    KwdNamePortBuffer() : Fw::LinearBufferBase(m_buff, CAPACITY) {
+
     }
 
   private:

--- a/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
@@ -17,61 +17,39 @@
 
 //! Serialization buffer for KwdName port
 //! A port with a keyword name
-class KwdNamePortBuffer :
-  public Fw::LinearBufferBase
-{
-
+class KwdNamePortBuffer : public Fw::LinearBufferBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constants for KwdNamePortBuffer
     // ----------------------------------------------------------------------
 
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
-    static constexpr FwSizeType CAPACITY =
-      sizeof(U32);
+    static constexpr FwSizeType CAPACITY = sizeof(U32);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for KwdNamePortBuffer
     // ----------------------------------------------------------------------
 
-    //! Get the capacity of the buffer
-    //! \return The capacity
-    Fw::Serializable::SizeType getCapacity() const override {
-      return CAPACITY;
-    }
-
-    //! Get the buffer address (non-const)
-    //! \return The buffer address
-    U8* getBuffAddr() override {
-      return m_buff;
-    }
-
-    //! Get the buffer address (const)
-    //! \return The buffer address
-    const U8* getBuffAddr() const override {
-      return m_buff;
+    //! Constructor
+    KwdNamePortBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = CAPACITY;
     }
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
-
 };
 
 //! Serializer for KwdName port
 //! A port with a keyword name
 class KwdNamePortSerializer {
-
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for KwdNamePortSerializer
     // ----------------------------------------------------------------------
@@ -80,61 +58,46 @@ class KwdNamePortSerializer {
     KwdNamePortSerializer();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for KwdNamePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public static functions for KwdNamePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(
-        U32& time,
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(U32& time,
+                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member variables for KwdNamePortSerializer
     // ----------------------------------------------------------------------
 
     U32 m_time;
-
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input KwdName port
 //! A port with a keyword name
-class InputKwdNamePort :
-  public Fw::InputPortBase
-{
-
+class InputKwdNamePort : public Fw::InputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public types for InputKwdNamePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32& time
-    );
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp, FwIndexType portNum, U32& time);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for InputKwdNamePort
     // ----------------------------------------------------------------------
@@ -143,7 +106,6 @@ class InputKwdNamePort :
     InputKwdNamePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for InputKwdNamePort
     // ----------------------------------------------------------------------
@@ -152,16 +114,14 @@ class InputKwdNamePort :
     void init();
 
     //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
     );
 
     //! Invoke a port interface
     void invoke(U32& time);
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member functions for InputKwdNamePort
     // ----------------------------------------------------------------------
@@ -170,31 +130,24 @@ class InputKwdNamePort :
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(
-        Fw::LinearBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
     );
 
 #endif
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for InputKwdNamePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
-
 };
 
 //! Output KwdName port
 //! A port with a keyword name
-class OutputKwdNamePort :
-  public Fw::OutputPortBase
-{
-
+class OutputKwdNamePort : public Fw::OutputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for OutputKwdNamePort
     // ----------------------------------------------------------------------
@@ -203,7 +156,6 @@ class OutputKwdNamePort :
     OutputKwdNamePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for OutputKwdNamePort
     // ----------------------------------------------------------------------
@@ -212,22 +164,19 @@ class OutputKwdNamePort :
     void init();
 
     //! Register an input port
-    void addCallPort(
-        InputKwdNamePort* callPort //!< The input port
+    void addCallPort(InputKwdNamePort* callPort  //!< The input port
     );
 
     //! Invoke a port connection
     void invoke(U32& time) const;
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for OutputKwdNamePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputKwdNamePort* m_port;
-
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
@@ -44,9 +44,8 @@ class PrimitivePortBuffer :
     // ----------------------------------------------------------------------
 
     //! Constructor
-    PrimitivePortBuffer() {
-      this->m_buffAddr = m_buff;
-      this->m_capacity = CAPACITY;
+    PrimitivePortBuffer() : Fw::LinearBufferBase(m_buff, CAPACITY) {
+
     }
 
   private:

--- a/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
@@ -17,12 +17,8 @@
 
 //! Serialization buffer for Primitive port
 //! A port with primitive parameters
-class PrimitivePortBuffer :
-  public Fw::LinearBufferBase
-{
-
+class PrimitivePortBuffer : public Fw::LinearBufferBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constants for PrimitivePortBuffer
     // ----------------------------------------------------------------------
@@ -30,53 +26,31 @@ class PrimitivePortBuffer :
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
     static constexpr FwSizeType CAPACITY =
-      sizeof(U32) +
-      sizeof(U32) +
-      sizeof(F32) +
-      sizeof(F32) +
-      sizeof(U8) +
-      sizeof(U8);
+        sizeof(U32) + sizeof(U32) + sizeof(F32) + sizeof(F32) + sizeof(U8) + sizeof(U8);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for PrimitivePortBuffer
     // ----------------------------------------------------------------------
 
-    //! Get the capacity of the buffer
-    //! \return The capacity
-    Fw::Serializable::SizeType getCapacity() const override {
-      return CAPACITY;
-    }
-
-    //! Get the buffer address (non-const)
-    //! \return The buffer address
-    U8* getBuffAddr() override {
-      return m_buff;
-    }
-
-    //! Get the buffer address (const)
-    //! \return The buffer address
-    const U8* getBuffAddr() const override {
-      return m_buff;
+    //! Constructor
+    PrimitivePortBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = CAPACITY;
     }
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
-
 };
 
 //! Serializer for Primitive port
 //! A port with primitive parameters
 class PrimitivePortSerializer {
-
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for PrimitivePortSerializer
     // ----------------------------------------------------------------------
@@ -85,35 +59,30 @@ class PrimitivePortSerializer {
     PrimitivePortSerializer();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for PrimitivePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public static functions for PrimitivePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(
-        U32 u32,
-        U32& u32Ref,
-        F32 f32,
-        F32& f32Ref,
-        bool b,
-        bool& bRef,
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(U32 u32,
+                                                 U32& u32Ref,
+                                                 F32 f32,
+                                                 F32& f32Ref,
+                                                 bool b,
+                                                 bool& bRef,
+                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member variables for PrimitivePortSerializer
     // ----------------------------------------------------------------------
@@ -124,37 +93,29 @@ class PrimitivePortSerializer {
     F32 m_f32Ref;
     bool m_b;
     bool m_bRef;
-
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input Primitive port
 //! A port with primitive parameters
-class InputPrimitivePort :
-  public Fw::InputPortBase
-{
-
+class InputPrimitivePort : public Fw::InputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public types for InputPrimitivePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      U32 u32,
-      U32& u32Ref,
-      F32 f32,
-      F32& f32Ref,
-      bool b,
-      bool& bRef
-    );
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
+                                FwIndexType portNum,
+                                U32 u32,
+                                U32& u32Ref,
+                                F32 f32,
+                                F32& f32Ref,
+                                bool b,
+                                bool& bRef);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for InputPrimitivePort
     // ----------------------------------------------------------------------
@@ -163,7 +124,6 @@ class InputPrimitivePort :
     InputPrimitivePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for InputPrimitivePort
     // ----------------------------------------------------------------------
@@ -172,23 +132,14 @@ class InputPrimitivePort :
     void init();
 
     //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(
-        U32 u32,
-        U32& u32Ref,
-        F32 f32,
-        F32& f32Ref,
-        bool b,
-        bool& bRef
-    );
+    void invoke(U32 u32, U32& u32Ref, F32 f32, F32& f32Ref, bool b, bool& bRef);
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member functions for InputPrimitivePort
     // ----------------------------------------------------------------------
@@ -197,31 +148,24 @@ class InputPrimitivePort :
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(
-        Fw::LinearBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
     );
 
 #endif
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for InputPrimitivePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
-
 };
 
 //! Output Primitive port
 //! A port with primitive parameters
-class OutputPrimitivePort :
-  public Fw::OutputPortBase
-{
-
+class OutputPrimitivePort : public Fw::OutputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for OutputPrimitivePort
     // ----------------------------------------------------------------------
@@ -230,7 +174,6 @@ class OutputPrimitivePort :
     OutputPrimitivePort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for OutputPrimitivePort
     // ----------------------------------------------------------------------
@@ -239,29 +182,19 @@ class OutputPrimitivePort :
     void init();
 
     //! Register an input port
-    void addCallPort(
-        InputPrimitivePort* callPort //!< The input port
+    void addCallPort(InputPrimitivePort* callPort  //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(
-        U32 u32,
-        U32& u32Ref,
-        F32 f32,
-        F32& f32Ref,
-        bool b,
-        bool& bRef
-    ) const;
+    void invoke(U32 u32, U32& u32Ref, F32 f32, F32& f32Ref, bool b, bool& bRef) const;
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for OutputPrimitivePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputPrimitivePort* m_port;
-
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
@@ -17,8 +17,12 @@
 
 //! Serialization buffer for Primitive port
 //! A port with primitive parameters
-class PrimitivePortBuffer : public Fw::LinearBufferBase {
+class PrimitivePortBuffer :
+  public Fw::LinearBufferBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constants for PrimitivePortBuffer
     // ----------------------------------------------------------------------
@@ -26,31 +30,41 @@ class PrimitivePortBuffer : public Fw::LinearBufferBase {
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
     static constexpr FwSizeType CAPACITY =
-        sizeof(U32) + sizeof(U32) + sizeof(F32) + sizeof(F32) + sizeof(U8) + sizeof(U8);
+      sizeof(U32) +
+      sizeof(U32) +
+      sizeof(F32) +
+      sizeof(F32) +
+      sizeof(U8) +
+      sizeof(U8);
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for PrimitivePortBuffer
     // ----------------------------------------------------------------------
 
     //! Constructor
     PrimitivePortBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = CAPACITY;
+      this->m_buffAddr = m_buff;
+      this->m_capacity = CAPACITY;
     }
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
+
 };
 
 //! Serializer for Primitive port
 //! A port with primitive parameters
 class PrimitivePortSerializer {
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for PrimitivePortSerializer
     // ----------------------------------------------------------------------
@@ -59,30 +73,35 @@ class PrimitivePortSerializer {
     PrimitivePortSerializer();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for PrimitivePortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public static functions for PrimitivePortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(U32 u32,
-                                                 U32& u32Ref,
-                                                 F32 f32,
-                                                 F32& f32Ref,
-                                                 bool b,
-                                                 bool& bRef,
-                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(
+        U32 u32,
+        U32& u32Ref,
+        F32 f32,
+        F32& f32Ref,
+        bool b,
+        bool& bRef,
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member variables for PrimitivePortSerializer
     // ----------------------------------------------------------------------
@@ -93,29 +112,37 @@ class PrimitivePortSerializer {
     F32 m_f32Ref;
     bool m_b;
     bool m_bRef;
+
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input Primitive port
 //! A port with primitive parameters
-class InputPrimitivePort : public Fw::InputPortBase {
+class InputPrimitivePort :
+  public Fw::InputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public types for InputPrimitivePort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
-                                FwIndexType portNum,
-                                U32 u32,
-                                U32& u32Ref,
-                                F32 f32,
-                                F32& f32Ref,
-                                bool b,
-                                bool& bRef);
+    typedef void (*CompFuncPtr)(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      U32 u32,
+      U32& u32Ref,
+      F32 f32,
+      F32& f32Ref,
+      bool b,
+      bool& bRef
+    );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for InputPrimitivePort
     // ----------------------------------------------------------------------
@@ -124,6 +151,7 @@ class InputPrimitivePort : public Fw::InputPortBase {
     InputPrimitivePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for InputPrimitivePort
     // ----------------------------------------------------------------------
@@ -132,14 +160,23 @@ class InputPrimitivePort : public Fw::InputPortBase {
     void init();
 
     //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
+    void addCallComp(
+        Fw::PassiveComponentBase* callComp, //!< The containing component
+        CompFuncPtr funcPtr //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(U32 u32, U32& u32Ref, F32 f32, F32& f32Ref, bool b, bool& bRef);
+    void invoke(
+        U32 u32,
+        U32& u32Ref,
+        F32 f32,
+        F32& f32Ref,
+        bool b,
+        bool& bRef
+    );
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member functions for InputPrimitivePort
     // ----------------------------------------------------------------------
@@ -148,24 +185,31 @@ class InputPrimitivePort : public Fw::InputPortBase {
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(
+        Fw::LinearBufferBase& _buffer //!< The serial buffer
     );
 
 #endif
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for InputPrimitivePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
+
 };
 
 //! Output Primitive port
 //! A port with primitive parameters
-class OutputPrimitivePort : public Fw::OutputPortBase {
+class OutputPrimitivePort :
+  public Fw::OutputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for OutputPrimitivePort
     // ----------------------------------------------------------------------
@@ -174,6 +218,7 @@ class OutputPrimitivePort : public Fw::OutputPortBase {
     OutputPrimitivePort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for OutputPrimitivePort
     // ----------------------------------------------------------------------
@@ -182,19 +227,29 @@ class OutputPrimitivePort : public Fw::OutputPortBase {
     void init();
 
     //! Register an input port
-    void addCallPort(InputPrimitivePort* callPort  //!< The input port
+    void addCallPort(
+        InputPrimitivePort* callPort //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(U32 u32, U32& u32Ref, F32 f32, F32& f32Ref, bool b, bool& bRef) const;
+    void invoke(
+        U32 u32,
+        U32& u32Ref,
+        F32 f32,
+        F32& f32Ref,
+        bool b,
+        bool& bRef
+    ) const;
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for OutputPrimitivePort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputPrimitivePort* m_port;
+
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
@@ -19,8 +19,12 @@
 
 //! Serialization buffer for String port
 //! A port with string parameters
-class StringPortBuffer : public Fw::LinearBufferBase {
+class StringPortBuffer :
+  public Fw::LinearBufferBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constants for StringPortBuffer
     // ----------------------------------------------------------------------
@@ -28,33 +32,39 @@ class StringPortBuffer : public Fw::LinearBufferBase {
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
     static constexpr FwSizeType CAPACITY =
-        Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-        Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-        Fw::StringBase::STATIC_SERIALIZED_SIZE(100) + Fw::StringBase::STATIC_SERIALIZED_SIZE(100);
+      Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
+      Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
+      Fw::StringBase::STATIC_SERIALIZED_SIZE(100) +
+      Fw::StringBase::STATIC_SERIALIZED_SIZE(100);
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for StringPortBuffer
     // ----------------------------------------------------------------------
 
     //! Constructor
     StringPortBuffer() {
-        this->m_buffAddr = m_buff;
-        this->m_capacity = CAPACITY;
+      this->m_buffAddr = m_buff;
+      this->m_capacity = CAPACITY;
     }
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
+
 };
 
 //! Serializer for String port
 //! A port with string parameters
 class StringPortSerializer {
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for StringPortSerializer
     // ----------------------------------------------------------------------
@@ -63,39 +73,44 @@ class StringPortSerializer {
     StringPortSerializer();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for StringPortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public static functions for StringPortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(const Fw::StringBase& str80,  //!< A string of size 80
-                                                 Fw::StringBase& str80Ref,
-                                                 const Fw::StringBase& str100,  //!< A string of size 100
-                                                 Fw::StringBase& str100Ref,
-                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(
+        const Fw::StringBase& str80, //!< A string of size 80
+        Fw::StringBase& str80Ref,
+        const Fw::StringBase& str100, //!< A string of size 100
+        Fw::StringBase& str100Ref,
+        Fw::SerialBufferBase& _buffer //!< The serial buffer
     );
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for StringPortSerializer
     // ----------------------------------------------------------------------
 
     char m___fprime_ac_str80_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-    char m___fprime_ac_str80Ref_buffer[Fw::StringBase::BUFFER_SIZE(
-        static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+    char m___fprime_ac_str80Ref_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
     char m___fprime_ac_str100_buffer[Fw::StringBase::BUFFER_SIZE(100)];
     char m___fprime_ac_str100Ref_buffer[Fw::StringBase::BUFFER_SIZE(100)];
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member variables for StringPortSerializer
     // ----------------------------------------------------------------------
@@ -104,27 +119,35 @@ class StringPortSerializer {
     Fw::ExternalString m_str80Ref;
     Fw::ExternalString m_str100;
     Fw::ExternalString m_str100Ref;
+
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input String port
 //! A port with string parameters
-class InputStringPort : public Fw::InputPortBase {
+class InputStringPort :
+  public Fw::InputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public types for InputStringPort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
-                                FwIndexType portNum,
-                                const Fw::StringBase& str80,
-                                Fw::StringBase& str80Ref,
-                                const Fw::StringBase& str100,
-                                Fw::StringBase& str100Ref);
+    typedef void (*CompFuncPtr)(
+      Fw::PassiveComponentBase* callComp,
+      FwIndexType portNum,
+      const Fw::StringBase& str80,
+      Fw::StringBase& str80Ref,
+      const Fw::StringBase& str100,
+      Fw::StringBase& str100Ref
+    );
 
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for InputStringPort
     // ----------------------------------------------------------------------
@@ -133,6 +156,7 @@ class InputStringPort : public Fw::InputPortBase {
     InputStringPort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for InputStringPort
     // ----------------------------------------------------------------------
@@ -141,17 +165,21 @@ class InputStringPort : public Fw::InputPortBase {
     void init();
 
     //! Register a component
-    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
-                     CompFuncPtr funcPtr                  //!< The port callback function
+    void addCallComp(
+        Fw::PassiveComponentBase* callComp, //!< The containing component
+        CompFuncPtr funcPtr //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(const Fw::StringBase& str80,  //!< A string of size 80
-                Fw::StringBase& str80Ref,
-                const Fw::StringBase& str100,  //!< A string of size 100
-                Fw::StringBase& str100Ref);
+    void invoke(
+        const Fw::StringBase& str80, //!< A string of size 80
+        Fw::StringBase& str80Ref,
+        const Fw::StringBase& str100, //!< A string of size 100
+        Fw::StringBase& str100Ref
+    );
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member functions for InputStringPort
     // ----------------------------------------------------------------------
@@ -160,24 +188,31 @@ class InputStringPort : public Fw::InputPortBase {
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(
+        Fw::LinearBufferBase& _buffer //!< The serial buffer
     );
 
 #endif
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for InputStringPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
+
 };
 
 //! Output String port
 //! A port with string parameters
-class OutputStringPort : public Fw::OutputPortBase {
+class OutputStringPort :
+  public Fw::OutputPortBase
+{
+
   public:
+
     // ----------------------------------------------------------------------
     // Public constructors for OutputStringPort
     // ----------------------------------------------------------------------
@@ -186,6 +221,7 @@ class OutputStringPort : public Fw::OutputPortBase {
     OutputStringPort();
 
   public:
+
     // ----------------------------------------------------------------------
     // Public member functions for OutputStringPort
     // ----------------------------------------------------------------------
@@ -194,22 +230,27 @@ class OutputStringPort : public Fw::OutputPortBase {
     void init();
 
     //! Register an input port
-    void addCallPort(InputStringPort* callPort  //!< The input port
+    void addCallPort(
+        InputStringPort* callPort //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(const Fw::StringBase& str80,  //!< A string of size 80
-                Fw::StringBase& str80Ref,
-                const Fw::StringBase& str100,  //!< A string of size 100
-                Fw::StringBase& str100Ref) const;
+    void invoke(
+        const Fw::StringBase& str80, //!< A string of size 80
+        Fw::StringBase& str80Ref,
+        const Fw::StringBase& str100, //!< A string of size 100
+        Fw::StringBase& str100Ref
+    ) const;
 
   private:
+
     // ----------------------------------------------------------------------
     // Private member variables for OutputStringPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputStringPort* m_port;
+
 };
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
@@ -44,9 +44,8 @@ class StringPortBuffer :
     // ----------------------------------------------------------------------
 
     //! Constructor
-    StringPortBuffer() {
-      this->m_buffAddr = m_buff;
-      this->m_capacity = CAPACITY;
+    StringPortBuffer() : Fw::LinearBufferBase(m_buff, CAPACITY) {
+
     }
 
   private:

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
@@ -19,12 +19,8 @@
 
 //! Serialization buffer for String port
 //! A port with string parameters
-class StringPortBuffer :
-  public Fw::LinearBufferBase
-{
-
+class StringPortBuffer : public Fw::LinearBufferBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constants for StringPortBuffer
     // ----------------------------------------------------------------------
@@ -32,51 +28,33 @@ class StringPortBuffer :
     //! The buffer capacity. This is the sum of the static serialized
     //! sizes of the port arguments.
     static constexpr FwSizeType CAPACITY =
-      Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-      Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-      Fw::StringBase::STATIC_SERIALIZED_SIZE(100) +
-      Fw::StringBase::STATIC_SERIALIZED_SIZE(100);
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(100) + Fw::StringBase::STATIC_SERIALIZED_SIZE(100);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for StringPortBuffer
     // ----------------------------------------------------------------------
 
-    //! Get the capacity of the buffer
-    //! \return The capacity
-    Fw::Serializable::SizeType getCapacity() const override {
-      return CAPACITY;
-    }
-
-    //! Get the buffer address (non-const)
-    //! \return The buffer address
-    U8* getBuffAddr() override {
-      return m_buff;
-    }
-
-    //! Get the buffer address (const)
-    //! \return The buffer address
-    const U8* getBuffAddr() const override {
-      return m_buff;
+    //! Constructor
+    StringPortBuffer() {
+        this->m_buffAddr = m_buff;
+        this->m_capacity = CAPACITY;
     }
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables
     // ----------------------------------------------------------------------
 
     U8 m_buff[CAPACITY];
-
 };
 
 //! Serializer for String port
 //! A port with string parameters
 class StringPortSerializer {
-
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for StringPortSerializer
     // ----------------------------------------------------------------------
@@ -85,44 +63,39 @@ class StringPortSerializer {
     StringPortSerializer();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for StringPortSerializer
     // ----------------------------------------------------------------------
 
     //! Deserialze port arguments into members
-    Fw::SerializeStatus deserializePortArgs(
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus deserializePortArgs(Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   public:
-
     // ----------------------------------------------------------------------
     // Public static functions for StringPortSerializer
     // ----------------------------------------------------------------------
 
     //! Serialize port arguments into a buffer
-    static Fw::SerializeStatus serializePortArgs(
-        const Fw::StringBase& str80, //!< A string of size 80
-        Fw::StringBase& str80Ref,
-        const Fw::StringBase& str100, //!< A string of size 100
-        Fw::StringBase& str100Ref,
-        Fw::SerialBufferBase& _buffer //!< The serial buffer
+    static Fw::SerializeStatus serializePortArgs(const Fw::StringBase& str80,  //!< A string of size 80
+                                                 Fw::StringBase& str80Ref,
+                                                 const Fw::StringBase& str100,  //!< A string of size 100
+                                                 Fw::StringBase& str100Ref,
+                                                 Fw::SerialBufferBase& _buffer  //!< The serial buffer
     );
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for StringPortSerializer
     // ----------------------------------------------------------------------
 
     char m___fprime_ac_str80_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
-    char m___fprime_ac_str80Ref_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+    char m___fprime_ac_str80Ref_buffer[Fw::StringBase::BUFFER_SIZE(
+        static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
     char m___fprime_ac_str100_buffer[Fw::StringBase::BUFFER_SIZE(100)];
     char m___fprime_ac_str100Ref_buffer[Fw::StringBase::BUFFER_SIZE(100)];
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member variables for StringPortSerializer
     // ----------------------------------------------------------------------
@@ -131,35 +104,27 @@ class StringPortSerializer {
     Fw::ExternalString m_str80Ref;
     Fw::ExternalString m_str100;
     Fw::ExternalString m_str100Ref;
-
 };
 
 #if !FW_DIRECT_PORT_CALLS
 
 //! Input String port
 //! A port with string parameters
-class InputStringPort :
-  public Fw::InputPortBase
-{
-
+class InputStringPort : public Fw::InputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public types for InputStringPort
     // ----------------------------------------------------------------------
 
     //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      FwIndexType portNum,
-      const Fw::StringBase& str80,
-      Fw::StringBase& str80Ref,
-      const Fw::StringBase& str100,
-      Fw::StringBase& str100Ref
-    );
+    typedef void (*CompFuncPtr)(Fw::PassiveComponentBase* callComp,
+                                FwIndexType portNum,
+                                const Fw::StringBase& str80,
+                                Fw::StringBase& str80Ref,
+                                const Fw::StringBase& str100,
+                                Fw::StringBase& str100Ref);
 
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for InputStringPort
     // ----------------------------------------------------------------------
@@ -168,7 +133,6 @@ class InputStringPort :
     InputStringPort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for InputStringPort
     // ----------------------------------------------------------------------
@@ -177,21 +141,17 @@ class InputStringPort :
     void init();
 
     //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
+    void addCallComp(Fw::PassiveComponentBase* callComp,  //!< The containing component
+                     CompFuncPtr funcPtr                  //!< The port callback function
     );
 
     //! Invoke a port interface
-    void invoke(
-        const Fw::StringBase& str80, //!< A string of size 80
-        Fw::StringBase& str80Ref,
-        const Fw::StringBase& str100, //!< A string of size 100
-        Fw::StringBase& str100Ref
-    );
+    void invoke(const Fw::StringBase& str80,  //!< A string of size 80
+                Fw::StringBase& str80Ref,
+                const Fw::StringBase& str100,  //!< A string of size 100
+                Fw::StringBase& str100Ref);
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member functions for InputStringPort
     // ----------------------------------------------------------------------
@@ -200,31 +160,24 @@ class InputStringPort :
 
     //! Invoke the port with serialized arguments
     //! \return The serialize status
-    Fw::SerializeStatus invokeSerial(
-        Fw::LinearBufferBase& _buffer //!< The serial buffer
+    Fw::SerializeStatus invokeSerial(Fw::LinearBufferBase& _buffer  //!< The serial buffer
     );
 
 #endif
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for InputStringPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the port callback function
     CompFuncPtr m_func;
-
 };
 
 //! Output String port
 //! A port with string parameters
-class OutputStringPort :
-  public Fw::OutputPortBase
-{
-
+class OutputStringPort : public Fw::OutputPortBase {
   public:
-
     // ----------------------------------------------------------------------
     // Public constructors for OutputStringPort
     // ----------------------------------------------------------------------
@@ -233,7 +186,6 @@ class OutputStringPort :
     OutputStringPort();
 
   public:
-
     // ----------------------------------------------------------------------
     // Public member functions for OutputStringPort
     // ----------------------------------------------------------------------
@@ -242,27 +194,22 @@ class OutputStringPort :
     void init();
 
     //! Register an input port
-    void addCallPort(
-        InputStringPort* callPort //!< The input port
+    void addCallPort(InputStringPort* callPort  //!< The input port
     );
 
     //! Invoke a port connection
-    void invoke(
-        const Fw::StringBase& str80, //!< A string of size 80
-        Fw::StringBase& str80Ref,
-        const Fw::StringBase& str100, //!< A string of size 100
-        Fw::StringBase& str100Ref
-    ) const;
+    void invoke(const Fw::StringBase& str80,  //!< A string of size 80
+                Fw::StringBase& str80Ref,
+                const Fw::StringBase& str100,  //!< A string of size 100
+                Fw::StringBase& str100Ref) const;
 
   private:
-
     // ----------------------------------------------------------------------
     // Private member variables for OutputStringPort
     // ----------------------------------------------------------------------
 
     //! The pointer to the input port
     InputStringPort* m_port;
-
 };
 
 #endif

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -16593,13 +16593,17 @@ struct T final : public Fw::Serializable { // Extend Fw::Serializable
 In some cases, you may want to define an abstract type <code>T</code> that represents
 a data buffer and that is used only in <a href="#Defining-Ports">port definitions</a>.
 In this case you can implement
-<code>T</code> as a class that extends <code>Fw::SerialBufferBase</code>.
+<code>T</code> as a class that extends <code>Fw::LinearBufferBase</code>.
 Instead of implementing the <code>serializeTo</code> and <code>deserializeFrom</code> functions
-directly, you override functions that get the address and the capacity
-(allocated size) of the buffer; the base class <code>Fw::SerialBufferBase</code>
-uses these functions to implement <code>serializeTo</code> and <code>deserializeFrom</code>.
-For an example of how to do this, see the files <code>Fw/Cmd/CmdArgBuffer.hpp</code>
-and <code>Fw/Cmd/CmdArgBuffer.cpp</code> in the F Prime repository.
+directly, you provide the storage for the buffer and pass its address and
+capacity (allocated size) to the <code>Fw::LinearBufferBase</code> constructor; the base
+class uses this address and capacity to implement <code>serializeTo</code> and
+<code>deserializeFrom</code>.
+This can be done by inheriting from <code>Fw::LinearBufferBase</code> directly (see
+<code>HashBuffer</code> constructor in <code>Utils/Hash/HashBufferCommon.cpp</code>) or by using
+the <code>Fw::LinearBufferTemplate</code> class template (see <code>Fw/Cmd/CmdArgBuffer.hpp</code>
+for an example, it defines <code>Fw::CmdArgBuffer</code> as a specialization of
+<code>Fw::LinearBufferTemplate</code>).
 Be careful, though: if you implement an abstract type <code>T</code> this way
 and you try to use the type <code>T</code> outside of a port definition,
 the generated C&#43;&#43; may not compile.</p>

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -167,13 +167,17 @@ struct T final : public Fw::Serializable { // Extend Fw::Serializable
 In some cases, you may want to define an abstract type `T` that represents
 a data buffer and that is used only in <<Defining-Ports,port definitions>>.
 In this case you can implement
-`T` as a class that extends `Fw::SerialBufferBase`.
+`T` as a class that extends `Fw::LinearBufferBase`.
 Instead of implementing the `serializeTo` and `deserializeFrom` functions
-directly, you override functions that get the address and the capacity
-(allocated size) of the buffer; the base class `Fw::SerialBufferBase`
-uses these functions to implement `serializeTo` and `deserializeFrom`.
-For an example of how to do this, see the files `Fw/Cmd/CmdArgBuffer.hpp`
-and `Fw/Cmd/CmdArgBuffer.cpp` in the F Prime repository.
+directly, you provide the storage for the buffer and pass its address and
+capacity (allocated size) to the `Fw::LinearBufferBase` constructor; the base
+class uses this address and capacity to implement `serializeTo` and
+`deserializeFrom`.
+This can be done by inheriting from `Fw::LinearBufferBase` directly (see 
+`HashBuffer` constructor in `Utils/Hash/HashBufferCommon.cpp`) or by using 
+the `Fw::LinearBufferTemplate` class template (see `Fw/Cmd/CmdArgBuffer.hpp`
+for an example, it defines `Fw::CmdArgBuffer` as a specialization of 
+`Fw::LinearBufferTemplate`).
 Be careful, though: if you implement an abstract type `T` this way
 and you try to use the type `T` outside of a port definition,
 the generated {cpp} may not compile.

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -173,11 +173,10 @@ directly, you provide the storage for the buffer and pass its address and
 capacity (allocated size) to the `Fw::LinearBufferBase` constructor; the base
 class uses this address and capacity to implement `serializeTo` and
 `deserializeFrom`.
-This can be done by inheriting from `Fw::LinearBufferBase` directly (see 
-`HashBuffer` constructor in `Utils/Hash/HashBufferCommon.cpp`) or by using 
-the `Fw::LinearBufferTemplate` class template (see `Fw/Cmd/CmdArgBuffer.hpp`
-for an example, it defines `Fw::CmdArgBuffer` as a specialization of 
-`Fw::LinearBufferTemplate`).
+To do this, you can write a custom buffer that inherits from `Fw::LinearBufferBase` (for example,
+see the `HashBuffer` constructor in `Utils/Hash/HashBufferCommon.cpp`), or you can use 
+the `Fw::LinearBufferTemplate` class template (for example, see `Fw/Cmd/CmdArgBuffer.hpp`;
+it defines `Fw::CmdArgBuffer` as a specialization of `Fw::LinearBufferTemplate`).
 Be careful, though: if you implement an abstract type `T` this way
 and you try to use the type `T` outside of a port definition,
 the generated {cpp} may not compile.


### PR DESCRIPTION
 https://github.com/nasa/fprime/issues/5509 was approved to convert the getBuffAddr & getCapacity methods of LinearBufferBase from virtual to concrete in order to improve performance. 

That relies on updating the fpp-to-cpp tool to: 
1. Remove the overrides for  getBuffAddr & getCapacity class methods 
2. Update the constructors to set `m_buffAddr` and `m_capacity` 

This PR will produce Ac files that don't compile unless that changes from https://github.com/nasa/fprime/pull/5584 are included in fprime